### PR TITLE
Feat/mtgjson pipeline

### DIFF
--- a/src/automana/worker/celeryconfig.py
+++ b/src/automana/worker/celeryconfig.py
@@ -51,24 +51,31 @@ timezone = os.getenv("CELERY_TIMEZONE", "Australia/Sydney")
 beat_schedule = {
     "refresh-scryfall-manifest-nightly": {
         "task": "automana.worker.tasks.pipelines.daily_scryfall_data_pipeline",
-        "schedule": crontab(hour=8, minute=8),  # 02:00 AEST
+        "schedule": crontab(hour=2, minute=0),  # 02:00 AEST
     },
-        "refresh-mtgjson-daily": {
-            "task": "automana.worker.tasks.pipelines.daily_mtgjson_data_pipeline",
-            "schedule": crontab(hour=9, minute=8),  # 03:00 AEST
-        },
-    # MTGStock staging runs AFTER Scryfall so that new scryfall_id migrations
-    # published that day are available when pricing.resolve_price_rejects()
-    # re-runs the reject resolver. Offset from mtgjson to avoid contending on
-    # the pricing schema.
+    "refresh-mtgjson-daily": {
+        "task": "automana.worker.tasks.pipelines.daily_mtgjson_data_pipeline",
+        "schedule": crontab(hour=3, minute=0),  # 03:00 AEST
+    },
+    # MTGStock staging runs AFTER Scryfall so reject resolver sees fresh
+    # scryfall_id migrations, and AFTER MTGJson to avoid contention on the
+    # pricing schema.
     "refresh-mtgstock-daily": {
         "task": "automana.worker.tasks.pipelines.mtgStock_download_pipeline",
-        "schedule": crontab(hour=10, minute=8),
+        "schedule": crontab(hour=4, minute=0),  # 04:00 AEST
     },
     "daily-analytics-report": {
         "task": "automana.worker.tasks.analytics.daily_summary_analytics_task",
-        "schedule": crontab(hour=11, minute=0),  # 03:00 AEST
-    }
+        "schedule": crontab(hour=5, minute=0),  # 05:00 AEST — after all data pipelines
+    },
+    "pipeline-health-am": {
+        "task": "automana.worker.tasks.pipelines.pipeline_health_alert_task",
+        "schedule": crontab(hour=6, minute=0),  # 06:00 AEST — post-pipeline check
+    },
+    "pipeline-health-pm": {
+        "task": "automana.worker.tasks.pipelines.pipeline_health_alert_task",
+        "schedule": crontab(hour=18, minute=0),  # 18:00 AEST — same-day insurance
+    },
 }
 
 

--- a/src/automana/worker/tasks/pipelines.py
+++ b/src/automana/worker/tasks/pipelines.py
@@ -155,3 +155,16 @@ def run_scryfall_integrity_checks(self):
         run_service.s("ops.integrity.public_schema_leak"),
     )
     return wf.apply_async().id
+
+
+@shared_task(bind=True)
+def pipeline_health_alert_task(self):
+    """Twice-daily Celery Beat job: run all ops.integrity.* services, persist
+    a snapshot, and post a transition-only Discord alert.
+
+    Per project rules this task does NOT use ``autoretry_for``; retry policy
+    lives at the run_service layer. A failure here is logged via Celery's
+    standard machinery and does not retry — twice-daily cadence makes the
+    next scheduled invocation the recovery path.
+    """
+    return run_service("ops.health.alert_check")


### PR DESCRIPTION
Title: feat: MTGJson pipeline, pipeline health alert system, MTGStock fixes, ops monitoring
                                                                 
  Body:                                                      
                                                   
  ## Summary                                                                                                                                                                                                                               
                                                                                                                                                                                                                                           
  This branch delivers several interrelated milestones across the AutoMana backend.                                                                                                                                                        
                                                                                                                                                                                                                                           
  ### Pipeline Health Alert System (new)                                                                                                                                                                                                 
  - **`ops.pipeline_health_snapshot` table** — persists every `ops.integrity.*` run result (status, counts, full JSONB report) keyed by `run_id` + `check_set`                                                                             
  - **`PipelineHealthSnapshotRepository`** — `insert_snapshots(rows)` batch insert + `latest_for_check_set(check_set, exclude_run_id)` diff query, following the `AbstractRepository` connection-injection pattern
  - **`HealthAlertService`** (`ops.health.alert_check`) — discovers all `ops.integrity.*` services at runtime, runs them sequentially, persists snapshots, diffs each result against the prior run, and posts to Discord **only on         
  `ok/warn/error` state transitions**; silent on unchanged runs; broken integrity services produce synthetic error rows so the alert fires rather than silently zeroing out                                                              
  - **`pipeline_health_alert_task`** — thin `@shared_task` Celery wrapper, no `autoretry_for` per project rules
  - **Beat schedule timezone fix** — all four existing entries were firing ~6 h late (UTC vs AEST confusion with `timezone="Australia/Sydney"`); corrected to 02:00 / 03:00 / 04:00 / 05:00 AEST; two new entries `pipeline-health-am`     
  (06:00 AEST) and `pipeline-health-pm` (18:00 AEST) added    
                                                                                                                                                                                                                                           
  ### MTGJson Pipeline                                                                                                                                                                                                                   
  - Streaming payload delivery directly into staging stored procedure (avoids double-load)                                                                                                                                                 
  - Per-service execution knobs (`runs_in_transaction`, `command_timeout`) wired through `ServiceConfig`                                                                                                                                   
  - Service key renamed to match project naming conventions                                                                                                                                                                                
                                                                                                                                                                                                                                           
  ### MTGStock Pipeline                                                                                                                                                                                                                    
  - Full pipeline wired end-to-end: download → stage → enrich → reject-resolve                                                                                                                                                             
  - Fixed `asyncpg` `command_timeout` race condition in `bulk_load` that caused spurious `InterfaceError` on long ETL runs                                                                                                                 
  - `mtgstock_report` integrity service hardened to survive missing staging tables and empty DBs                                                                                                                                           
                                                              
  ### Ops Monitoring                                                                                                                                                                                                                       
  - **`MetricRegistry`** — pluggable metric-capture system; `mtgstock_sanity_report` uses it to surface pricing coverage metrics                                                                                                           
  - Integrity check services: public schema leak, Scryfall run diff, Scryfall integrity (24 checks), MTGStock report (11 checks)                                                                                                           
                                                                                                                                                                                                                                           
  ### Card Catalog                                                                                                                                                                                                                         
  - `register_external_identifier` service + `identifier_ref` seed data, simplified per review                                                                                                                                             
                                                                                                                                                                                                                                           
  ### Infrastructure                                                                                                                                                                                                                       
  - `rebuild_dev_db.sh` — stage flags, `--dry-run`, `verify` stage, container healthcheck preflight, per-stage log files                                                                                                                   
  - Backend `Dockerfile` unblocked                                                                                                                                                                                                         
                                                                                                                                                                                                                                           
  ### Auth / eBay                                                                                                                                                                                                                          
  - JWT body-only with `httponly` session cookie; schema-qualified sessions                                                                                                                                                                
  - Write-side listings services with idempotency + auth helpers                                                                                                                                                                           
                                                                                                                                                                                                                                           
  ### Tests                                                   
  - Phase 1 unit tests covering MTGStock pipeline steps (caught 6 source bugs via TDD)                                                                                                                                                     
  - 30 unit tests for `PipelineHealthSnapshotRepository` and `HealthAlertService`                                                                                                                                                          
                                                                                                                                                                                                                                           
  ## Test plan                                                                                                                                                                                                                             
                                                                                                                                                                                                                                           
  - [ ] `PYTHONPATH=src pytest tests/unit/core/repositories/ops/test_pipeline_health_snapshot_repository.py -v` — 4 tests pass                                                                                                             
  - [ ] `PYTHONPATH=src pytest tests/unit/core/services/ops/test_health_alert_service.py -v` — 26 tests pass                                                                                                                               
  - [ ] `PYTHONPATH=src pytest tests/ -x -q` — full unit suite green                                                                                                                                                                       
  - [ ] `automana-run ops.health.alert_check` against dev DB — inserts snapshot rows, returns `alerted: false` on clean run                                                                                                                
  - [ ] Second invocation produces no transitions (status unchanged)                                                                                                                                                                       
  - [ ] Celery Beat entries visible in Flower at correct AEST times
                                                                     