### PR TITLE
Feat/pipeline health alert

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -58,16 +58,21 @@ services:
       ENV: dev
       POSTGRES_USER: ${APP_BACKEND_DB_USER}
       POSTGRES_PASSWORD_FILE: /run/secrets/backend_db_password
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: 5432
       MODULES_NAMESPACE: backend
     networks:
       - backend-network
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000/health || exit 1"]
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:8000/health')\" || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
     depends_on:
       postgres:
+        condition: service_healthy
+      redis:
         condition: service_healthy
   proxy:
     build:
@@ -76,24 +81,26 @@ services:
       args:
         NGINX_CONF: nginx.local.conf
     container_name: automana-proxy-dev
+    restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"
     volumes:
       - ../config/nginx/certs:/etc/nginx/certs:ro
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:80/health || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- --no-check-certificate https://localhost/health > /dev/null || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
     networks:
       - backend-network
-      - frontend-network
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
   redis:
     image: redis:7.0-alpine
     container_name: automana-redis-dev
+    restart: unless-stopped
     ports:
       - "6379:6379"
     volumes:
@@ -112,10 +119,11 @@ services:
       context: ..
       dockerfile: deploy/docker/celery/celery.Dockerfile
     volumes:
-      - "/data:/data:/data/mtgjson"
+      - /data:/data
     secrets:
       - celery_db_password
     container_name: automana-celery-dev
+    restart: unless-stopped
     env_file:
       - ../config/env/.env.dev
     environment:
@@ -148,6 +156,7 @@ services:
       context: ..
       dockerfile: deploy/docker/celery/celery.Dockerfile
     container_name: automana-celery-beat-dev
+    restart: unless-stopped
     env_file:
       - ../config/env/.env.dev
     secrets:
@@ -158,6 +167,9 @@ services:
       CELERY_POOL: "prefork"
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
+      POSTGRES_USER: ${APP_CELERY_DB_USER}
+      POSTGRES_PASSWORD_FILE: /run/secrets/celery_db_password
+      MODULES_NAMESPACE: celery
     depends_on:
       redis:
           condition: service_healthy
@@ -178,6 +190,7 @@ services:
       context: ..
       dockerfile: deploy/docker/celery/celery.Dockerfile
     container_name: automana-flower-dev
+    restart: unless-stopped
     env_file:
       - ../config/env/.env.dev
     environment:
@@ -185,8 +198,6 @@ services:
       FLOWER_PORT: "5555"
       FLOWER_PERSISTENT: "True"
       FLOWER_DB: /home/appuser/flower/flower.db
-    ports:
-      - "5555:5555"
     volumes:
       - flower-data-dev:/home/appuser/flower
     depends_on:
@@ -199,6 +210,7 @@ services:
     command: >
       sh -c "celery -A automana.worker.main:app --broker=${BROKER_URL} flower
       --port=5555
+      --url_prefix=flower
       --persistent=True
       --db=/home/appuser/flower/flower.db
       --logging=${CELERY_LOGLEVEL:-info}"
@@ -255,9 +267,7 @@ secrets:
     file: ../config/secrets/tavily_api_key.txt
 
 networks:
-  frontend-network:  # nginx <-> backend
-    driver: bridge
-  backend-network:   # backend <-> postgres <-> redis <-> celery <-> schema-spy
+  backend-network:
     driver: bridge
 volumes:
   pgdata-dev:

--- a/deploy/docker/backend/Backend.Dockerfile
+++ b/deploy/docker/backend/Backend.Dockerfile
@@ -19,13 +19,16 @@ COPY uv.lock /app/uv.lock
 COPY src /app/src
 RUN uv sync --frozen
 
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONPATH="/app/src"
+
 # Security: run as non-root
 RUN useradd -m appuser
 USER appuser
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')" || exit 1
 
 CMD ["uvicorn", "automana.api.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/deploy/docker/nginx/nginx.Dockerfile
+++ b/deploy/docker/nginx/nginx.Dockerfile
@@ -1,7 +1,7 @@
 FROM nginx:alpine
 
 # Install envsubst for environment variable substitution
-RUN apk add --no-cache gettext
+RUN apk add --no-cache gettext wget
 
 ARG NGINX_CONF=nginx.local.conf
 COPY ${NGINX_CONF} /etc/nginx/nginx.conf

--- a/deploy/docker/nginx/nginx.local.conf
+++ b/deploy/docker/nginx/nginx.local.conf
@@ -1,7 +1,7 @@
 worker_processes auto;
 
 events {
-    worker_connections 1024; 
+    worker_connections 1024;
 }
 
 http {
@@ -10,136 +10,111 @@ http {
         '"time": "$time_iso8601",'
         '"request_id":"$request_id",'
         '"remote_addr": "$remote_addr",'
-         '"method":"$request_method",'
+        '"method":"$request_method",'
         '"uri":"$request_uri",'
         '"status":$status,'
         '"request_time":$request_time,'
         '"upstream_time":"$upstream_response_time"'
     '}';
 
-access_log /var/log/nginx/access.log json;
-error_log /var/log/nginx/error.log warn;
+    access_log /var/log/nginx/access.log json;
+    error_log  /var/log/nginx/error.log warn;
 
-#rate limiting
-limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
 
- # Performance settings
-sendfile on;
-tcp_nopush on;
-tcp_nodelay on;
-keepalive_timeout 65;
-types_hash_max_size 2048;
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
 
-# Gzip compression
-gzip on;
-gzip_vary on;
-gzip_min_length 10240;
-gzip_proxied any;
-gzip_types
-    text/plain
-    text/css
-    text/xml
-    text/javascript
-    application/json
-    application/javascript
-    application/xml+rss
-    application/atom+xml;
+    gzip            on;
+    gzip_vary       on;
+    gzip_min_length 10240;
+    gzip_proxied    any;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/json
+        application/javascript
+        application/xml+rss
+        application/atom+xml;
 
-upstream fastapi_backend {
-    server backend:8000;
-    keepalive 32;
-}
-
-upstream flower {
-    server flower:5555;
-    keepalive 4;
-}
-  # -------------------------
-  # HTTP (80) - challenge + redirect
-  # -------------------------
-server {
-    listen 80;
-    server_name localhost;
-
-    location / {
-    return 301 https://$host$request_uri;
-    }
-}
-
-  # -------------------------
-  # HTTPS (443) - main gateway
-  # -------------------------
-server {
-    listen 443 ssl http2;
-    server_name localhost;
-
-    ssl_certificate     /etc/nginx/certs/localhost.pem;
-    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
-
-    # Apply global rate limit
-    limit_req zone=perip burst=20 nodelay;
-
-    # Forward headers to FastAPI
-    proxy_set_header Host              $host;
-    proxy_set_header X-Real-IP         $remote_addr;
-    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Request-ID      $request_id;
-
-    #max size for file uploads
-    client_max_body_size 100M;
-
-    location /health {
-      proxy_pass http://fastapi_backend;
-      proxy_set_header Host $host;
-            access_log off;
+    upstream fastapi_backend {
+        server backend:8000;
+        keepalive 32;
     }
 
-     location /api/ {
-            proxy_pass http://fastapi_backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # WebSocket support
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            
-            # Timeouts
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+    upstream flower {
+        server flower:5555;
+        keepalive 4;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            return 301 https://$host$request_uri;
         }
-    location /flower/ {
-        proxy_pass http://flower/;
+    }
+
+    server {
+        listen 443 ssl http2;
+        server_name localhost;
+
+        ssl_certificate     /etc/nginx/certs/localhost.pem;
+        ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
+
+        limit_req zone=perip burst=20 nodelay;
+
+        client_max_body_size 100M;
+
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade    $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_connect_timeout 60s;
-        proxy_send_timeout    60s;
-        proxy_read_timeout    60s;
-    }
-    location /docs {
+        proxy_set_header X-Request-ID      $request_id;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options           "SAMEORIGIN" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy   "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
+
+        location /health {
             proxy_pass http://fastapi_backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            access_log off;
         }
+
+        location /api/ {
+            proxy_pass http://fastapi_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_connect_timeout 60s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+        }
+
+        location /flower/ {
+            proxy_pass http://flower;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_connect_timeout 60s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+        }
+
+        location /docs {
+            proxy_pass http://fastapi_backend;
+        }
+
         location / {
             proxy_pass http://fastapi_backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
         }
+    }
 }
-
-}
-

--- a/deploy/docker/nginx/nginx.prod.conf
+++ b/deploy/docker/nginx/nginx.prod.conf
@@ -8,139 +8,114 @@ http {
         '"time": "$time_iso8601",'
         '"request_id":"$request_id",'
         '"remote_addr": "$remote_addr",'
-         '"method":"$request_method",'
+        '"method":"$request_method",'
         '"uri":"$request_uri",'
         '"status":$status,'
         '"request_time":$request_time,'
         '"upstream_time":"$upstream_response_time"'
     '}';
 
-access_log /var/log/nginx/access.log json;
-error_log /var/log/nginx/error.log warn;
+    access_log /var/log/nginx/access.log json;
+    error_log  /var/log/nginx/error.log warn;
 
-#rate limiting
-limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
 
- # Performance settings
-sendfile on;
-tcp_nopush on;
-tcp_nodelay on;
-keepalive_timeout 65;
-types_hash_max_size 2048;
+    sendfile        on;
+    tcp_nopush      on;
+    tcp_nodelay     on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
 
-# Gzip compression
-gzip on;
-gzip_vary on;
-gzip_min_length 10240;
-gzip_proxied expired no-cache no-store private must-revalidate auth;
-gzip_types
-    text/plain
-    text/css
-    text/xml
-    text/javascript
-    application/json
-    application/javascript
-    application/xml+rss
-    application/atom+xml;
+    gzip            on;
+    gzip_vary       on;
+    gzip_min_length 10240;
+    gzip_proxied    expired no-cache no-store private must-revalidate auth;
+    gzip_types
+        text/plain
+        text/css
+        text/xml
+        text/javascript
+        application/json
+        application/javascript
+        application/xml+rss
+        application/atom+xml;
 
-upstream fastapi_backend {
-    server backend:8000;
-    keepalive 32;
-}
-
-upstream flower {
-    server flower:5555;
-    keepalive 4;
-}
-  # -------------------------
-  # HTTP (80) - challenge + redirect
-  # -------------------------
-server {
-    listen 80;
-    server_name _;
-
-    location /.well-known/acme-challenge/ {
-  root /var/www/certbot;
-    }
-    location / {
-    return 301 https://$host$request_uri;
-    }
-}
-
-  # -------------------------
-  # HTTPS (443) - main gateway
-  # -------------------------
-server {
-    listen 443 ssl http2;
-    server_name _;
-
-    ssl_certificate     /etc/nginx/certs/localhost.pem;
-    ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
-
-    # Apply global rate limit
-    limit_req zone=perip burst=20 nodelay;
-
-    # Forward headers to FastAPI
-    proxy_set_header Host              $host;
-    proxy_set_header X-Real-IP         $remote_addr;
-    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Request-ID      $request_id;
-
-    #max size for file uploads
-    client_max_body_size 100M;
-
-    location /health {
-      proxy_pass http://fastapi_backend;
-      proxy_set_header Host $host;
-            access_log off;
+    upstream fastapi_backend {
+        server backend:8000;
+        keepalive 32;
     }
 
-     location /api/ {
-            proxy_pass http://fastapi_backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-            
-            # WebSocket support
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            
-            # Timeouts
-            proxy_connect_timeout 60s;
-            proxy_send_timeout 60s;
-            proxy_read_timeout 60s;
+    upstream flower {
+        server flower:5555;
+        keepalive 4;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
         }
-    location /flower/ {
-        proxy_pass http://flower/;
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+    server {
+        listen 443 ssl http2;
+        server_name _;
+
+        ssl_certificate     /etc/nginx/certs/localhost.pem;
+        ssl_certificate_key /etc/nginx/certs/localhost-key.pem;
+
+        limit_req zone=perip burst=20 nodelay;
+
+        client_max_body_size 100M;
+
         proxy_set_header Host              $host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade    $http_upgrade;
-        proxy_set_header Connection "upgrade";
-        proxy_connect_timeout 60s;
-        proxy_send_timeout    60s;
-        proxy_read_timeout    60s;
-    }
-    location /docs {
+        proxy_set_header X-Request-ID      $request_id;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options           "SAMEORIGIN" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header Referrer-Policy           "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy   "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
+
+        location /health {
             proxy_pass http://fastapi_backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            access_log off;
         }
+
+        location /api/ {
+            proxy_pass http://fastapi_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_connect_timeout 60s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+        }
+
+        location /flower/ {
+            proxy_pass http://flower;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_connect_timeout 60s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+        }
+
+        location /docs {
+            proxy_pass http://fastapi_backend;
+        }
+
         location / {
             proxy_pass http://fastapi_backend;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
         }
+    }
 }
-
-}
-

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -53,7 +53,7 @@ What it does:
 - `postgres` publishes `5433:5432` (convenience for local tools)
 - `redis` publishes `6379:6379`
 - `proxy` publishes `80:80` and `443:443`
-- `flower` publishes `5555:5555` (Flower direct access, dev only)
+- `flower` is not directly exposed (only via nginx proxy)
 
 Run:
 
@@ -68,10 +68,29 @@ curl -f http://localhost:8000/health
 curl -f https://localhost/health -k
 ```
 
-Docs:
+Service access:
 
-- Direct backend: `http://localhost:8000/docs`
-- Through proxy: `https://localhost/docs` (may require `-k` for self-signed certs)
+| Service | URL | Notes |
+|---------|-----|-------|
+| Backend API | `http://localhost:8000` | Direct; also exposed through proxy |
+| Backend API (proxy) | `https://localhost/api/` | Through nginx reverse proxy (HTTPS) |
+| OpenAPI docs | `https://localhost/docs` | Through nginx reverse proxy |
+| Health check | `https://localhost/health` | Through nginx reverse proxy |
+| Flower | `https://localhost/flower/` | Through nginx proxy; auth: `admin:changeme_dev` (from `FLOWER_BASIC_AUTH`) |
+| Postgres | `localhost:5433` | Host-side access (`.env.dev` default); containers use `postgres:5432` |
+| Redis | `localhost:6379` | Host-side access; containers use `redis:6379` |
+
+### Container environment overrides
+
+The `backend` and `celery-beat` services override `POSTGRES_HOST` and `POSTGRES_PORT` in their `environment:` blocks:
+
+```yaml
+environment:
+  POSTGRES_HOST: postgres
+  POSTGRES_PORT: 5432
+```
+
+This overrides `.env.dev`'s `localhost:5433` (which is for host-side tools only). Inside the Docker network, containers reach Postgres via the service name `postgres` on port `5432`.
 
 Stop:
 
@@ -201,22 +220,23 @@ Flower provides a real-time web UI for inspecting Celery workers and tasks.
 
 ### Access
 
-| Environment | URL |
-|-------------|-----|
-| Dev (direct) | http://localhost:5555 |
-| Dev (proxy) | https://localhost/flower/ |
-| Prod (proxy) | https://your-domain/flower/ (requires `FLOWER_BASIC_AUTH`) |
+Flower is only exposed through the nginx reverse proxy (not directly on port 5555):
+
+| Environment | URL | Auth |
+|-------------|-----|------|
+| Dev (proxy) | https://localhost/flower/ | `admin:changeme_dev` (from `FLOWER_BASIC_AUTH` in `.env.dev`) |
+| Prod (proxy) | https://your-domain/flower/ | Configure via `FLOWER_BASIC_AUTH` in `.env.prod` |
 
 ### Persistence
 
-Task history is persisted via a named Docker volume (`flower-data-dev` or `flower-data-prod`). The SQLite database is stored at `/data/flower.db` inside the container.
+Task history is persisted via a named Docker volume (`flower-data-dev` or `flower-data-prod`). The SQLite database is stored at `/home/appuser/flower/flower.db` inside the container.
 
 ### Environment variables
 
 | Variable | Description |
 |----------|-------------|
 | `BROKER_URL` | Redis broker URL (e.g. `redis://redis:6379/0`) |
-| `FLOWER_BASIC_AUTH` | HTTP Basic Auth credentials in `user:password` format (required in prod) |
+| `FLOWER_BASIC_AUTH` | HTTP Basic Auth credentials in `user:password` format (dev and prod) |
 
 ## Operational notes / caveats
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -134,11 +134,12 @@ Flower provides a real-time web UI for inspecting Celery workers and tasks.
 
 ### Access
 
-| Environment | URL |
-|-------------|-----|
-| Dev (direct) | http://localhost:5555 |
-| Dev (proxy) | https://localhost/flower/ |
-| Prod (proxy) | https://your-domain/flower/ |
+Flower is only exposed through the nginx reverse proxy (not directly):
+
+| Environment | URL | Auth |
+|-------------|-----|------|
+| Dev (proxy) | https://localhost/flower/ | `admin:changeme_dev` |
+| Prod (proxy) | https://your-domain/flower/ | Via `FLOWER_BASIC_AUTH` (`.env.prod`) |
 
 ### Follow Flower logs
 
@@ -160,10 +161,14 @@ Flower persists task history to a SQLite database at `/data/flower.db` inside th
 
 To update the Flower Basic Auth password:
 
-1. Update `FLOWER_BASIC_AUTH` in the relevant env file (`config/env/.env.prod`).
+1. Update `FLOWER_BASIC_AUTH` in the relevant env file (e.g. `config/env/.env.dev` or `config/env/.env.prod`).
 2. Restart Flower:
 
 ```bash
+# Dev
+docker compose -f deploy/docker-compose.dev.yml up -d --no-deps flower
+
+# Prod
 docker compose -f deploy/docker-compose.prod.yml up -d --no-deps flower
 ```
 
@@ -199,7 +204,21 @@ For the full check catalogue, severity definitions, recommended cadence, and int
 
 ---
 
-## Certificates
+## Security
+
+### Security headers
+
+nginx adds the following security headers to all responses on port 443:
+
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains` (HSTS)
+- `X-Frame-Options: SAMEORIGIN` (clickjacking protection)
+- `X-Content-Type-Options: nosniff` (MIME type sniffing prevention)
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Content-Security-Policy` (configured per route)
+
+These are defined in `nginx.local.conf` and `nginx.prod.conf`.
+
+### Certificates
 
 nginx mounts certs from `config/nginx/certs/`.
 
@@ -208,3 +227,19 @@ After updating certs on the host, restart the proxy:
 ```bash
 docker compose -f deploy/docker-compose.prod.yml restart proxy
 ```
+
+## Service healthchecks
+
+All services in docker-compose.dev.yml have healthchecks configured:
+
+| Service | Check method | Notes |
+|---------|--------------|-------|
+| `backend` | `python3 urllib.request.urlopen('http://localhost:8000/health')` | Direct to backend |
+| `postgres` | `pg_isready -U admin -d automana` | Database ready probe |
+| `redis` | `redis-cli ping` | Cache ready probe |
+| `proxy` | `wget -qO- --no-check-certificate https://localhost/health` | Reverse proxy ready; uses wget (curl not available) |
+| `celery-beat` | `test -f /tmp/celerybeat.pid && kill -0 $(cat /tmp/celerybeat.pid)` | Process alive check |
+| `celery-worker` | `celery -A automana.worker.main:app inspect ping` | Worker responds to inspect |
+| `flower` | `python -c "import urllib.request; urllib.request.urlopen('http://localhost:5555/healthcheck')"` | Flower endpoint |
+
+All services except `schema-spy` have `restart: unless-stopped` configured.

--- a/src/automana/core/database.py
+++ b/src/automana/core/database.py
@@ -48,6 +48,19 @@ async def init_async_pool(settings:Settings) -> asyncpg.Pool:
                 server_settings={
                     "client_encoding": "UTF8",
                     "search_path": _SEARCH_PATH,
+                    # Pre-set temp_buffers to the value that
+                    # pricing.load_staging_prices_batched requests via
+                    # SET LOCAL.  PostgreSQL only blocks changes to
+                    # temp_buffers after the first temp-table access in a
+                    # session; if the connection already holds the target
+                    # value the SET LOCAL becomes a no-op and the check
+                    # passes even on a recycled pool connection that has
+                    # previously run the procedure.  Without this, the
+                    # asyncpg pool hands back a warmed-up connection whose
+                    # local buffer count is already initialised, causing:
+                    #   InvalidParameterValueError: "temp_buffers" cannot be
+                    #   changed after any temporary tables have been accessed.
+                    "temp_buffers": "32768",  # 32768 × 8 kB = 256 MB
                 },
             )
             logger.info("Async pool created")

--- a/src/automana/core/metrics/pricing/__init__.py
+++ b/src/automana/core/metrics/pricing/__init__.py
@@ -4,6 +4,7 @@ The runner service (`ops.integrity.pricing_report`) imports this module so
 that `MetricRegistry.select(prefix="pricing.")` finds every metric without
 any caller needing to remember the individual module paths.
 """
-from automana.core.metrics.pricing import freshness_metrics  # noqa: F401
-from automana.core.metrics.pricing import coverage_metrics   # noqa: F401
-from automana.core.metrics.pricing import integrity_metrics  # noqa: F401
+from automana.core.metrics.pricing import freshness_metrics      # noqa: F401
+from automana.core.metrics.pricing import coverage_metrics       # noqa: F401
+from automana.core.metrics.pricing import integrity_metrics      # noqa: F401
+from automana.core.metrics.pricing import card_coverage_metrics  # noqa: F401

--- a/src/automana/core/metrics/pricing/card_coverage_metrics.py
+++ b/src/automana/core/metrics/pricing/card_coverage_metrics.py
@@ -1,0 +1,110 @@
+"""pricing.card_coverage.* — catalog-side price coverage metrics.
+
+Measures how many of the known MTG card versions actually have price
+observations in the canonical table, broken down by foil finish.
+
+Distinct from ``pricing.coverage.*`` which measures coverage from the
+source-product side (% of source-registered products with a recent price).
+"""
+from __future__ import annotations
+
+from automana.core.metrics.registry import MetricRegistry, MetricResult, Threshold
+from automana.core.repositories.app_integration.mtg_stock.price_repository import PriceRepository
+
+
+async def _get_stats(price_repository: PriceRepository) -> dict:
+    return await price_repository.fetch_card_coverage_stats()
+
+
+@MetricRegistry.register(
+    path="pricing.card_coverage.catalog_coverage_pct",
+    category="health",
+    description="% of card_versions in card_catalog that have at least one price_observation.",
+    severity=Threshold(warn=50, error=20, direction="lower_is_worse"),
+    db_repositories=["price"],
+)
+async def catalog_coverage_pct(price_repository: PriceRepository) -> MetricResult:
+    stats = await _get_stats(price_repository)
+    total = stats["total_card_versions"]
+    with_price = stats["with_price"]
+    pct = round(100.0 * with_price / total, 2) if total else None
+    return MetricResult(
+        row_count=pct,
+        details={
+            "total_card_versions": total,
+            "with_price": with_price,
+            "without_price": stats["without_price"],
+        },
+    )
+
+
+@MetricRegistry.register(
+    path="pricing.card_coverage.card_versions_with_any_price",
+    category="volume",
+    description="Count of card_versions with at least one price_observation (any finish).",
+    severity=None,
+    db_repositories=["price"],
+)
+async def card_versions_with_any_price(price_repository: PriceRepository) -> MetricResult:
+    stats = await _get_stats(price_repository)
+    return MetricResult(
+        row_count=stats["with_price"],
+        details={"total_card_versions": stats["total_card_versions"]},
+    )
+
+
+@MetricRegistry.register(
+    path="pricing.card_coverage.card_versions_without_price",
+    category="health",
+    description="Count of card_versions with zero price observations.",
+    severity=Threshold(warn=10_000, error=50_000, direction="higher_is_worse"),
+    db_repositories=["price"],
+)
+async def card_versions_without_price(price_repository: PriceRepository) -> MetricResult:
+    stats = await _get_stats(price_repository)
+    return MetricResult(
+        row_count=stats["without_price"],
+        details={"total_card_versions": stats["total_card_versions"]},
+    )
+
+
+@MetricRegistry.register(
+    path="pricing.card_coverage.card_versions_with_nonfoil_price",
+    category="volume",
+    description="Count of card_versions with at least one NONFOIL price observation.",
+    severity=None,
+    db_repositories=["price"],
+)
+async def card_versions_with_nonfoil_price(price_repository: PriceRepository) -> MetricResult:
+    stats = await _get_stats(price_repository)
+    return MetricResult(
+        row_count=stats["with_nonfoil_price"],
+        details={"total_card_versions": stats["total_card_versions"]},
+    )
+
+
+@MetricRegistry.register(
+    path="pricing.card_coverage.card_versions_with_foil_price",
+    category="volume",
+    description="Count of card_versions with at least one foil (FOIL/ETCHED) price observation.",
+    severity=None,
+    db_repositories=["price"],
+)
+async def card_versions_with_foil_price(price_repository: PriceRepository) -> MetricResult:
+    stats = await _get_stats(price_repository)
+    return MetricResult(
+        row_count=stats["with_foil_price"],
+        details={"total_card_versions": stats["total_card_versions"]},
+    )
+
+
+@MetricRegistry.register(
+    path="pricing.card_coverage.total_observation_rows",
+    category="volume",
+    description="Estimated total rows in pricing.price_observation (via pg_class.reltuples — fast, not exact).",
+    severity=Threshold(warn=500_000, error=10_000, direction="lower_is_worse"),
+    db_repositories=["price"],
+)
+async def total_observation_rows(price_repository: PriceRepository) -> MetricResult:
+    n = await price_repository.fetch_total_observation_count()
+    return MetricResult(row_count=n)

--- a/src/automana/core/repositories/abstract_repositories/AbstractDBRepository.py
+++ b/src/automana/core/repositories/abstract_repositories/AbstractDBRepository.py
@@ -1,8 +1,11 @@
 ﻿from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 import asyncpg, psycopg2
+import logging
 from typing import Optional,  TypeVar,  Generic, Union
 from automana.core.QueryExecutor import QueryExecutor
+
+logger = logging.getLogger(__name__)
 
 T =TypeVar('T')
 
@@ -26,10 +29,10 @@ class AbstractRepository(Generic[T], ABC):
     def execute_query_sync(self, query, *args):
         """Execute a query that returns results"""
         if self.executor:
-            print("Executing query with executor")
+            logger.debug("Executing query with executor")
             return self.executor.execute_query(self.connection, query, *args)
         else:
-            print("Executing query withOUT executor")
+            logger.debug("Executing query without executor")
             # Fallback to direct connection
             with self.connection.cursor() as cursor:
                 cursor.execute(query, args)
@@ -38,11 +41,11 @@ class AbstractRepository(Generic[T], ABC):
     def execute_command_sync(self, query, *args):
         """Execute a command that doesn't return results"""
         if self.executor:
-            print("Executing query with executor")
+            logger.debug("Executing query with executor")
             return self.executor.execute_command(self.connection, query, *args)
         else:
             # Fallback to direct connection
-            print("Executing query withOUT executor")
+            logger.debug("Executing query without executor")
             with self.connection.cursor() as cursor:
                 cursor.execute(query, args)
                 self.connection.commit()
@@ -51,21 +54,21 @@ class AbstractRepository(Generic[T], ABC):
     async def execute_query(self, query, *args):
         """Execute a query that returns results"""
         if self.executor:
-            print("Executing query with executor")
+            logger.debug("Executing query with executor")
             return await self.executor.execute_query(self.connection, query, *args)
         else:
-            print("Executing query withOUT executor")
+            logger.debug("Executing query without executor")
             # Fallback to direct connection
             return await self.connection.fetch(query, *args)
     
     async def execute_command(self, query, *args):
         """Execute a command that doesn't return results"""
         if self.executor:
-            print("Executing query with executor")
+            logger.debug("Executing query with executor")
             return await self.executor.execute_command(self.connection, query, *args)
         else:
             # Fallback to direct connection
-            print("Executing query withOUT executor")
+            logger.debug("Executing query without executor")
             return await self.connection.execute(query, *args)
         
     @abstractmethod

--- a/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
+++ b/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
@@ -284,6 +284,88 @@ class PriceRepository(AbstractRepository):
         rows = await self.execute_query(query, ())
         return rows[0]["n"] if rows else 0
 
+    async def fetch_card_coverage_stats(self) -> dict:
+        """Card-version-level price coverage across the full catalog.
+
+        Returns counts for: total card versions, those with any price
+        observation, those without, and the foil/nonfoil split.  Single
+        round-trip via CTE to keep latency predictable on large hypertables.
+        """
+        query = """
+        WITH
+          total AS (
+            SELECT COUNT(*)::int AS n FROM card_catalog.card_version
+          ),
+          priced AS (
+            SELECT COUNT(DISTINCT mcp.card_version_id)::int AS n
+            FROM pricing.mtg_card_products mcp
+            WHERE EXISTS (
+              SELECT 1
+              FROM pricing.source_product sp
+              JOIN pricing.price_observation po
+                ON po.source_product_id = sp.source_product_id
+              WHERE sp.product_id = mcp.product_id
+            )
+          ),
+          nonfoil AS (
+            SELECT COUNT(DISTINCT mcp.card_version_id)::int AS n
+            FROM pricing.mtg_card_products mcp
+            JOIN pricing.source_product sp ON sp.product_id = mcp.product_id
+            JOIN pricing.price_observation po ON po.source_product_id = sp.source_product_id
+            JOIN pricing.card_finished cf ON cf.finish_id = po.finish_id
+            WHERE upper(cf.code) = 'NONFOIL'
+          ),
+          foil AS (
+            SELECT COUNT(DISTINCT mcp.card_version_id)::int AS n
+            FROM pricing.mtg_card_products mcp
+            JOIN pricing.source_product sp ON sp.product_id = mcp.product_id
+            JOIN pricing.price_observation po ON po.source_product_id = sp.source_product_id
+            JOIN pricing.card_finished cf ON cf.finish_id = po.finish_id
+            WHERE upper(cf.code) <> 'NONFOIL'
+          )
+        SELECT
+          t.n   AS total_card_versions,
+          p.n   AS with_price,
+          t.n - p.n AS without_price,
+          nf.n  AS with_nonfoil_price,
+          f.n   AS with_foil_price
+        FROM total t, priced p, nonfoil nf, foil f
+        """
+        rows = await self.execute_query(query, ())
+        if not rows:
+            return {
+                "total_card_versions": 0,
+                "with_price": 0,
+                "without_price": 0,
+                "with_nonfoil_price": 0,
+                "with_foil_price": 0,
+            }
+        r = rows[0]
+        return {
+            "total_card_versions": r["total_card_versions"],
+            "with_price": r["with_price"],
+            "without_price": r["without_price"],
+            "with_nonfoil_price": r["with_nonfoil_price"],
+            "with_foil_price": r["with_foil_price"],
+        }
+
+    async def fetch_total_observation_count(self) -> int:
+        """Estimated total row count of price_observation via pg_class.reltuples.
+
+        Fast (no full scan); good enough for a volume alarm. Use the real
+        COUNT only when exact values matter.
+        """
+        query = """
+        SELECT reltuples::bigint AS n
+        FROM pg_class c
+        JOIN pg_namespace ns ON ns.oid = c.relnamespace
+        WHERE ns.nspname = 'pricing' AND c.relname = 'price_observation'
+        """
+        rows = await self.execute_query(query, ())
+        # pg_class.reltuples = -1 means the table has never been ANALYZEd; treat as 0.
+        n = rows[0]["n"] if rows else 0
+        return max(n, 0)
+
     def add(self):
         raise NotImplementedError("Method not implemented")
 

--- a/src/automana/core/service_manager.py
+++ b/src/automana/core/service_manager.py
@@ -164,7 +164,12 @@ class ServiceManager:
         if cls._instance is None or not cls._instance._initialized:
             raise RuntimeError("ServiceManager not initialized")
 
-        logger.info(
+        # DEBUG: entry point trace — emitted before every awaited service
+        # call, including the 3 inner calls health_alert_service makes for
+        # each integrity check_set. At INFO this floods logs twice daily
+        # with wiring detail that adds no operator value beyond what
+        # service_path in the ContextFilter already provides.
+        logger.debug(
             "service_execution_requested",
             extra={
                 "action": "execute_service",

--- a/src/automana/core/services/ops/health_alert_service.py
+++ b/src/automana/core/services/ops/health_alert_service.py
@@ -283,7 +283,12 @@ async def run_alert_check(
         try:
             status = await _post_to_discord(webhook, payload)
             alerted = 200 <= status < 300
-            if not alerted:
+            if alerted:
+                logger.info(
+                    "discord_alert_sent",
+                    extra={"degraded": len(degraded), "recovered": len(recovered)},
+                )
+            else:
                 logger.warning("discord_post_non_2xx", extra={"http_status": status})
         except Exception as exc:
             logger.warning("discord_post_failed", extra={"exc_type": type(exc).__name__})

--- a/src/automana/database/SQL/schemas/06_prices.sql
+++ b/src/automana/database/SQL/schemas/06_prices.sql
@@ -25,6 +25,11 @@ CREATE TABLE IF NOT EXISTS pricing.data_provider (
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+INSERT INTO pricing.data_provider (code, description) VALUES
+  ('mtgstocks', 'MTGStocks price scrape'),
+  ('mtgjson',   'MTGJson bulk data file'),
+  ('scryfall',  'Scryfall API')
+ON CONFLICT (code) DO NOTHING;
 
 CREATE TABLE IF NOT EXISTS pricing.price_metric (
   metric_id   SMALLSERIAL PRIMARY KEY,
@@ -497,7 +502,11 @@ BEGIN
   -- determine overall date range from raw data
   SET LOCAL work_mem = '512MB';
   SET LOCAL maintenance_work_mem = '1GB';
-  SET LOCAL temp_buffers = '256MB';
+  -- NOTE: temp_buffers cannot be changed after first temp-table access in a
+  -- session, so it is NOT set here.  The target value (256 MB = 32768 pages)
+  -- is pre-configured at pool-connection time via asyncpg server_settings in
+  -- core/database.py, which makes this SET LOCAL a no-op on pool-recycled
+  -- connections and avoids InvalidParameterValueError on second+ invocations.
   SET LOCAL synchronous_commit = off;
 
   SELECT min(ts_date), max(ts_date) INTO v_min, v_max FROM pricing.raw_mtg_stock_price;
@@ -518,6 +527,10 @@ BEGIN
   SELECT dp.data_provider_id INTO v_data_provider_id
   FROM pricing.data_provider dp
   WHERE dp.code = 'mtgstocks';
+
+  IF v_data_provider_id IS NULL THEN
+    RAISE EXCEPTION 'Missing pricing.data_provider row with code=mtgstocks';
+  END IF;
 -----------------------------------------------
   SELECT cg.game_id INTO v_mtg_game_id
   FROM card_catalog.card_games_ref cg
@@ -525,41 +538,9 @@ BEGIN
   ORDER BY CASE lower(cg.code) WHEN 'mtg' THEN 1 ELSE 2 END
   LIMIT 1;
 
-  EXECUTE $sql$
-    CREATE TABLE IF NOT EXISTS pricing.stg_price_observation_reject (
-      ts_date date NOT NULL,
-      game_code text NOT NULL,
-      print_id bigint NOT NULL,
-      source_code text NOT NULL,
-      data_provider_id SMALLINT NOT NULL,
-      scraped_at timestamptz NOT NULL,
-
-      list_low_cents INTEGER,
-      list_avg_cents INTEGER,
-      sold_avg_cents INTEGER,
-
-      is_foil boolean NOT NULL,
-      value numeric(12,4),
-
-      card_name text,
-      set_abbr text,
-      collector_number text,
-      scryfall_id text,
-      tcg_id text,
-      cardtrader_id text,
-
-      is_terminal boolean NOT NULL DEFAULT false,
-      terminal_reason text,
-
-      resolution_attempted_at timestamptz NOT NULL DEFAULT now(),
-      reject_reason text NOT NULL,
-      resolved_at timestamptz,
-      resolved_source_product_id bigint,
-      resolved_product_id uuid,
-      resolved_card_version_id uuid,
-resolved_method text
-    );
-  $sql$;
+  -- stg_price_observation_reject is pre-created by 06_prices.sql schema section;
+  -- app_celery only has USAGE on the pricing schema (not CREATE), so the
+  -- CREATE TABLE IF NOT EXISTS that used to live here was removed.
 
   v_start := v_min;
   WHILE v_start <= v_max LOOP
@@ -614,14 +595,15 @@ resolved_method text
         (v.sold_avg_cents * 100)::int AS sold_avg_cents,
         v.is_foil,
         v.value,
-        v.data_provider_id
+        r.data_provider_id
       FROM tmp_raw_batch r
       CROSS JOIN LATERAL (VALUES
-        (r.price_low,          false, r.price_low),
-        (r.price_avg,          false, r.price_avg),
-        (r.price_avg,           true, r.price_foil),
-        (r.price_market,       false, r.price_market),
-        (r.price_market,        true, r.price_market_foil)
+        -- Non-foil row: all three non-foil price fields; filter on any non-null price.
+        (r.price_low, r.price_avg, r.price_market, false,
+         COALESCE(r.price_avg, r.price_market, r.price_low)),
+        -- Foil row: foil-specific prices only; filter on any non-null foil price.
+        (NULL::numeric, r.price_foil, r.price_market_foil, true,
+         COALESCE(r.price_foil, r.price_market_foil))
       ) AS v(list_low_cents, list_avg_cents, sold_avg_cents, is_foil, value)
       WHERE v.value IS NOT NULL;
 
@@ -700,7 +682,12 @@ resolved_method text
     AND u.collector_number IS NOT NULL
     AND (u.card_name IS NULL OR uc.card_name IS NULL OR lower(uc.card_name) = lower(u.card_name));
 
-  -- 3d) Final resolved rows
+  -- 3d) Final resolved rows — built from tmp_batch_foil_split so that each row
+  --     already carries the foil-split price columns (list_low_cents, list_avg_cents,
+  --     sold_avg_cents, is_foil, value) needed by the reject insert and the staging
+  --     insert downstream. tmp_map_print / tmp_map_external / tmp_map_fallback are
+  --     keyed by print_id / set_abbr+collector_number, which are present on both
+  --     the raw and foil-split tables.
   DROP TABLE IF EXISTS tmp_resolved;
   CREATE TEMP TABLE tmp_resolved ON COMMIT DROP AS
   SELECT
@@ -712,7 +699,7 @@ resolved_method text
       WHEN mf.card_version_id IS NOT NULL THEN 'SET_COLLECTOR'
       ELSE 'UNRESOLVED'
     END AS resolution_method
-  FROM tmp_raw_batch u
+  FROM tmp_batch_foil_split u
   LEFT JOIN tmp_map_print mp
     ON mp.print_id = u.print_id
   LEFT JOIN tmp_map_external me
@@ -866,8 +853,8 @@ resolved_method text
           r.source_code,
           r.data_provider_id,
           r.value,
-          l.product_id::text,
-          r.card_version_id::text,
+          l.product_id,
+          r.card_version_id,
           l.source_product_id,
           r.set_abbr,
           r.collector_number,
@@ -898,8 +885,8 @@ resolved_method text
     END IF;
       v_start := v_end + 1;
   END LOOP;
-  CREATE INDEX IF NOT EXISTS stg_price_obs_date_spid_foil_idx
-  ON pricing.stg_price_observation (ts_date, source_product_id, is_foil);
+  -- stg_price_obs_date_spid_foil_idx is pre-created by 06_prices.sql schema section;
+  -- CREATE INDEX IF NOT EXISTS removed — same reason as CREATE TABLE above.
   RAISE NOTICE 'load_staging_prices_batched: total inserted % rows', total_inserted;
 END;
 $$;

--- a/src/automana/worker/main.py
+++ b/src/automana/worker/main.py
@@ -61,10 +61,14 @@ def run_service(self,prev=None, path: str = None, **kwargs):
     allowed_keys = set(sig.parameters.keys())
 
     filtered_context = {k: v for k, v in context.items() if k in allowed_keys}
-    logger.info(
-    "run_service_start",
-    extra={"service_path": path, "kwargs_keys": list(filtered_context.keys())}
-)
+    # DEBUG: per-step executor wiring — fires once per chain link, not a
+    # business event. Keep at DEBUG so the default INFO level stays quiet
+    # across multi-step pipelines (e.g. the 10-step scryfall chain or the
+    # 3 inner execute_service calls inside run_alert_check).
+    logger.debug(
+        "run_service_start",
+        extra={"service_path": path, "kwargs_keys": list(filtered_context.keys())}
+    )
     try:
         result = state.loop.run_until_complete(
             ServiceManager.execute_service(path, **filtered_context)

--- a/tests/integration/services/ops/conftest.py
+++ b/tests/integration/services/ops/conftest.py
@@ -1,0 +1,19 @@
+import asyncpg
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture(scope="function")
+async def db_pool(timescale_container, _test_env, db_migrations_applied):
+    host = timescale_container.get_container_host_ip()
+    port = timescale_container.get_exposed_port(5432)
+    pool = await asyncpg.create_pool(
+        host=host,
+        port=int(port),
+        user="automana_test",
+        password="test_password",
+        database="automana_test",
+        min_size=1,
+        max_size=3,
+    )
+    yield pool
+    await pool.close()

--- a/tests/integration/services/ops/test_health_alert_service_integration.py
+++ b/tests/integration/services/ops/test_health_alert_service_integration.py
@@ -1,0 +1,119 @@
+"""Integration tests for HealthAlertService (ops.health.alert_check).
+
+Uses real Postgres (testcontainer) to verify that:
+  1. Snapshot rows are correctly persisted for each integrity service.
+  2. A second identical run produces no transitions and does not call Discord.
+  3. Injecting a synthetic prior-state error row causes the next run to
+     detect a recovery transition and call Discord exactly once.
+
+The integrity services themselves are stubbed — their SQL correctness is
+covered by their own unit tests. Here we verify persistence, diffing, and
+the alerting contract. Discord is always mocked.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from automana.core.repositories.ops.pipeline_health_snapshot_repository import (
+    PipelineHealthSnapshotRepository,
+)
+from automana.core.services.ops import health_alert_service as svc
+
+
+pytestmark = [pytest.mark.integration]
+
+
+_CANNED_OK = {
+    "check_set": "scryfall_integrity",
+    "total_checks": 5,
+    "error_count": 0,
+    "warn_count": 0,
+    "ok_count": 5,
+    "errors": [],
+    "warnings": [],
+    "passed": [],
+    "rows": [],
+}
+
+
+async def _run(conn, report=None):
+    """Run the service with all side-effects mocked; return (result, poster mock)."""
+    repo = PipelineHealthSnapshotRepository(conn)
+    poster = AsyncMock(return_value=204)
+    with (
+        patch.object(svc, "_discover_integrity_services", return_value=["ops.integrity.scryfall_integrity"]),
+        patch.object(svc, "_run_integrity_service", new=AsyncMock(return_value=report or _CANNED_OK)),
+        patch.object(svc, "_get_webhook_url", return_value="https://discord.example/webhook"),
+        patch.object(svc, "_post_to_discord", new=poster),
+    ):
+        result = await svc.run_alert_check(pipeline_health_snapshot_repository=repo)
+    return result, poster
+
+
+async def test_rows_persisted_for_each_integrity_service(db_pool):
+    async with db_pool.acquire() as conn:
+        out, _ = await _run(conn)
+
+    assert out["total_check_sets"] == 1
+    async with db_pool.acquire() as conn:
+        rows = await conn.fetch(
+            "SELECT check_set FROM ops.pipeline_health_snapshot WHERE run_id = $1",
+            uuid.UUID(out["run_id"]),
+        )
+    assert len(rows) == 1
+    assert rows[0]["check_set"] == "scryfall_integrity"
+
+
+async def test_second_run_produces_no_transition(db_pool):
+    poster = AsyncMock(return_value=204)
+    async with db_pool.acquire() as conn:
+        repo = PipelineHealthSnapshotRepository(conn)
+        with (
+            patch.object(svc, "_discover_integrity_services", return_value=["ops.integrity.scryfall_integrity"]),
+            patch.object(svc, "_run_integrity_service", new=AsyncMock(return_value=_CANNED_OK)),
+            patch.object(svc, "_get_webhook_url", return_value="https://discord.example/webhook"),
+            patch.object(svc, "_post_to_discord", new=poster),
+        ):
+            await svc.run_alert_check(pipeline_health_snapshot_repository=repo)
+            second = await svc.run_alert_check(pipeline_health_snapshot_repository=repo)
+
+    assert second["degraded"] == []
+    assert second["recovered"] == []
+    assert second["alerted"] is False
+    # First run may alert (if there was a prior row from another test with a
+    # different status). Second run must never alert when status is unchanged.
+    assert poster.await_count <= 1
+
+
+async def test_injected_error_row_triggers_recovery_on_next_run(db_pool):
+    # Establish a baseline run so there is at least one committed 'ok' row.
+    async with db_pool.acquire() as conn:
+        await _run(conn)
+
+    # Inject a synthetic 'error' snapshot with captured_at strictly after the
+    # baseline so it wins the ORDER BY captured_at DESC race for "latest prior".
+    injected_run_id = uuid.uuid4()
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO ops.pipeline_health_snapshot
+                (run_id, captured_at, check_set, pipeline, status,
+                 error_count, warn_count, total_checks, report)
+            VALUES
+                ($1, now() + interval '50 ms', $2, $3, 'error', 1, 0, 1, '{}'::jsonb)
+            """,
+            injected_run_id,
+            "scryfall_integrity",
+            svc.derive_pipeline("scryfall_integrity"),
+        )
+
+    # Next run: canned report is still 'ok', injected prior is 'error' → recovered.
+    async with db_pool.acquire() as conn:
+        out, poster = await _run(conn)
+
+    transitions = out["degraded"] + out["recovered"]
+    assert transitions, f"Expected a recovery transition but got none: {out}"
+    poster.assert_awaited_once()


### PR DESCRIPTION
Title: feat(ops): pipeline health alert + catalog-side price coverage metrics                                                                                                                       
                                                                                                                                                                                                      
  Body:                                                                                                                                                                                               
  ## Summary                                                                                                                                                                                          
                                                                                                                                                                                                      
  - **Health alert service**: new `run_alert_check` Celery task posting degraded/recovered signals to Discord; logs `discord_alert_sent` on success                                                   
  - **Catalog-side price coverage**: 6 new `pricing.card_coverage.*` metrics showing how many of the ~113k `card_version` rows have prices, split by foil/nonfoil                                     
  - **MTGStock pipeline fixes**: pre-seed `pricing.data_provider` rows; remove dynamic DDL from `load_staging_prices_batched` (app_celery lacks CREATE); guard missing provider with RAISE EXCEPTION;
  fix foil-split column mapping; pre-set `temp_buffers=32768` at pool level to avoid InvalidParameterValueError on recycled connections                                                               
  - **Log hygiene**: demote per-step wiring logs to DEBUG; replace print() in AbstractDBRepository with logger.debug()                                                                                
                                                                                                                                                                                                      
  ## New metrics (ops.integrity.pricing_report)                                                                                                                                                       
                                                                                                                                                                                                    
  | Metric | Threshold |                                                                                                                                                                              
  |---|---|                                                                                                                                                                                         
  | `pricing.card_coverage.catalog_coverage_pct` | WARN < 50%, ERROR < 20% |
  | `pricing.card_coverage.card_versions_with_any_price` | informational |  
  | `pricing.card_coverage.card_versions_without_price` | WARN ≥ 10k, ERROR ≥ 50k |                                                                                                                   
  | `pricing.card_coverage.card_versions_with_nonfoil_price` | informational |     
  | `pricing.card_coverage.card_versions_with_foil_price` | informational |                                                                                                                           
  | `pricing.card_coverage.total_observation_rows` | WARN < 500k, ERROR < 10k |                                                                                                                     
                                                                                                                                                                                                      
  ## Test plan                                                                                                                                                                                      
  - [ ] `automana-run ops.integrity.pricing_report` shows 13 checks (7 existing + 6 new)                                                                                                              
  - [ ] `catalog_coverage_pct` fires ERROR on empty dev DB (expected)                                                                                                                               
  - [ ] `total_observation_rows` returns 0 (not -1) on unanalyzed table                                                                                                                               
  - [ ] MTGStock pipeline end-to-end: foil/nonfoil counts populate after price load
  - [ ] `run_alert_check` posts to Discord and logs `discord_alert_sent`                                                                                                                              
  - [ ] No InvalidParameterValueError on second `load_staging_prices_batched` invocation    