### PR TITLE
test(pricing): update pricing_report tests for 6 card_coverage metrics

### DIFF
--- a/tests/unit/core/services/ops/test_pricing_report.py
+++ b/tests/unit/core/services/ops/test_pricing_report.py
@@ -15,6 +15,14 @@ def _repos():
     price.fetch_orphan_observation_count.return_value = 0
     price.fetch_stg_residual_count.return_value = 0
     price.fetch_observation_pk_collision_count.return_value = 0
+    price.fetch_card_coverage_stats.return_value = {
+        "total_card_versions": 1000,
+        "with_price": 800,
+        "without_price": 200,
+        "with_nonfoil_price": 750,
+        "with_foil_price": 400,
+    }
+    price.fetch_total_observation_count.return_value = 50000
     ops = AsyncMock()
     return price, ops
 
@@ -24,7 +32,7 @@ async def test_pricing_report_runs_all_seven_metrics_with_no_filter():
     price, ops = _repos()
     out = await pricing_report(price_repository=price, ops_repository=ops)
     assert out["check_set"] == "pricing_report"
-    assert out["total_checks"] == 7
+    assert out["total_checks"] == 13
     paths = {r["check_name"] for r in out["rows"]}
     expected = {
         "pricing.freshness.price_observation_max_age_days",
@@ -34,6 +42,12 @@ async def test_pricing_report_runs_all_seven_metrics_with_no_filter():
         "pricing.referential.observation_without_source_product",
         "pricing.staging.stg_price_observation_residual_count",
         "pricing.duplicate_detection.observation_duplicates_on_pk",
+        "pricing.card_coverage.catalog_coverage_pct",
+        "pricing.card_coverage.card_versions_with_any_price",
+        "pricing.card_coverage.card_versions_without_price",
+        "pricing.card_coverage.card_versions_with_nonfoil_price",
+        "pricing.card_coverage.card_versions_with_foil_price",
+        "pricing.card_coverage.total_observation_rows",
     }
     assert paths == expected
 
@@ -54,4 +68,4 @@ async def test_pricing_report_one_failing_metric_does_not_kill_report():
     price.fetch_max_observation_age_days.side_effect = RuntimeError("db down")
     out = await pricing_report(price_repository=price, ops_repository=ops)
     assert out["error_count"] == 1
-    assert out["total_checks"] == 7
+    assert out["total_checks"] == 13


### PR DESCRIPTION
## Summary
`card_coverage_metrics.py` was added in `feat(pricing): add catalog-side price coverage metrics` but the unit tests for `pricing_report` were never updated. This caused 3 test failures: `fetch_card_coverage_stats` and `fetch_total_observation_count` were unmocked, so `MagicMock` values flowed into `MetricRegistry.evaluate` and raised `TypeError: '>=' not supported between instances of 'MagicMock' and 'int'`.

## Changes Introduced
- `tests/unit/core/services/ops/test_pricing_report.py`: added mocks for `fetch_card_coverage_stats` and `fetch_total_observation_count` in `_repos()`
- Updated `total_checks` assertions from `7` to `13` (7 original + 6 new card_coverage metrics)
- Added the 6 new `pricing.card_coverage.*` paths to the exhaustive path set in `test_pricing_report_runs_all_seven_metrics_with_no_filter`

## Acceptance Checklist
- [x] All tests pass (361 unit tests green)
- [x] No debug logs left behind
- [x] Follows project coding standards
- [x] Ready for review