### PR TITLE
fix(pricing): wire ingestion_run_id into call_load_stage_from_raw

### DIFF
--- a/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
+++ b/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
@@ -33,15 +33,21 @@ class PriceRepository(AbstractRepository):
             format='csv',
             header=True)
 
-    async def call_load_stage_from_raw(self, source_name: str = "mtgstocks", batch_days: int = 30):
-        """Call pricing.load_staging_prices_batched(source_name, batch_days).
+    async def call_load_stage_from_raw(
+        self, source_name: str = "mtgstocks", batch_days: int = 30,
+        ingestion_run_id: Optional[int] = None,
+    ):
+        """Call pricing.load_staging_prices_batched(source_name, batch_days, ingestion_run_id).
 
         `source_name` must match a row in `pricing.price_source.code`. Migration
-        16 made `source_name` a required positional argument."""
+        16 made `source_name` a required positional argument.
+        When `ingestion_run_id` is provided, the procedure writes per-batch rows
+        to `ops.ingestion_step_batches` and updates `ops.ingestion_run_steps.progress`."""
         await self.connection.execute(
-            "CALL pricing.load_staging_prices_batched($1::varchar, $2::int);",
+            "CALL pricing.load_staging_prices_batched($1::varchar, $2::int, $3::int);",
             source_name,
             batch_days,
+            ingestion_run_id,
         )
 
     async def call_resolve_price_rejects(


### PR DESCRIPTION
# Summary

PR #124 added a `p_ingestion_run_id INT DEFAULT NULL` parameter to `pricing.load_staging_prices_batched`. This PR updates the Python repository method to accept and forward the new parameter, completing the binding between the service layer and the procedure.

---

# Changes Introduced

- `PriceRepository.call_load_stage_from_raw`: added `ingestion_run_id: Optional[int] = None` parameter and updated the `CALL` statement to pass `$3::int`.

---

# Acceptance Checklist

- [x] Code compiles without errors
- [x] Follows project coding standards
- [x] Ready for review