### PR TITLE
feat(pricing): retry-rejects pipeline step + inline promotion + MTGJson fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Git worktrees
+.worktrees/
+
 #Python
 __pycache__/
 */__pycache__/

--- a/docs/MTGSTOCK_PIPELINE.md
+++ b/docs/MTGSTOCK_PIPELINE.md
@@ -10,8 +10,8 @@ The pipeline is structured in **four stages**, each backed by a dedicated table 
 |---|---|---|---|
 | 1. Raw landing | Scraper output | Bulk insert | `pricing.raw_mtg_stock_price` |
 | 2. Resolve + stage | `raw_mtg_stock_price` | `pricing.load_staging_prices_batched` | `pricing.stg_price_observation` + `pricing.stg_price_observation_reject` |
-| 3. Load fact | `stg_price_observation` | `pricing.load_prices_from_staged_batched` | `pricing.price_observation` |
-| 4. Retry rejects | `stg_price_observation_reject` | `pricing.resolve_price_rejects` | Re-feeds back to `stg_price_observation` |
+| 3. Retry rejects | `stg_price_observation_reject` | `pricing.resolve_price_rejects` | Re-feeds resolved rows back to `stg_price_observation` in same run |
+| 4. Load fact | `stg_price_observation` | `pricing.load_prices_from_staged_batched` | `pricing.price_observation` |
 
 All DDL and routines live in [`src/automana/database/SQL/schemas/06_prices.sql`](../src/automana/database/SQL/schemas/06_prices.sql).
 
@@ -149,7 +149,7 @@ Resolved rows are inserted into `pricing.stg_price_observation` (wide model — 
 
 | Column | Notes |
 |---|---|
-| `stg_id BIGSERIAL PK` | Surrogate for the DELETE key in stage 3 |
+| `stg_id BIGSERIAL PK` | Surrogate for the DELETE key in stage 4 |
 | `ts_date`, `game_code`, `print_id` | From raw |
 | `list_low_cents`, `list_avg_cents`, `sold_avg_cents` | Nullable — each staging row may carry only a subset |
 | `is_foil` | Derived from which raw price column the row came from |
@@ -163,7 +163,35 @@ Indexes: `stg_price_obs_date_spid_foil_idx (ts_date, source_product_id, is_foil)
 
 ---
 
-## Stage 3 — Load fact table
+## Stage 3 — Retry rejects
+
+**Routine:** `pricing.resolve_price_rejects(p_limit INT DEFAULT 50000, p_only_unresolved BOOL DEFAULT TRUE)`
+
+Picks up to `p_limit` unresolved rejects and retries resolution. Takes fresh `scryfall_migration` data into account, so rejects from before a migration landed can be retroactively resolved. Runs **before** Stage 4 so that newly-resolved rows are promoted to `price_observation` in the same pipeline run.
+
+### Pipeline
+
+1. Slice candidates into `tmp_rejects` (`resolved_at IS NULL AND is_terminal IS FALSE`, or everything if `p_only_unresolved := FALSE`).
+2. Re-run the same resolution waterfall as stage 2 (`print_id` → external IDs → set+collector), producing `tmp_resolved`.
+3. Back-fill `card_external_identifier` for rows resolved via EXTERNAL_ID or SET_COLLECTOR so future runs hit the cheaper PRINT_ID path.
+4. Ensure `product_ref` + `mtg_card_products` for any newly-resolved `card_version_id`.
+5. Ensure `source_product` for each `(product_id, mtgstocks source_id)` pair.
+6. **Re-feed** resolved rejects into `stg_price_observation` — with the full wide payload. Skips rows where all three cents columns are NULL.
+7. **Mark** the reject row terminal:
+   - Successful retries → `terminal_reason = 'Resolved via <METHOD> mapping'`.
+   - Rows whose `scryfall_id` is in `scryfall_migration` with `migration_strategy = 'delete'` → `terminal_reason = 'Scryfall migration delete and no alternative identifiers'`.
+
+### Match key for the terminal update
+
+The reject table has no surrogate key. The match predicate is `(ts_date, print_id, is_foil, source_code, data_provider_id, scraped_at)`. If this is ever not unique in practice, add `rej_id BIGSERIAL PRIMARY KEY` to `stg_price_observation_reject` and carry it through `tmp_rejects → tmp_resolved`.
+
+### Returns
+
+`bigint` — number of rows re-fed into `stg_price_observation`. Those rows are then promoted to `price_observation` by Stage 4 in the same run.
+
+---
+
+## Stage 4 — Load fact table
 
 **Routine:** `pricing.load_prices_from_staged_batched(batch_days INT DEFAULT 30)`
 
@@ -202,34 +230,6 @@ Moves resolved staging rows into `pricing.price_observation`.
 ### Known ceiling: compressed chunks
 
 If staging ever carries rows older than 180 days, the upsert fails with `cannot update compressed chunk`. Mitigation is architectural: keep staging drained inside the compression window, or add an explicit decompression step for out-of-window batches.
-
----
-
-## Stage 4 — Retry rejects
-
-**Routine:** `pricing.resolve_price_rejects(p_limit INT DEFAULT 50000, p_only_unresolved BOOL DEFAULT TRUE)`
-
-Picks up to `p_limit` unresolved rejects and retries resolution. Takes fresh `scryfall_migration` data into account, so rejects from before a migration landed can be retroactively resolved.
-
-### Pipeline
-
-1. Slice candidates into `tmp_rejects` (`resolved_at IS NULL AND is_terminal IS FALSE`, or everything if `p_only_unresolved := FALSE`).
-2. Re-run the same resolution waterfall as stage 2 (`print_id` → external IDs → set+collector), producing `tmp_resolved`.
-3. Ensure `product_ref` + `mtg_card_products` for any newly-resolved `card_version_id`.
-4. Ensure `source_product` for each `(product_id, mtgstocks source_id)` pair.
-5. **Re-feed** resolved rejects into `stg_price_observation` — with the full wide payload (`list_low_cents`, `list_avg_cents`, `sold_avg_cents`, `is_foil`, `data_provider_id`, `value`, and all audit metadata). Skips rows where all three cents columns are NULL.
-6. **Mark** the reject row terminal:
-   - Successful retries → `terminal_reason = 'Resolved via <METHOD> mapping'`.
-   - Rows whose `scryfall_id` is in `scryfall_migration` with `migration_strategy = 'delete'` and no alternative identifiers → `terminal_reason = 'Scryfall migration delete and no alternative identifiers'`.
-
-### Match key for the terminal update
-
-The reject table has no surrogate key yet. The match predicate is
-`(ts_date, print_id, is_foil, source_code, data_provider_id, scraped_at)` — one natural row per scrape per `(day, product, foil, provider)`. If this is ever not unique in practice, add `rej_id BIGSERIAL PRIMARY KEY` to `stg_price_observation_reject` and carry it through `tmp_rejects → tmp_resolved`.
-
-### Returns
-
-`bigint` — number of rows re-fed into `stg_price_observation`. After a successful retry those rows go through stage 3 normally on the next run.
 
 ---
 
@@ -278,23 +278,23 @@ pricing.raw_mtg_stock_price
 
 **Why non-atomic:** the asyncpg pool's default `command_timeout` is 60 s (see `core/database.py`). A single COPY of a 10 000-folder batch can exceed that limit, which surfaces as `AttributeError: 'NoneType' object has no attribute 'done'` inside asyncpg's `base_protocol.py`. Running without an outer transaction also allows per-batch audit rows to commit incrementally rather than being held open for the entire bulk load.
 
-**Re-run idempotency caveat:** `pricing.raw_mtg_stock_price` has no primary key or uniqueness constraint, and `bulk_load` does not `TRUNCATE` the table before loading. If a run crashes mid-way and is re-run, duplicate rows accumulate in the raw landing table. Stage 2 (`load_staging_prices_batched`) pivots those duplicates forward into staging; Stage 3 (`load_prices_from_staged_batched`) deduplicates on the fact-table primary key before the upsert, so duplicates do not propagate to `pricing.price_observation`. This is a pre-existing design property of the landing table, not introduced by the timeout change.
+**Re-run idempotency caveat:** `pricing.raw_mtg_stock_price` has no primary key or uniqueness constraint, and `bulk_load` does not `TRUNCATE` the table before loading. If a run crashes mid-way and is re-run, duplicate rows accumulate in the raw landing table. Stage 2 (`load_staging_prices_batched`) pivots those duplicates forward into staging; Stage 4 (`load_prices_from_staged_batched`) deduplicates on the fact-table primary key before the upsert, so duplicates do not propagate to `pricing.price_observation`. This is a pre-existing design property of the landing table, not introduced by the timeout change.
 
 ### Idempotency
 
-- Stage 2 is idempotent on a per-row basis: re-inserting the same `(ts_date, print_id, scraped_at)` produces a duplicate staging row, but stage 3's dedup collapses them before the upsert. Still, avoid re-running stage 2 over the same raw window without draining staging first — it wastes work.
-- Stage 3 is strictly idempotent: the ON CONFLICT clause ensures re-running over the same window is a no-op if nothing has changed.
-- Stage 4 is safe to run repeatedly — it only picks rejects that are not yet terminal.
+- Stage 2 is idempotent on a per-row basis: re-inserting the same `(ts_date, print_id, scraped_at)` produces a duplicate staging row, but stage 4's dedup collapses them before the upsert. Still, avoid re-running stage 2 over the same raw window without draining staging first — it wastes work.
+- Stage 3 is safe to run repeatedly — it only picks rejects that are not yet terminal.
+- Stage 4 is strictly idempotent: the ON CONFLICT clause ensures re-running over the same window is a no-op if nothing has changed.
 
 ### Chaining under Celery
 
-The Celery chain that drives this pipeline (once wired) should follow the pattern established by [`docs/MTGJSON_PIPELINE.md`](MTGJSON_PIPELINE.md):
+The active Celery chain in `worker/tasks/pipelines.py::mtgStock_download_pipeline`:
 
 1. `ops.pipeline_services.start_run`
-2. (scraper service — writes to `raw_mtg_stock_price`)
-3. `staging.mtgstock.load_to_staging` → calls `load_staging_prices_batched`
-4. `staging.mtgstock.load_to_fact` → calls `load_prices_from_staged_batched`
-5. `staging.mtgstock.retry_rejects` → calls `resolve_price_rejects` (optional, periodic)
+2. `mtg_stock.data_staging.bulk_load` → COPY parquet files into `raw_mtg_stock_price`
+3. `mtg_stock.data_staging.from_raw_to_staging` → calls `load_staging_prices_batched`
+4. `mtg_stock.data_staging.retry_rejects` → calls `resolve_price_rejects`
+5. `mtg_stock.data_staging.from_staging_to_prices` → calls `load_prices_from_staged_batched`
 6. `ops.pipeline_services.finish_run`
 
 Context keys between steps must match parameter names (the `run_service` dispatcher filters by signature — see [`CLAUDE.md`](../CLAUDE.md)).

--- a/docs/superpowers/specs/2026-04-26-card-search-design.md
+++ b/docs/superpowers/specs/2026-04-26-card-search-design.md
@@ -1,0 +1,260 @@
+# Card Search — Design Spec
+**Date:** 2026-04-26
+**Branch target:** main
+**Status:** Approved
+
+---
+
+## Goals
+
+1. Typo-tolerant name search (fuzzy matching via pg_trgm)
+2. Autocomplete / typeahead endpoint for incremental name suggestions
+3. Oracle text search ("find all cards that say 'draw a card'")
+4. Combined filter search (color + type + rarity + CMC + format legality in one query)
+5. Redis cache to absorb repeat queries
+6. Fix the per-row materialized view trigger (performance hazard during ETL bulk imports)
+
+Non-goal: semantic / embedding-based search (pgvector). Deferred to a future spec.
+
+---
+
+## Architecture overview
+
+Two-tier search:
+
+```
+autocomplete (fast)          full search (rich)
+       │                            │
+v_card_name_suggest          v_card_versions_complete
+  (4 columns, pg_trgm)        (30+ columns, tsvector + pg_trgm)
+       │                            │
+CardReferenceRepository.suggest()   CardReferenceRepository.search()
+       │                            │
+   card_service.suggest()       card_service.search()
+       │                            │
+GET /card-reference/suggest    GET /card-reference/
+```
+
+Both paths go through Redis before hitting the database.
+
+---
+
+## Section 1 — Database layer
+
+### 1a. pg_trgm extension + new indexes
+
+All DDL lives in `src/automana/database/SQL/schemas/02_card_schema.sql` (the project has no separate migrations directory — schema changes go directly into the schema files so a full rebuild from scratch produces the correct state).
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Unique index required by REFRESH MATERIALIZED VIEW CONCURRENTLY
+CREATE UNIQUE INDEX idx_v_card_name_suggest_pk
+    ON card_catalog.v_card_name_suggest (card_version_id);
+
+-- Trigram index for autocomplete view (primary fuzzy target)
+CREATE INDEX gin_trgm_idx_v_card_name_suggest
+    ON card_catalog.v_card_name_suggest
+    USING GIN (card_name gin_trgm_ops);
+
+-- Trigram index for full search view (fuzzy name ranking in combined queries)
+CREATE INDEX gin_trgm_idx_v_card_versions_name
+    ON card_catalog.v_card_versions_complete
+    USING GIN (card_name gin_trgm_ops);
+```
+
+### 1b. New `v_card_name_suggest` materialized view
+
+Lightweight — 4 columns only. Sourced from `card_version` JOIN `unique_cards_ref` JOIN `sets_ref` JOIN `rarities_ref`. No aggregations, no JSONB, no arrays.
+
+Columns: `card_version_id`, `card_name`, `set_code`, `rarity_name`
+
+Lives in `src/automana/database/SQL/schemas/02_card_schema.sql`, added after the existing `v_card_versions_complete` block.
+
+### 1c. Drop per-row trigger, add refresh procedure
+
+The existing `trigger_refresh_card_versions()` fires on every INSERT/UPDATE/DELETE to `unique_cards_ref` and `card_version`. During a 30k-card ETL bulk import this causes 30k+ full view recomputes. Drop it.
+
+Replace with a stored procedure:
+
+```sql
+CREATE OR REPLACE PROCEDURE card_catalog.refresh_card_search_views()
+LANGUAGE plpgsql AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY card_catalog.v_card_versions_complete;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY card_catalog.v_card_name_suggest;
+END;
+$$;
+```
+
+Called once at the end of the Scryfall and MTGJson pipeline tasks after bulk import completes. Both Celery tasks get a `call refresh_card_search_views()` step added to their pipeline chain.
+
+---
+
+## Section 2 — Repository layer
+
+File: `src/automana/core/repositories/card_catalog/card_repository.py`
+
+### 2a. New `suggest(query, limit)` method
+
+Queries `v_card_name_suggest` only. Uses the `%` trigram operator so PostgreSQL uses the GIN index.
+
+```sql
+SELECT card_version_id, card_name, set_code, rarity_name,
+       word_similarity($1, card_name) AS score
+FROM card_catalog.v_card_name_suggest
+WHERE $1 % card_name
+ORDER BY score DESC
+LIMIT $2
+```
+
+Returns a list of `CardSuggestion` objects (new lightweight Pydantic model).
+
+### 2b. Updated `search()` method
+
+Replaces the ILIKE name filter with fuzzy matching. Adds oracle text search. All existing filters are backward-compatible.
+
+**Name filter (replaces ILIKE):**
+```sql
+word_similarity($name, card_name) > 0.3
+```
+Uses the new trigram GIN index on `v_card_versions_complete`.
+
+**New oracle text filter:**
+```sql
+search_vector @@ websearch_to_tsquery('english', $oracle_text)
+```
+Activates the existing `idx_v_card_versions_complete_search` GIN index (already present, never queried).
+
+**New format legality filter:**
+```sql
+legalities->>'$format' = 'legal'
+```
+Uses the existing `idx_v_card_versions_complete_legalities` GIN index.
+
+**Relevance ordering:**
+When name and/or oracle_text are supplied, ORDER BY includes a relevance score. The expression is constructed dynamically by the repository method:
+- `name` only: `ORDER BY word_similarity($name, card_name) DESC`
+- `oracle_text` only: `ORDER BY ts_rank_cd(search_vector, websearch_to_tsquery('english', $oracle_text)) DESC`
+- Both: `ORDER BY (word_similarity($name, card_name) + ts_rank_cd(search_vector, websearch_to_tsquery('english', $oracle_text))) DESC`
+- Neither: falls back to existing `sort_by` / `sort_order` params
+
+**New method signature parameter:** `oracle_text: str | None = None`, `format: str | None = None`. All existing parameters unchanged.
+
+---
+
+## Section 3 — Service and cache layer
+
+File: `src/automana/core/services/card_catalog/card_service.py`
+
+### Cache key strategy
+
+| Operation | Key pattern | TTL |
+|-----------|-------------|-----|
+| Suggest | `card_search:suggest:{lower(q)}:{limit}` | 10 min |
+| Full search | `card_search:full:{sha256(sorted_params)}` | 60 min |
+
+Uses existing `get_from_cache` / `set_to_cache` from `src/automana/core/utils/redis_cache.py`.
+
+### 3a. New `suggest()` service
+
+Read-through cache: check Redis → on miss, call `CardReferenceRepository.suggest()` → serialize → store → return.
+
+Registered as service `"card_catalog.card.suggest"`.
+
+### 3b. `search()` service — add cache wrapper
+
+Wrap existing `search_cards()` at `card_service.py:114-166` with the same read-through pattern. No change to search logic itself.
+
+### 3c. New `invalidate_search_cache()` service
+
+Scans Redis for keys matching `card_search:*` and deletes them. Called at the end of both `mtgjson_download_pipeline` and `scryfall_download_pipeline` Celery tasks, after `refresh_card_search_views()` completes.
+
+This ensures users see new set data immediately after a pipeline run without waiting for TTL expiry.
+
+---
+
+## Section 4 — API layer
+
+File: `src/automana/api/routers/mtg/card_reference.py`
+File: `src/automana/api/dependancies/query_deps.py`
+
+### 4a. New `GET /card-reference/suggest` endpoint
+
+```
+GET /card-reference/suggest?q=lightn&limit=10
+```
+
+- `q`: required, minimum length 2
+- `limit`: 1–20, default 10
+- Response: `[{card_version_id, card_name, set_code, rarity_name, score}]`
+- No pagination — always returns a short ranked list
+- Placed above the `{card_id}` path endpoint to avoid routing conflicts
+
+Calls service `"card_catalog.card.suggest"`.
+
+### 4b. Extended `GET /card-reference/` search
+
+Two new optional query params added to `card_search_params()` in `query_deps.py`:
+
+- `oracle_text: str | None` — passed to repository oracle text clause
+- `format: str | None` — filters on `legalities->>'<format>' = 'legal'`
+
+All existing params unchanged. Existing clients are not broken.
+
+---
+
+## New Pydantic models
+
+File: `src/automana/core/models/card_catalog/card.py` (existing card models file)
+
+- `CardSuggestion`: `card_version_id`, `card_name`, `set_code`, `rarity_name`, `score: float`
+- `CardSuggestionResponse`: `suggestions: list[CardSuggestion]`
+
+`CardSearchResult` (existing) gains no new fields — `oracle_text` and `format` are inputs, not outputs.
+
+---
+
+## Schema file changes
+
+All changes go into `src/automana/database/SQL/schemas/02_card_schema.sql` in this order:
+
+1. `CREATE EXTENSION IF NOT EXISTS pg_trgm` (near top, with other extensions)
+2. DDL for `v_card_name_suggest` materialized view
+3. Unique index on `v_card_name_suggest(card_version_id)` (required for CONCURRENTLY)
+4. Trigram GIN indexes on both views
+5. `DROP TRIGGER` / `DROP FUNCTION` for the per-row refresh trigger
+6. `CREATE OR REPLACE PROCEDURE card_catalog.refresh_card_search_views()`
+
+A full rebuild from scratch will produce the correct state with no migration step required.
+
+---
+
+## ETL integration points
+
+| Pipeline | Where to add |
+|----------|-------------|
+| `scryfall_download_pipeline` | After bulk card insert step: call `refresh_card_search_views()`, then `invalidate_search_cache()` |
+| `mtgjson_download_pipeline` | Same pattern |
+
+No changes to the MTGStock pipeline (it doesn't import card catalog data).
+
+---
+
+## What is NOT changing
+
+- Existing `GET /card-reference/` response shape
+- Existing `GET /card-reference/{card_id}` endpoint
+- `CardSearchResult` model
+- All existing indexes on `v_card_versions_complete`
+- `insert_full_card_version()` and `insert_batch_card_versions()` stored procedures
+- Pagination and sorting logic
+
+---
+
+## Out of scope
+
+- pgvector / semantic "find similar cards" search
+- GraphQL
+- Elasticsearch or external search engines
+- Search analytics / logging of queries

--- a/src/automana/core/services/app_integration/mtg_stock/data_staging.py
+++ b/src/automana/core/services/app_integration/mtg_stock/data_staging.py
@@ -231,7 +231,7 @@ async def retry_rejects(price_repository: PriceRepository,
             ingestion_run_id=ingestion_run_id, current_step=step_name, status="failed",
             error_details={"error": str(e)},
         )
-        logger.error("retry_rejects: failed with %s", e)
+        logger.exception("retry_rejects: failed with %s", e)
         raise
 
 

--- a/src/automana/database/SQL/schemas/06_prices.sql
+++ b/src/automana/database/SQL/schemas/06_prices.sql
@@ -500,6 +500,17 @@ DECLARE
   v_batch_seq   INT := 0;
   v_batch_start TIMESTAMPTZ;
   v_total_days  INT;
+  -- Promotion dimension IDs — resolved once before the loop
+  v_price_type_id      int;
+  v_finish_foil_id     smallint;
+  v_finish_default_id  smallint;
+  v_condition_id       smallint;
+  v_language_id        smallint;
+  -- Per-batch promotion counters
+  v_prom_rows          bigint;
+  v_prom_deleted       bigint;
+  total_promoted       bigint := 0;
+  total_staged_drained bigint := 0;
 
 BEGIN
   -- determine overall date range from raw data
@@ -548,6 +559,26 @@ BEGIN
   -- CREATE TABLE IF NOT EXISTS that used to live here was removed.
 
   v_start := v_min;
+
+  -- Resolve promotion dimension IDs once — stable across all batches.
+  v_finish_default_id := pricing.default_finish_id();
+  SELECT cf.finish_id INTO v_finish_foil_id
+  FROM pricing.card_finished cf
+  WHERE lower(cf.code) IN ('foil', 'foiled', 'premium')
+  ORDER BY cf.finish_id LIMIT 1;
+  IF v_finish_foil_id IS NULL THEN
+    v_finish_foil_id := v_finish_default_id;
+  END IF;
+  SELECT tt.transaction_type_id INTO v_price_type_id
+  FROM pricing.transaction_type tt
+  WHERE lower(tt.transaction_type_code) = 'sell'
+  ORDER BY tt.transaction_type_id LIMIT 1;
+  IF v_price_type_id IS NULL THEN
+    RAISE EXCEPTION 'No ''sell'' row in pricing.transaction_type';
+  END IF;
+  v_condition_id := pricing.default_condition_id();
+  v_language_id  := card_catalog.default_language_id();
+
   WHILE v_start <= v_max LOOP
     v_batch_seq   := v_batch_seq + 1;
     v_batch_start := clock_timestamp();
@@ -883,7 +914,104 @@ BEGIN
       GET DIAGNOSTICS cur_rows = ROW_COUNT;
       total_inserted := total_inserted + cur_rows;
 
-      RAISE NOTICE 'Inserted % rows for batch', cur_rows;
+      -- -----------------------------------------------------------------------
+      -- Inline promotion: drain staging rows for this date window immediately.
+      -- Keeps stg_price_observation from accumulating across the full run.
+      -- Uses distinct temp-table names (_prom_batch/_prom_dedup) to avoid
+      -- colliding with the _batch/_dedup names in load_prices_from_staged_batched.
+      -- -----------------------------------------------------------------------
+      DROP TABLE IF EXISTS _prom_batch;
+      CREATE TEMP TABLE _prom_batch ON COMMIT DROP AS
+      SELECT
+        s.stg_id,
+        s.ts_date,
+        s.source_product_id,
+        s.data_provider_id,
+        v_price_type_id::int                              AS price_type_id,
+        CASE WHEN s.is_foil THEN v_finish_foil_id
+             ELSE v_finish_default_id END                 AS finish_id,
+        v_condition_id                                    AS condition_id,
+        v_language_id                                     AS language_id,
+        s.list_low_cents,
+        s.list_avg_cents,
+        s.sold_avg_cents,
+        s.scraped_at
+      FROM pricing.stg_price_observation s
+      WHERE s.ts_date >= v_start
+        AND s.ts_date <= v_end
+        AND NOT (s.list_low_cents IS NULL
+             AND s.list_avg_cents IS NULL
+             AND s.sold_avg_cents IS NULL);
+
+      DROP TABLE IF EXISTS _prom_dedup;
+      CREATE TEMP TABLE _prom_dedup ON COMMIT DROP AS
+      SELECT *
+      FROM (
+        SELECT b.*,
+               row_number() OVER (
+                 PARTITION BY
+                   b.ts_date,
+                   b.source_product_id,
+                   b.price_type_id,
+                   b.finish_id,
+                   b.condition_id,
+                   b.language_id,
+                   b.data_provider_id
+                 ORDER BY b.scraped_at DESC, b.stg_id DESC
+               ) AS rn
+        FROM _prom_batch b
+      ) x
+      WHERE rn = 1;
+
+      INSERT INTO pricing.price_observation (
+        ts_date, source_product_id, price_type_id,
+        finish_id, condition_id, language_id, data_provider_id,
+        list_low_cents, list_avg_cents, sold_avg_cents,
+        scraped_at
+      )
+      SELECT
+        ts_date, source_product_id, price_type_id,
+        finish_id, condition_id, language_id, data_provider_id,
+        list_low_cents, list_avg_cents, sold_avg_cents,
+        scraped_at
+      FROM _prom_dedup
+      ORDER BY ts_date
+      ON CONFLICT (ts_date, source_product_id, price_type_id,
+                   finish_id, condition_id, language_id, data_provider_id)
+      DO UPDATE SET
+        list_low_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.list_low_cents IS NOT NULL
+            THEN EXCLUDED.list_low_cents
+          ELSE pricing.price_observation.list_low_cents
+        END,
+        list_avg_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.list_avg_cents IS NOT NULL
+            THEN EXCLUDED.list_avg_cents
+          ELSE pricing.price_observation.list_avg_cents
+        END,
+        sold_avg_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.sold_avg_cents IS NOT NULL
+            THEN EXCLUDED.sold_avg_cents
+          ELSE pricing.price_observation.sold_avg_cents
+        END,
+        scraped_at = GREATEST(pricing.price_observation.scraped_at, EXCLUDED.scraped_at),
+        updated_at = now();
+
+      GET DIAGNOSTICS v_prom_rows = ROW_COUNT;
+      total_promoted := total_promoted + v_prom_rows;
+
+      DELETE FROM pricing.stg_price_observation s
+      USING _prom_batch b
+      WHERE s.stg_id = b.stg_id;
+
+      GET DIAGNOSTICS v_prom_deleted = ROW_COUNT;
+      total_staged_drained := total_staged_drained + v_prom_deleted;
+
+      RAISE NOTICE 'Batch % to %: staged %, promoted %, drained %',
+                   v_start, v_end, cur_rows, v_prom_rows, v_prom_deleted;
       v_ok := true;
     EXCEPTION WHEN OTHERS THEN
       RAISE WARNING 'Error processing batch % to %: %', v_start, v_end, SQLERRM;
@@ -911,7 +1039,8 @@ BEGIN
         0,
         ROUND(EXTRACT(EPOCH FROM (clock_timestamp() - v_batch_start)) * 1000)::int,
         jsonb_build_object('date_start', v_start::text, 'date_end', v_end::text,
-                           'total_inserted', total_inserted)
+                           'total_inserted', total_inserted,
+                           'promoted', v_prom_rows)
       FROM ops.ingestion_run_steps st
       WHERE st.ingestion_run_id = p_ingestion_run_id
         AND st.step_name = 'raw_to_staging'
@@ -926,7 +1055,8 @@ BEGIN
   END LOOP;
   -- stg_price_obs_date_spid_foil_idx is pre-created by 06_prices.sql schema section;
   -- CREATE INDEX IF NOT EXISTS removed — same reason as CREATE TABLE above.
-  RAISE NOTICE 'load_staging_prices_batched: total inserted % rows', total_inserted;
+  RAISE NOTICE 'load_staging_prices_batched: total staged %, promoted %, drained %',
+               total_inserted, total_promoted, total_staged_drained;
 END;
 $$;
 

--- a/src/automana/database/SQL/schemas/06_prices.sql
+++ b/src/automana/database/SQL/schemas/06_prices.sql
@@ -554,6 +554,12 @@ BEGIN
     v_end := LEAST(v_start + (batch_days - 1), v_max);
     v_ok :=false;
     BEGIN
+      -- Session locals are cleared by the previous COMMIT, so re-apply.
+      SET LOCAL work_mem                    = '512MB';
+      SET LOCAL maintenance_work_mem        = '1GB';
+      SET LOCAL synchronous_commit          = off;
+      SET LOCAL max_parallel_workers_per_gather = 4;
+
       RAISE NOTICE 'Loading raw -> staging for % to %', v_start, v_end;
       
       -- -------------------------------------------------------------------------
@@ -1296,8 +1302,7 @@ BEGIN
       r.print_id,
       r.card_version_id
     FROM tmp_resolved r
-    WHERE r.print_id IS NOT NULL
-      AND r.card_version_id IS NOT NULL
+    WHERE r.card_version_id IS NOT NULL
       AND r.resolution_method <> 'PRINT_ID'
   ),
   unambiguous_print AS (

--- a/tests/unit/core/services/app_integration/mtg_stock/test_data_staging.py
+++ b/tests/unit/core/services/app_integration/mtg_stock/test_data_staging.py
@@ -27,7 +27,7 @@ class TestServiceConfigFlags:
         cfg = ServiceRegistry.get("mtg_stock.data_staging.from_raw_to_staging")
         assert cfg is not None
         assert cfg.runs_in_transaction is False
-        assert cfg.command_timeout == 3600
+        assert cfg.command_timeout == 86400  # 24h ceiling for 456M raw rows
 
     def test_from_staging_to_prices_is_non_atomic(self):
         cfg = ServiceRegistry.get("mtg_stock.data_staging.from_staging_to_prices")


### PR DESCRIPTION
## Summary

- **Retry rejects pipeline step**: wires `mtg_stock.data_staging.retry_rejects` into the MTGStock Celery chain between `from_raw_to_staging` and `from_staging_to_prices`. Calls `pricing.resolve_price_rejects()` which re-feeds previously-rejected rows (resolved via fresh `scryfall_migration` entries or updated external identifiers) back into staging so they get promoted in the same run rather than the next one.
- **`resolve_price_rejects` improvements**: back-fill `card_external_identifier` for rows resolved via EXTERNAL_ID/SET_COLLECTOR, add per-method `RAISE NOTICE` breakdown, fix implicit AND/OR precedence bug in candidate filter.
- **`load_staging_prices_batched` — inline promotion**: dimension IDs resolved once before the loop; each batch now drains its staging rows into `price_observation` immediately (upsert + delete), keeping `stg_price_observation` lean between batches. Batch step JSON includes `promoted` counter.
- **SET LOCAL re-applied inside loop**: `work_mem`, `maintenance_work_mem`, `synchronous_commit`, `max_parallel_workers_per_gather` reset at the top of every batch block (they revert on each `COMMIT`).
- **MTGJson staging promotion fixes**: `src.name → src.code` in CTE joins, `finish_type` uppercase normalization, batch window `WHERE` clause re-enabled, `DO NOTHING → DO UPDATE RETURNING` on `insert_product_source` CTE.
- **`stg_price_observation` made UNLOGGED** for faster staging writes.
- **`ApimtgjsonRepository.name` promoted to `@property`**.
- **Docs**: `MTGSTOCK_PIPELINE.md` stage ordering corrected (Stage 3 = retry rejects, Stage 4 = load fact) with accurate Celery chain list.

## Test plan

- [x] `tests/unit/core/services/app_integration/mtg_stock/test_data_staging.py` — 7 unit tests covering retry_rejects happy/failure paths and all four service config-flag invariants
- [x] `tests/unit/core/repositories/app_integration/mtgjson/test_apimtgjson_repository.py` — `@property` regression
- [x] `tests/integration/services/mtgjson/test_promote_staging.py` — end-to-end MTGJson staging promotion (requires live DB)
- [x] Full pipeline smoke test: run `mtgStock_download_pipeline` against dev and verify `ops.ingestion_runs` shows all steps as `success`, `stg_price_observation` is empty after completion, and `price_observation` row counts increase

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)