### PR TITLE
fix(nginx): add proxy timeouts to /health and HTTP/1.1 to missing locations

### DIFF
--- a/deploy/docker/nginx/nginx.local.conf
+++ b/deploy/docker/nginx/nginx.local.conf
@@ -85,7 +85,11 @@ http {
         add_header Content-Security-Policy   "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
 
         location /health {
-            proxy_pass http://fastapi_backend;
+            proxy_pass            http://fastapi_backend;
+            proxy_http_version    1.1;
+            proxy_connect_timeout 2s;
+            proxy_send_timeout    2s;
+            proxy_read_timeout    2s;
             access_log off;
         }
 
@@ -110,11 +114,13 @@ http {
         }
 
         location /docs {
-            proxy_pass http://fastapi_backend;
+            proxy_pass         http://fastapi_backend;
+            proxy_http_version 1.1;
         }
 
         location / {
-            proxy_pass http://fastapi_backend;
+            proxy_pass         http://fastapi_backend;
+            proxy_http_version 1.1;
         }
     }
 }


### PR DESCRIPTION
## Summary

- The `/health` location was missing `proxy_read_timeout`, so nginx inherited the default 60s — exceeding the proxy container's 5s Docker healthcheck budget whenever the backend was slow or restarting. This caused the proxy to flip `unhealthy` and stay there until the backend fully recovered.
- Added `proxy_connect_timeout 2s`, `proxy_send_timeout 2s`, `proxy_read_timeout 2s` to `/health` so nginx fails fast and the Docker health check stays within its budget.
- Added `proxy_http_version 1.1` to `/health`, `/docs`, and the catchall `location /` — the upstream block declares `keepalive 32` which requires HTTP/1.1; those three locations were silently using HTTP/1.0 (the nginx default), making the keepalive pool dead config.

## Test plan

- [x] Rebuilt proxy container locally — all containers healthy, health checks completing in ~46ms
- [x] Verify proxy stays healthy during a backend restart cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)