### PR TITLE
docs: sync docs for nginx timeouts, pool keepalive, and card search

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -140,8 +140,9 @@ Base: `/api/catalog/mtg`
 
 Card reference (`/api/catalog/mtg/card-reference`)
 
+- `GET /api/catalog/mtg/card-reference/suggest` — autocomplete card names (typo-tolerant, fuzzy matching via pg_trgm; `q` min 2 chars, `limit` 1-20; cached 10 min)
 - `GET /api/catalog/mtg/card-reference/{card_id}` — get card by id
-- `GET /api/catalog/mtg/card-reference/` — search cards (paginated)
+- `GET /api/catalog/mtg/card-reference/` — search cards (paginated; supports `name`, `oracle_text`, `format`, plus other filters; cached 60 min)
 - `POST /api/catalog/mtg/card-reference/` — insert a card
 - `POST /api/catalog/mtg/card-reference/bulk` — insert up to 50 cards
 - `POST /api/catalog/mtg/card-reference/upload-file` — upload large JSON file

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -205,6 +205,18 @@ Important settings include:
 - `DATA_DIR` (base path for file storage)
 - `DISCORD_WEBHOOK_URL` (analytics notifications)
 
+## Caching
+
+**Application-level caching** uses Redis via a thin wrapper in [`src/automana/core/utils/redis_cache.py`](../src/automana/core/utils/redis_cache.py):
+
+- **Card search suggest** — 10-minute cache (TTL) for autocomplete queries; key is SHA256(query, limit)
+- **Card search full** — 60-minute cache for full search queries; key is SHA256 of all filter parameters
+- **Other services** — Register caches in the service via `service_manager.execute_service("path.to.cache_key", ...)`
+
+**Configuration:** `BROKER_URL` (e.g. `redis://redis:6379/0`) comes from environment; no hardcoded defaults.
+
+**Cache invalidation:** Pipeline tasks (`daily_scryfall_data_pipeline`, `daily_mtgjson_data_pipeline`) call `card_catalog.card_search.invalidate` and `card_catalog.card_search.refresh` after bulk card imports to clear and rebuild search indexes.
+
 ## Deployment
 
 ### Reverse proxy (nginx)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -214,6 +214,30 @@ The nginx image selects the config at build time via a build arg:
 - dev uses `nginx.local.conf` (wired in `deploy/docker-compose.dev.yml`)
 - prod uses `nginx.prod.conf` (wired in `deploy/docker-compose.prod.yml`)
 
+### Proxy configuration
+
+The nginx config defines per-location proxy settings:
+
+| Location | Purpose | HTTP version | Timeouts |
+|----------|---------|--------------|----------|
+| `/health` | Backend health probe | 1.1 | 2s connect/send/read |
+| `/api/` | Application API + WebSocket | 1.1 | 60s connect/send/read |
+| `/flower/` | Celery task monitoring | 1.1 | 60s connect/send/read |
+| `/docs` | OpenAPI documentation | 1.1 | (default 60s) |
+| `/` | Catchall | 1.1 | (default 60s) |
+
+**Key note:** All locations use `proxy_http_version 1.1` to enable the upstream connection keepalive pool (32 connections), which would be unused under HTTP/1.0. The `/health` location has short 2-second timeouts to prevent cascading proxy restarts when the backend hiccups (the Docker healthcheck has a 5-second timeout).
+
+### Security headers
+
+All responses on HTTPS (port 443) include:
+
+- `Strict-Transport-Security: max-age=31536000; includeSubDomains` (HSTS)
+- `X-Frame-Options: SAMEORIGIN` (clickjacking protection)
+- `X-Content-Type-Options: nosniff` (MIME sniffing prevention)
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'`
+
 ## Flower (Celery monitoring)
 
 Flower provides a real-time web UI for inspecting Celery workers and tasks.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -128,6 +128,32 @@ docker compose -f deploy/docker-compose.prod.yml start backend
 
 If your prod DB/user names differ, use the values from `config/env/.env.prod`.
 
+## Database connection pool (asyncpg)
+
+The backend application uses asyncpg's connection pool with TCP keepalive and timeout configuration to handle long-running batch operations (e.g., bulk pricing imports).
+
+### Pool settings (in `src/automana/core/database.py`)
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `min_size` | 2 | Minimum concurrent connections |
+| `max_size` | 10 | Maximum concurrent connections |
+| `command_timeout` | 60s | Default timeout per SQL command |
+| `max_inactive_connection_lifetime` | 3600s (1h) | Recycle idle connections to prevent stale state |
+| `server_settings.temp_buffers` | 32768 (256 MB) | Pre-allocate staging buffer for batch procedures; prevents `InvalidParameterValueError` on recycled connections |
+
+### TCP keepalive settings (PostgreSQL session-level)
+
+To prevent the OS TCP stack from silently dropping connections during long Python-side batch work (e.g., 30-50s CPU-heavy inter-batch windows in MTGStock bulk_load):
+
+| Setting | Value | Purpose |
+|---------|-------|---------|
+| `tcp_keepalives_idle` | 60s | Seconds before first keepalive probe |
+| `tcp_keepalives_interval` | 10s | Interval between probes |
+| `tcp_keepalives_count` | 5 | Probes before giving up |
+
+**Why this matters:** Without keepalive, idle connections can be closed by the OS or an intermediate proxy, causing `InterfaceError('connection has been released back to the pool')` on the next query, especially during multi-hour bulk pricing imports. These settings ensure the connection stays alive across long idle windows.
+
 ## Flower (Celery monitoring)
 
 Flower provides a real-time web UI for inspecting Celery workers and tasks.
@@ -237,9 +263,25 @@ All services in docker-compose.dev.yml have healthchecks configured:
 | `backend` | `python3 urllib.request.urlopen('http://localhost:8000/health')` | Direct to backend |
 | `postgres` | `pg_isready -U admin -d automana` | Database ready probe |
 | `redis` | `redis-cli ping` | Cache ready probe |
-| `proxy` | `wget -qO- --no-check-certificate https://localhost/health` | Reverse proxy ready; uses wget (curl not available) |
+| `proxy` | `wget -qO- --no-check-certificate https://localhost/health` | Reverse proxy ready; uses wget (curl not available); 5s timeout matches nginx `/health` timeouts |
 | `celery-beat` | `test -f /tmp/celerybeat.pid && kill -0 $(cat /tmp/celerybeat.pid)` | Process alive check |
 | `celery-worker` | `celery -A automana.worker.main:app inspect ping` | Worker responds to inspect |
 | `flower` | `python -c "import urllib.request; urllib.request.urlopen('http://localhost:5555/healthcheck')"` | Flower endpoint |
 
 All services except `schema-spy` have `restart: unless-stopped` configured.
+
+### Nginx proxy timeouts and keepalive
+
+The nginx reverse proxy in `deploy/docker/nginx/nginx.local.conf` has per-location timeout configuration:
+
+| Location | Timeouts | HTTP version | Notes |
+|----------|----------|--------------|-------|
+| `/health` | connect 2s, send 2s, read 2s | 1.1 | Short timeouts prevent cascade failures; matches 5s Docker healthcheck budget |
+| `/api/` | connect 60s, send 60s, read 60s | 1.1 | Long timeouts for API calls and WebSocket upgrades |
+| `/flower/` | connect 60s, send 60s, read 60s | 1.1 | Celery monitoring; supports WebSocket upgrades |
+| `/docs` | (no explicit timeouts) | 1.1 | Inherits nginx defaults; HTTP/1.1 enables upstream keepalive |
+| `/` (catchall) | (no explicit timeouts) | 1.1 | Inherits nginx defaults; HTTP/1.1 enables upstream keepalive |
+
+**Why HTTP/1.1 everywhere:** The `upstream fastapi_backend` block defines `keepalive 32`, which only works with HTTP/1.1. Prior versions defaulted to HTTP/1.0, making the keepalive pool ineffective. Setting `proxy_http_version 1.1` explicitly activates connection pooling for all locations.
+
+**Why `/health` has short timeouts:** The proxy container's Docker healthcheck (5s limit) must complete before timeout. If the backend hiccups and nginx waits the default 60s for a response, the healthcheck fails and the proxy restarts repeatedly, cascading failures. Short timeouts (2s) allow the healthcheck to fail fast and retry.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -36,6 +36,30 @@ Quick in-container check:
 docker exec -it automana-proxy-prod sh -lc "wget -qO- http://backend:8000/health || true"
 ```
 
+## Proxy healthcheck failing / proxy container repeatedly restarting
+
+The nginx proxy container's healthcheck (`wget ... /health`) is timing out or failing.
+
+Likely cause: Backend is slow or temporarily unresponsive. The nginx `/health` location has 2-second proxy timeouts (see `OPERATIONS.md` → "Service healthchecks"). If the backend takes longer, the healthcheck fails, and Docker restarts the proxy.
+
+Checks:
+
+```bash
+# Check proxy healthcheck logs
+docker compose -f deploy/docker-compose.dev.yml logs --tail 50 proxy
+
+# Check backend health directly
+curl http://localhost:8000/health
+
+# Check backend logs for slowness
+docker compose -f deploy/docker-compose.dev.yml logs --tail 100 backend
+```
+
+If the backend is slow:
+- Check database connectivity: `docker compose -f deploy/docker-compose.dev.yml logs --tail 50 postgres`
+- Verify asyncpg pool is initialized correctly (check `src/automana/core/database.py` pool settings)
+- Ensure Redis is healthy: `docker compose -f deploy/docker-compose.dev.yml logs --tail 50 redis`
+
 ## HTTPS issues / browser warnings
 
 Your default certs are mounted from `config/nginx/certs/` and may be self-signed.
@@ -62,6 +86,22 @@ Ensure `DATABASE_URL` (in `config/env/.env.prod`) uses `postgres` as host:
 
 - ✅ `...@postgres:5432/...`
 - ❌ `...@localhost:5432/...`
+
+## InterfaceError during long-running batch operations (e.g., bulk_load)
+
+Error: `InterfaceError: connection has been released back to the pool`
+
+Likely cause: The database connection was silently closed by the OS TCP stack during a long idle window (e.g., 30-50s of CPU-heavy batch processing with no DB activity).
+
+This is prevented by TCP keepalive settings configured in `src/automana/core/database.py`:
+- `tcp_keepalives_idle`: 60s before first probe
+- `tcp_keepalives_interval`: 10s between probes
+- `tcp_keepalives_count`: 5 probes before giving up
+
+If you still see this error:
+- Ensure the asyncpg pool is reinitialized (pool is created once at app startup via `init_async_pool()`)
+- Check that `max_inactive_connection_lifetime=3600` is set in the pool config
+- Verify the backend container is not being restarted mid-operation
 
 ## Postgres init scripts did not run
 


### PR DESCRIPTION
# Summary

Syncs documentation with three recent backend changes: nginx proxy timeout hardening, asyncpg TCP keepalive configuration, and the two-tier card search feature. All additions are grounded in the actual code — no speculative content.

---

# Changes Introduced

- **docs/API.md** — Added `/card-reference/suggest` endpoint (typo-tolerant autocomplete, pg_trgm, 10 min cache). Updated `/card-reference/` search to document `oracle_text`, `format` params and 60 min Redis cache.
- **docs/ARCHITECTURE.md** — New "Caching" section: Redis TTLs, SHA256 key strategy, pipeline-driven invalidation after bulk card imports.
- **docs/DEPLOYMENT.md** — Expanded nginx section: per-location proxy settings table (HTTP/1.1, timeouts), security headers (HSTS, X-Frame-Options, CSP, etc.).
- **docs/OPERATIONS.md** — New asyncpg pool settings table; TCP keepalive rationale for long-running batch ops; nginx keepalive/timeout explanation table.
- **docs/TROUBLESHOOTING.md** — Two new sections: proxy healthcheck cascade failures (nginx 2s timeout rationale) and `InterfaceError` on long-running batch operations (TCP keepalive fix).

---

# Acceptance Checklist
- [ ] Code compiles without errors
- [ ] All tests pass (if applicable)
- [x] Documentation updated
- [ ] Added/updated unit tests
- [x] No debug logs left behind
- [x] Follows project coding standards
- [x] Ready for review