### PR TITLE
fix(auth): resolve three login/session blockers

### DIFF
--- a/src/automana/api/services/auth/auth_service.py
+++ b/src/automana/api/services/auth/auth_service.py
@@ -127,7 +127,9 @@ async def login( user_repository: UserRepository
             "session_creation",
             extra={"action": "login", "username": username, "result": "create_session"},
         )
-        session_id, refresh_token = await create_new_session(session_repository, user, ip_address, user_agent, expire_time)
+        new_session = await create_new_session(session_repository, user, ip_address, user_agent, expire_time)
+        session_id = new_session["session_id"]
+        refresh_token = new_session["refresh_token"]
     # Create access token
     token_data = {
         "sub": user.username,
@@ -136,7 +138,7 @@ async def login( user_repository: UserRepository
     # Create JWT token with settings from configuration
     access_token = create_access_token(
         data=token_data,
-        secret_key=settings.secret_key,
+        secret_key=settings.jwt_secret_key,
         algorithm=settings.encrypt_algorithm,
         expires_delta=access_token_expires
     )

--- a/src/automana/api/services/auth/session_service.py
+++ b/src/automana/api/services/auth/session_service.py
@@ -41,6 +41,10 @@ async def validate_session_credentials(
         raise session_exceptions.SessionExpiredError(f"Session {session_id} is expired")
     return session
 
+@ServiceRegistry.register(
+    "auth.session.get_user_from_session",
+    db_repositories=["session", "user"],
+)
 async def get_user_from_session(
     session_repository,
     user_repository,
@@ -117,7 +121,7 @@ async def rotate_session_token(session_repository: SessionRepository
         settings = get_general_settings()
         refresh_token = create_access_token(data={"session_id": str(session_id)}
                                             , expires_delta=timedelta(days=7)
-                                            , secret_key=settings.secret_key
+                                            , secret_key=settings.jwt_secret_key
                                             , algorithm=settings.encrypt_algorithm
                                             )
         await session_repository.rotate_token(token_id
@@ -130,7 +134,7 @@ async def create_new_session(session_repository: SessionRepository, user: UserIn
     session_id = uuid4()
     settings = get_general_settings()
     logger.info(f"Creating new session for user {user.username} with ID {session_id} at IP {ip_address} and user agent {user_agent}")
-    refresh_token = create_access_token(data={"session_id": str(session_id)}, secret_key=settings.secret_key, algorithm=settings.encrypt_algorithm, expires_delta=timedelta(days=7))
+    refresh_token = create_access_token(data={"session_id": str(session_id)}, secret_key=settings.jwt_secret_key, algorithm=settings.encrypt_algorithm, expires_delta=timedelta(days=7))
     new_session = CreateSession(
         session_id=session_id,
         user_id=user.unique_id,

--- a/tests/unit/api/services/auth/test_auth_service.py
+++ b/tests/unit/api/services/auth/test_auth_service.py
@@ -1,0 +1,165 @@
+"""
+Tests for automana.api.services.auth.auth_service
+
+Bug 1 — login calls create_access_token with settings.secret_key (missing attribute);
+         the correct field is settings.jwt_secret_key.
+Bug 3 — login unpacks create_new_session's dict by iterating keys, not values:
+         `session_id, refresh_token = await create_new_session(...)`
+         iterates {'session_id': <uuid>, 'refresh_token': <str>} and assigns
+         the key *names* ('session_id', 'refresh_token') to the variables
+         instead of the actual UUID and token string.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+from automana.api.services.auth.auth_service import login
+from automana.api.services.auth.auth import decode_access_token
+from automana.api.schemas.user_management.user import UserInDB
+
+pytestmark = pytest.mark.unit
+
+_JWT_SECRET = "test-jwt-secret-unit"
+_ALGO = "HS256"
+
+
+class _StrictSettings:
+    """Has jwt_secret_key but no secret_key — any access to secret_key raises AttributeError."""
+    jwt_secret_key = _JWT_SECRET
+    jwt_algorithm = _ALGO
+    encrypt_algorithm = _ALGO
+    access_token_expiry = 30
+
+
+def _make_user(username: str = "alice") -> MagicMock:
+    user = MagicMock(spec=UserInDB)
+    user.unique_id = uuid4()
+    user.username = username
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — login correctly unpacks dict values (not dict keys)
+# ---------------------------------------------------------------------------
+
+class TestLoginDictUnpack:
+    async def test_session_id_in_result_is_uuid_string_not_dict_key(
+        self, monkeypatch, mock_session_repository, mock_user_repository
+    ):
+        """login() must read session_id from the dict VALUE returned by create_new_session.
+
+        Before fix: session_id = 'session_id' (the string key name).
+        After fix:  session_id = str(known_uuid).
+        """
+        known_uuid = uuid4()
+        known_token = "actual-refresh-token-value"
+
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.get_general_settings",
+            lambda: _StrictSettings(),
+        )
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.create_new_session",
+            AsyncMock(return_value={"session_id": known_uuid, "refresh_token": known_token}),
+        )
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.authenticate_user",
+            AsyncMock(return_value=_make_user()),
+        )
+        mock_session_repository.get_by_user_id = AsyncMock(return_value=[])
+
+        result = await login(
+            user_repository=mock_user_repository,
+            session_repository=mock_session_repository,
+            username="alice",
+            password="any",
+            ip_address="127.0.0.1",
+            user_agent="pytest",
+        )
+
+        assert result.get("session_id") == str(known_uuid), (
+            f"Expected '{known_uuid}', got '{result.get('session_id')}' — "
+            "dict keys were iterated instead of values"
+        )
+
+    async def test_refresh_token_in_result_is_token_value_not_dict_key(
+        self, monkeypatch, mock_session_repository, mock_user_repository
+    ):
+        """login() must read refresh_token from the dict VALUE, not the key name.
+
+        Before fix: refresh_token = 'refresh_token' (the string key name).
+        After fix:  refresh_token = 'actual-refresh-token-value'.
+        """
+        known_uuid = uuid4()
+        known_token = "actual-refresh-token-value"
+
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.get_general_settings",
+            lambda: _StrictSettings(),
+        )
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.create_new_session",
+            AsyncMock(return_value={"session_id": known_uuid, "refresh_token": known_token}),
+        )
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.authenticate_user",
+            AsyncMock(return_value=_make_user()),
+        )
+        mock_session_repository.get_by_user_id = AsyncMock(return_value=[])
+
+        result = await login(
+            user_repository=mock_user_repository,
+            session_repository=mock_session_repository,
+            username="alice",
+            password="any",
+            ip_address="127.0.0.1",
+            user_agent="pytest",
+        )
+
+        assert result.get("refresh_token") == known_token, (
+            f"Expected '{known_token}', got '{result.get('refresh_token')}' — "
+            "dict keys were iterated instead of values"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — login access token signed with jwt_secret_key
+# ---------------------------------------------------------------------------
+
+class TestLoginAccessTokenSigning:
+    async def test_access_token_decodable_with_jwt_secret_key(
+        self, monkeypatch, mock_session_repository, mock_user_repository
+    ):
+        """login() must pass settings.jwt_secret_key to create_access_token.
+
+        Before fix: settings.secret_key raises AttributeError (field missing on Settings).
+        After fix:  access_token is present and decodable with jwt_secret_key.
+        """
+        known_uuid = uuid4()
+
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.get_general_settings",
+            lambda: _StrictSettings(),
+        )
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.create_new_session",
+            AsyncMock(return_value={"session_id": known_uuid, "refresh_token": "rt"}),
+        )
+        monkeypatch.setattr(
+            "automana.api.services.auth.auth_service.authenticate_user",
+            AsyncMock(return_value=_make_user("alice")),
+        )
+        mock_session_repository.get_by_user_id = AsyncMock(return_value=[])
+
+        result = await login(
+            user_repository=mock_user_repository,
+            session_repository=mock_session_repository,
+            username="alice",
+            password="any",
+            ip_address="127.0.0.1",
+            user_agent="pytest",
+        )
+
+        assert "access_token" in result, f"Expected access_token in result, got: {result}"
+        decoded = decode_access_token(result["access_token"], _JWT_SECRET, _ALGO)
+        assert decoded["sub"] == "alice"

--- a/tests/unit/api/services/auth/test_session_service.py
+++ b/tests/unit/api/services/auth/test_session_service.py
@@ -1,0 +1,123 @@
+"""
+Tests for automana.api.services.auth.session_service
+
+Bug 1 — create_new_session and rotate_session_token access settings.secret_key
+         (attribute does not exist on Settings); correct field is jwt_secret_key.
+Bug 2 — get_user_from_session is never registered with @ServiceRegistry.register,
+         so every cookie-authenticated endpoint raises a service-not-found error.
+"""
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+from datetime import datetime, timezone, timedelta
+
+from automana.api.services.auth.session_service import create_new_session, rotate_session_token
+from automana.api.services.auth.auth import decode_access_token
+from automana.api.schemas.user_management.user import UserInDB
+from automana.core.service_registry import ServiceRegistry
+
+pytestmark = pytest.mark.unit
+
+_JWT_SECRET = "test-jwt-secret-unit"
+_ALGO = "HS256"
+
+
+class _StrictSettings:
+    """Settings substitute with jwt_secret_key but deliberately no secret_key.
+
+    If any code path accesses settings.secret_key it will raise AttributeError,
+    proving it uses the wrong field.
+    """
+    jwt_secret_key = _JWT_SECRET
+    encrypt_algorithm = _ALGO
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — service registration
+# ---------------------------------------------------------------------------
+
+class TestGetUserFromSessionRegistration:
+    def test_is_registered_in_service_registry(self):
+        import automana.api.services.auth.session_service  # noqa: F401 — trigger decorator
+        config = ServiceRegistry.get("auth.session.get_user_from_session")
+        assert config is not None, (
+            "get_user_from_session must be decorated with "
+            "@ServiceRegistry.register('auth.session.get_user_from_session')"
+        )
+
+    def test_registration_declares_session_and_user_repositories(self):
+        import automana.api.services.auth.session_service  # noqa: F401
+        config = ServiceRegistry.get("auth.session.get_user_from_session")
+        assert config is not None
+        assert "session" in config.db_repositories
+        assert "user" in config.db_repositories
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — create_new_session uses jwt_secret_key
+# ---------------------------------------------------------------------------
+
+class TestCreateNewSessionTokenSigning:
+    async def test_refresh_token_decodable_with_jwt_secret_key(
+        self, monkeypatch, mock_session_repository
+    ):
+        """create_new_session must sign the refresh token with settings.jwt_secret_key.
+
+        Before fix: settings.secret_key raises AttributeError (field missing).
+        After fix:  token is signed with jwt_secret_key and is decodable.
+        """
+        monkeypatch.setattr(
+            "automana.api.services.auth.session_service.get_general_settings",
+            lambda: _StrictSettings(),
+        )
+        session_uuid = uuid4()
+        mock_session_repository.add = AsyncMock(return_value=None)
+        mock_session_repository.get = AsyncMock(
+            return_value=[{"session_id": session_uuid, "refresh_token": "db-placeholder"}]
+        )
+
+        user = MagicMock(spec=UserInDB)
+        user.unique_id = uuid4()
+        user.username = "alice"
+
+        result = await create_new_session(
+            mock_session_repository,
+            user,
+            "10.0.0.1",
+            "pytest-agent/1.0",
+            datetime.now(timezone.utc) + timedelta(days=7),
+        )
+
+        decoded = decode_access_token(result["refresh_token"], _JWT_SECRET, _ALGO)
+        assert "session_id" in decoded
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — rotate_session_token uses jwt_secret_key
+# ---------------------------------------------------------------------------
+
+class TestRotateSessionTokenSigning:
+    async def test_rotated_token_decodable_with_jwt_secret_key(
+        self, monkeypatch, mock_session_repository
+    ):
+        """rotate_session_token must sign the new refresh token with settings.jwt_secret_key.
+
+        Before fix: settings.secret_key raises AttributeError.
+        After fix:  token is decodable with jwt_secret_key.
+        """
+        monkeypatch.setattr(
+            "automana.api.services.auth.session_service.get_general_settings",
+            lambda: _StrictSettings(),
+        )
+        mock_session_repository.rotate_token = AsyncMock(return_value=None)
+
+        result = await rotate_session_token(
+            mock_session_repository,
+            session_id=uuid4(),
+            refresh_token="old-token",
+            expire_time=datetime.now(timezone.utc) + timedelta(days=7),
+            token_id=uuid4(),
+        )
+
+        decoded = decode_access_token(result["refresh_token"], _JWT_SECRET, _ALGO)
+        assert "session_id" in decoded


### PR DESCRIPTION
## Summary

- **Bug 1** — `settings.secret_key` does not exist on `Settings`; replaced with `settings.jwt_secret_key` in `auth_service.login`, `session_service.create_new_session`, and `session_service.rotate_session_token`. Login crashed with `AttributeError` after bcrypt passed.
- **Bug 2** — `get_user_from_session` was never decorated with `@ServiceRegistry.register`, so every cookie-authenticated endpoint (`/me`, collections, etc.) raised a service-not-found error. Added the decorator with `db_repositories=["session", "user"]`.
- **Bug 3** — `auth_service.login` unpacked `create_new_session`'s return dict by iterating it (`session_id, refresh_token = await create_new_session(...)`), which yields key names (`"session_id"`, `"refresh_token"`) instead of values. Fixed to unpack by key access.

## Test plan

- [x] 7 new unit tests added (TDD: red → fix → green), all passing with no regressions (370 unit tests green)
- [x] Manual flow: `POST /api/users/users/` → `POST /api/users/auth/token` → `GET /api/users/users/me` with session cookie → `POST /api/users/auth/logout`

```bash
curl -i -X POST http://localhost:8000/api/users/users/ \
  -H "Content-Type: application/json" \
  -d '{"username":"testuser","email":"testuser@example.com","fullname":"Test User","password":"TestPass123!"}'

curl -i -c cookies.txt -X POST http://localhost:8000/api/users/auth/token \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "username=testuser&password=TestPass123!"

curl -i -b cookies.txt http://localhost:8000/api/users/users/me
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)