### PR TITLE
fix(card_catalog): narrow external_id_value_collision metric to per-printing-unique identifiers

### DIFF
--- a/docs/HEALTH_METRICS.md
+++ b/docs/HEALTH_METRICS.md
@@ -26,13 +26,13 @@ Source: `src/automana/core/metrics/card_catalog/`. Backed by `CardReferenceRepos
 | Path | Category | Severity | What it catches |
 |---|---|---|---|
 | `card_catalog.identifier_coverage.scryfall_id` | health | `≤99% → WARN`, `≤95% → ERROR` | The 113k-orphan incident — silent JOIN failures when `card_identifier_ref` is empty or a name is misspelled. Headline metric. |
-| `card_catalog.identifier_coverage.oracle_id` | health | `≤99% → WARN`, `≤95% → ERROR` | Bulk identifier backfill stalled mid-run. **Measured against `unique_cards_ref`, not `card_version`** — `oracle_id` is per-abstract-card (one value shared across all printings; the schema's `UNIQUE (ref_id, value)` constraint enforces this). Per-printing measurement would under-report by the average reprint rate (~3x). |
+| `card_catalog.identifier_coverage.oracle_id` | health | `≤99% → WARN`, `≤95% → ERROR` | Bulk identifier backfill stalled mid-run. **Measured against `unique_cards_ref`, not `card_version`** — `oracle_id` is per-abstract-card (one value shared across all printings of the same MTG card). Per-printing measurement would under-report by the average reprint rate (~3x). |
 | `card_catalog.identifier_coverage.tcgplayer_id` | health | `≤80% → WARN`, `≤60% → ERROR` | TCGPlayer mapping pipeline failure. Lower threshold reflects that regional/promo cards may legitimately lack a TCGPlayer ID. |
 | `card_catalog.identifier_coverage.cardmarket_id` | health | `≤70% → WARN`, `≤50% → ERROR` | Same as above, even lower threshold reflecting Cardmarket's narrower regional coverage. |
 | `card_catalog.identifier_coverage.multiverse_id` | volume | none (informational) | Tracks the count of a deprecated identifier — no pass/fail, just drift detection. |
 | `card_catalog.identifier_coverage.tcgplayer_etched_id` | volume | none (informational) | Etched-printing count; expected to be a tiny subset. |
 | `card_catalog.print_coverage.orphan_unique_cards` | health | `≥5 → WARN`, `≥50 → ERROR` | `unique_cards_ref` rows with zero `card_version` children. Small counts are benign (tokens/emblems); large counts mean a set ingest stalled. |
-| `card_catalog.duplicate_detection.external_id_value_collision` | health | `≥1 → ERROR` | The UNIQUE constraint on `(card_identifier_ref_id, value)` should make this 0. Any non-zero count = constraint bypass or replication desync. |
+| `card_catalog.duplicate_detection.external_id_value_collision` | health | `≥1 → ERROR` | Count of `(card_identifier_ref_id, value)` pairs shared by more than one `card_version_id` **for per-printing-unique identifiers only** (`scryfall_id`, `multiverse_id`, `tcgplayer_etched_id`, `mtgjson_id`). `oracle_id`, `tcgplayer_id`, and `cardmarket_id` are excluded — they legitimately share values across multiple card_version rows. Any non-zero count = ingest duplicate or upstream data error. |
 
 `details` for coverage metrics carries `{identifier_name, covered, total}` so the operator can see the raw counts behind the percentage.
 
@@ -116,7 +116,7 @@ automana-run ops.audit.scryfall_identifier_coverage --raw_file_path /data/automa
 
 Each row's `details` reports:
 
-- `classification` — `per-printing` (1:1 ratio of refs to distinct values), `per-printing-with-collisions` (mild ~1.0x–1.5x), or `per-abstract-card` (≥1.5x — the value is shared across multiple printings and the schema's `UNIQUE (ref_id, value)` will silently drop reprints via `ON CONFLICT DO NOTHING`).
+- `classification` — `per-printing` (1:1 ratio of refs to distinct values), `per-printing-with-collisions` (mild ~1.0x–1.5x), or `per-abstract-card` (≥1.5x — the value is shared across multiple printings; `tcgplayer_id`/`cardmarket_id` fall here intentionally).
 - `source_pct` / `stored_pct` / `gap_pct` — what fraction of the universe has this identifier in the file vs in the DB. Severity is `OK` if `gap_pct < 1`, `WARN` ≥ 1, `ERROR` ≥ 5.
 - The denominator on the DB side switches by classification: per-abstract-card identifiers measure against `unique_cards_ref`; per-printing identifiers measure against `card_version`. Same semantics as the corresponding `identifier_coverage.*` metric, so an audit row should match its metric's value within rounding.
 
@@ -138,7 +138,7 @@ multiverse_id          per-printing             OK  61.12    61.12  0.00        
 tcgplayer_etched_id    per-printing             OK   1.08     1.07  0.01         1220       1.00
 ```
 
-The two WARNs reflect ~1% of `tcgplayer_id` and `cardmarket_id` values that are shared across multiple printings (typically foil/non-foil pairs of the same printing) and silently absorbed by `ON CONFLICT DO NOTHING` in `card_catalog.insert_full_card_version`. Whether this is acceptable or worth a schema change is a separate question; the audit just surfaces it.
+The two WARNs reflect ~1% of `tcgplayer_id` and `cardmarket_id` values that are shared across multiple printings (typically foil/non-foil pairs of the same physical product). This is the expected post-fix state — the `UNIQUE (card_identifier_ref_id, value)` constraint was intentionally dropped so both card_version rows can own their external_identifier row for the shared product ID. The WARN gap will resolve to ~0 once the Scryfall pipeline runs against the updated schema (the previously-dropped second printing row will now be inserted).
 
 The audit is registered under the `ops.audit.*` namespace, **not** `ops.integrity.*`, so the `pipeline-health-check` skill does not auto-discover it. This is intentional — it's a heavy I/O operation (~5s for a 512MB raw file) meant for on-demand investigation.
 

--- a/src/automana/core/metrics/card_catalog/catalog_metrics.py
+++ b/src/automana/core/metrics/card_catalog/catalog_metrics.py
@@ -20,7 +20,13 @@ async def orphan_unique_cards(card_repository: CardReferenceRepository) -> Metri
 @MetricRegistry.register(
     path="card_catalog.duplicate_detection.external_id_value_collision",
     category="health",
-    description="Count of (card_identifier_ref_id, value) tuples appearing more than once (UNIQUE-constraint guard).",
+    description=(
+        "Count of (card_identifier_ref_id, value) pairs shared by more than one card_version_id "
+        "for identifiers that Scryfall/upstream guarantees are per-printing unique "
+        "(scryfall_id, multiverse_id, tcgplayer_etched_id, mtgjson_id). "
+        "tcgplayer_id, cardmarket_id, and oracle_id are excluded — they intentionally "
+        "share values across multiple card_version rows."
+    ),
     severity=Threshold(warn=1, error=1, direction="higher_is_worse"),
     db_repositories=["card"],
 )

--- a/src/automana/core/metrics/card_catalog/identifier_metrics.py
+++ b/src/automana/core/metrics/card_catalog/identifier_metrics.py
@@ -70,10 +70,11 @@ async def scryfall_id_coverage(card_repository: CardReferenceRepository) -> Metr
     db_repositories=["card"],
 )
 async def oracle_id_coverage(card_repository: CardReferenceRepository) -> MetricResult:
-    # oracle_id is per-abstract-card: the schema's UNIQUE (ref_id, value)
-    # constraint guarantees one row per oracle_id value, so per-card_version
-    # counting under-reports by the reprint rate. Measure against
-    # unique_cards_ref instead.
+    # oracle_id is per-abstract-card: one value is shared across every printing
+    # of the same MTG card. Measuring coverage per card_version would under-report
+    # by the average reprint rate (~3x). Measuring against unique_cards_ref instead
+    # correctly asks "does every abstract card have at least one printing with an
+    # oracle_id?" — which is the meaningful question.
     return await _coverage_by_unique_card(card_repository, "oracle_id")
 
 

--- a/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
+++ b/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
@@ -22,13 +22,6 @@ class PriceRepository(AbstractRepository):
         except Exception as e:
             logger.error("Error rolling back transaction: %s", e)
 
-    async def clear_raw_prices(self) -> int:
-        rows = await self.execute_query(
-            "WITH del AS (DELETE FROM pricing.raw_mtg_stock_price RETURNING 1) "
-            "SELECT count(*)::int AS n FROM del"
-        )
-        return rows[0]["n"] if rows else 0
-
     async def _copy_to_table(self, df, schema_name, table_name, timeout: float = 300):
         buf = io.BytesIO()
         df.to_csv(buf, index=False, header=True, encoding='utf-8')
@@ -97,19 +90,6 @@ class PriceRepository(AbstractRepository):
                 await self.connection.remove_listener('staging_log', _on_notify)
             except Exception:
                 pass
-
-    async def fetch_all_prices(self, schema_name, table_name):
-        """
-        Fetch all rows from the staging table for verification.
-        """
-        fetch_query = f"SELECT COUNT(*) FROM {schema_name}.{table_name};"
-        try:
-            count = await self.execute_query(fetch_query)
-            logger.info(f"Fetched {count} rows from {schema_name}.{table_name}.")
-            return count
-        except Exception as e:
-            logger.error(f"Error fetching data from {schema_name}.{table_name}: {e}")
-            return 0
 
     async def copy_prices(self, df):
         await self._copy_to_table(df, "pricing", "shopify_staging_raw")

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -330,9 +330,12 @@ class CardReferenceRepository(AbstractRepository[Any]):
         value: str,
     ) -> "CardReferenceRepository.ExternalIdentifierRegistration":
         """Idempotently register one (card_version, identifier_name, value) row via a single-CTE round-trip."""
-        # ON CONFLICT targets the PK only. A UNIQUE (ref_id, value) collision
-        # against a different card_version_id will raise — external IDs like
-        # scryfall_id are globally unique per card_version by design.
+        # ON CONFLICT targets the PK only. There is no UNIQUE (ref_id, value)
+        # constraint — it was intentionally dropped so that shared identifiers
+        # like tcgplayer_id and cardmarket_id can be owned by multiple
+        # card_version rows (foil/non-foil pairs of the same physical product).
+        # A duplicate (card_version_id, ref_id) row is silently absorbed; any
+        # other combination inserts a new row, which is the correct behaviour.
         query = """
             WITH ref AS (
                 SELECT card_identifier_ref_id
@@ -496,10 +499,12 @@ class CardReferenceRepository(AbstractRepository[Any]):
 
         Use this for identifiers that are a property of the *abstract card* (one
         value per ``unique_card_id``) rather than per-printing — most notably
-        ``oracle_id``. The schema's ``UNIQUE (card_identifier_ref_id, value)``
-        constraint causes per-printing counting to under-report by the average
-        reprint rate (~3x for oracle_id), making the per-card_version metric
-        meaningless for these identifiers.
+        ``oracle_id``. Because ``oracle_id`` is shared across every printing of
+        the same abstract card, counting rows per ``card_version`` would
+        under-report coverage by the average reprint rate (~3x for oracle_id),
+        making the per-``card_version`` metric misleading for these identifiers.
+        Note: the ``UNIQUE (card_identifier_ref_id, value)`` constraint no longer
+        exists; multiple ``card_version`` rows can legally share one oracle_id value.
 
         Returns the same shape as :meth:`fetch_identifier_coverage_pct`:
         ``{'covered': int, 'total': int, 'pct': float|None}``. ``covered`` is
@@ -601,18 +606,34 @@ class CardReferenceRepository(AbstractRepository[Any]):
         return rows[0]["n"] if rows else 0
 
     async def fetch_external_id_value_collisions(self) -> int:
-        """COUNT of (card_identifier_ref_id, value) tuples appearing more than once.
+        """COUNT of (card_identifier_ref_id, value) tuples shared by more than one
+        card_version_id for identifiers that upstream guarantees are per-printing unique.
 
-        The table has a UNIQUE constraint on (card_identifier_ref_id, value);
-        any non-zero count indicates constraint bypass or replication desync.
+        The ``UNIQUE (card_identifier_ref_id, value)`` constraint was dropped intentionally
+        to allow tcgplayer_id and cardmarket_id to be shared by foil/non-foil pairs of the
+        same physical product.  However, identifiers that upstream guarantees are strictly
+        one-per-printing — ``scryfall_id``, ``multiverse_id``, ``tcgplayer_etched_id``, and
+        ``mtgjson_id`` — should never collide.  Any non-zero count here indicates a real bug:
+        either a duplicate ingest, a pipeline retry that produced duplicate rows, or an
+        upstream data error that slipped past validation.
+
+        Identifiers intentionally excluded (expected multi-card_version sharing):
+        - oracle_id      — one value per abstract card, shared across all printings
+        - tcgplayer_id   — one product per physical SKU; foil/non-foil pairs share
+        - cardmarket_id  — same sharing pattern as tcgplayer_id
         """
         query = """
         SELECT COUNT(*)::int AS n
         FROM (
-            SELECT card_identifier_ref_id, value
-            FROM card_catalog.card_external_identifier
-            GROUP BY card_identifier_ref_id, value
-            HAVING COUNT(*) > 1
+            SELECT cei.card_identifier_ref_id, cei.value
+            FROM card_catalog.card_external_identifier cei
+            JOIN card_catalog.card_identifier_ref cir
+              ON cir.card_identifier_ref_id = cei.card_identifier_ref_id
+            WHERE cir.identifier_name IN (
+                'scryfall_id', 'multiverse_id', 'tcgplayer_etched_id', 'mtgjson_id'
+            )
+            GROUP BY cei.card_identifier_ref_id, cei.value
+            HAVING COUNT(DISTINCT cei.card_version_id) > 1
         ) dup
         """
         rows = await self.execute_query(query, ())

--- a/src/automana/core/repositories/ops/ops_repository.py
+++ b/src/automana/core/repositories/ops/ops_repository.py
@@ -1,6 +1,9 @@
 ﻿import json
+import logging
 from datetime import date as date_type
 from automana.core.repositories.abstract_repositories.AbstractDBRepository import AbstractRepository
+
+logger = logging.getLogger(__name__)
 from automana.core.repositories.ops.scryfall_data import update_bulk_scryfall_data_sql
 from automana.core.repositories.ops.integrity_check_sql import (
     scryfall_run_diff_sql,
@@ -45,8 +48,7 @@ class OpsRepository(AbstractRepository):
             query,
             batch_step.to_tuple()
         )
-    #beed to include the ressource upsert as well
-    async def start_run(self, 
+    async def start_run(self,
                         pipeline_name: str,
                           source_name: str,
                           run_key: str,
@@ -313,7 +315,7 @@ class OpsRepository(AbstractRepository):
             update_bulk_scryfall_data_sql,
             (json.dumps(items), ingestion_run_id)#source_id
         )
-        print("update_bulk_data_uri_return_new result:", result)
+        logger.debug("update_bulk_data_uri_return_new result: %s", result)
         record = result[0] if result and len(result) > 0 else None
         ressources_upserted = record.get("resources_upserted") if record else 0
         versions_inserted = record.get("versions_inserted") if record else 0


### PR DESCRIPTION
# Summary

The `card_catalog.duplicate_detection.external_id_value_collision` health metric was permanently firing ERROR on 23,073 rows that are intentional by design. The `UNIQUE (card_identifier_ref_id, value)` constraint on `card_external_identifier` was dropped in a recent schema change so that foil/non-foil pairs of the same physical product can both own their row for a shared `tcgplayer_id` or `cardmarket_id`. The metric was never updated to match — it kept querying for *any* `(ref_id, value)` pair appearing more than once, flagging all of those legitimate rows as errors.

This PR narrows the collision query to the four identifiers that upstream guarantees are strictly one-per-printing (`scryfall_id`, `multiverse_id`, `tcgplayer_etched_id`, `mtgjson_id`), excludes the intentionally-shared ones (`oracle_id`, `tcgplayer_id`, `cardmarket_id`), and uses `COUNT(DISTINCT card_version_id) > 1` so the guard asks the right question.

---

# Changes Introduced

- `card_repository.py` — Rewrote `fetch_external_id_value_collisions` SQL to join through `card_identifier_ref`, filter to per-printing-unique identifier names, and use `COUNT(DISTINCT card_version_id) > 1`
- `card_repository.py` — Removed stale UNIQUE-constraint claims from `register_external_identifier` comment and `fetch_identifier_coverage_pct_by_unique_card` docstring
- `catalog_metrics.py` — Updated metric description to enumerate checked vs excluded identifiers
- `identifier_metrics.py` — Fixed `oracle_id_coverage` comment (semantic reason, not constraint-based)
- `docs/HEALTH_METRICS.md` — Updated metric table row, audit classification description, and WARN explanation
- `price_repository.py` — Removed unused `clear_raw_prices` and `fetch_all_prices` dead code
- `ops_repository.py` — Replaced bare `print()` with `logger.debug()` per project logging conventions

---

# How to Test

Run the `card_catalog.duplicate_detection.external_id_value_collision` metric against the dev DB — it should return 0 (no collisions among `scryfall_id`, `multiverse_id`, `tcgplayer_etched_id`, `mtgjson_id`).

```bash
automana-run ops.health --metric card_catalog.duplicate_detection.external_id_value_collision
```

---

# Acceptance Checklist
- [ ] Code compiles without errors
- [ ] All tests pass (if applicable)
- [ ] Documentation updated
- [ ] No debug logs left behind
- [ ] Follows project coding standards
- [ ] Ready for review

---

# Additional Notes

`src/automana/database/SQL/maintenance/scryfall_integrity_checks.sql` (lines 33 and 418–419) still has two comment-only references to the dropped UNIQUE constraint. No runtime impact — flagged for a separate cleanup pass.