### PR TITLE
fix(tui): await remove_children() before mounting param widgets

### DIFF
--- a/src/automana/tools/tui/panels/api.py
+++ b/src/automana/tools/tui/panels/api.py
@@ -152,7 +152,7 @@ class ApiPanel(Vertical):
         tree.root.expand()
         viewer.show_info(f"Loaded {sum(len(v) for v in groups.values())} endpoints.")
 
-    def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
+    async def on_tree_node_selected(self, event: Tree.NodeSelected) -> None:
         node: TreeNode = event.node
         if not node.data:
             return
@@ -170,7 +170,7 @@ class ApiPanel(Vertical):
 
         # Rebuild param inputs
         params_area: Vertical = self.query_one("#params-area", Vertical)
-        params_area.remove_children()
+        await params_area.remove_children()
         self._param_names = []
 
         parameters = operation.get("parameters", [])


### PR DESCRIPTION
Textual's remove_children() returns an AwaitRemove coroutine; calling it without await only schedules the removal, so old widgets are still present when new ones with the same IDs are mounted. Switching routes triggered DuplicateIds on apiparam___body__ (and potentially any other param shared between consecutive routes).

Made on_tree_node_selected async and awaited the removal so the params-area is clean before new inputs are added.

#  Summary
Provide a short summary of the changes in this PR.
Example: "Implemented the pricing ingestion pipeline and added TimescaleDB schema."

---

#  Related Issues
Closes #ISSUE_NUMBER  
(Related to #ISSUE_NUMBER)

---

# Changes Introduced
- 
- 
- 

---

# How to Test
Describe how reviewers can test the changes locally.

Example:
1. Run `docker-compose up`
2. Call `/pricing/update`
3. Verify data is inserted into the pricing table

---

#  Acceptance Checklist
- [ ] Code compiles without errors
- [ ] All tests pass (if applicable)
- [ ] Documentation updated
- [ ] Added/updated unit tests
- [ ] No debug logs left behind
- [ ] Follows project coding standards
- [ ] Ready for review

---

#  Screenshots (if applicable)
Include screenshots or videos if the PR changes UI or workflows.

---

#  Additional Notes
Anything else reviewers should know?
