### PR TITLE
fix(pricing): remove hardcoded 300 s timeout from _copy_to_table

### DIFF
--- a/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
+++ b/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
@@ -22,17 +22,21 @@ class PriceRepository(AbstractRepository):
         except Exception as e:
             logger.error("Error rolling back transaction", extra={"error": str(e)})
 
-    async def _copy_to_table(self, df, schema_name, table_name, timeout: float = 300):
+    async def _copy_to_table(self, df, schema_name, table_name):
         buf = io.BytesIO()
         df.to_csv(buf, index=False, header=True, encoding='utf-8')
         buf.seek(0)
+        # No explicit timeout: inherits conn._config.command_timeout, which
+        # ServiceManager overrides per-service (3 600 s for bulk_load).
+        # A hardcoded 300 s ceiling fires before large historical-price batches
+        # finish, leaves PostgreSQL in COPY-IN mode, and breaks the connection.
         await self.connection.copy_to_table(
             table_name=table_name,
             schema_name=schema_name,
             source=buf,
             format='csv',
             header=True,
-            timeout=timeout)
+        )
 
     async def call_load_stage_from_raw(
         self, source_name: str = "mtgstocks", batch_days: int = 30,


### PR DESCRIPTION
## Summary

`_copy_to_table` passed an explicit `timeout=300` to asyncpg's `copy_to_table`, which overrode the service-manager-configured `command_timeout=3600` that `bulk_load` registers for exactly this reason. Large historical-price batches (5 000 folders × years of daily rows) routinely exceed 5 minutes. When the timeout fired, asyncpg left PostgreSQL in COPY-IN mode and released the broken connection back to the pool. The subsequent `ops_repository.update_run()` call in `track_step`'s except handler then raised `InterfaceError: connection was released back to the pool`, masking the original timeout and stalling the pipeline at ~78% completion on every run.

Removing the explicit `timeout` argument lets the call inherit `conn._config.command_timeout`, which `ServiceManager._execute_service` already patches to 3 600 s for `bulk_load` — no other change required.

---

## Changes Introduced

- `PriceRepository._copy_to_table`: removed `timeout: float = 300` parameter and the `timeout=timeout` kwarg on `connection.copy_to_table()`. Added an inline comment explaining why.

---

## How to Test

1. Ensure MTGStocks parquet data is present at `/data/automana_data/mtgstocks/raw/prints/`
2. Run `mtgStock_download_pipeline` via Celery or `automana-run`
3. Monitor `ops.ingestion_runs` — the `bulk_load` step should progress past 78% and complete with `status='success'`
4. Confirm `pricing.raw_mtg_stock_price` is populated, then `pricing.stg_price_observation`, then `pricing.price_observation`

---

## Acceptance Checklist
- [x] Code compiles without errors
- [x] No debug logs left behind
- [x] Follows project coding standards
- [x] Ready for review

---

## Additional Notes

There is a latent secondary issue: `track_step`'s `except` handler writes failure metadata using the same connection as the service. If any future failure also breaks the connection, the error write will fail and the original exception will be masked by `InterfaceError`. This is a pre-existing design limitation and is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)