### PR TITLE
fix(pricing): disable TimescaleDB decompression limit for bulk staging load

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,28 @@
 
 AutoMana is a FastAPI backend for tracking a Magic: The Gathering collection with integrations for eBay, Shopify, Scryfall, MTGJson, and MTGStock. It uses PostgreSQL (+ TimescaleDB + pgvector) for persistence, Redis for caching/queuing, and Celery for background jobs.
 
+**Requires:** Python >= 3.11, Docker Compose v2.
+
 ## Documentation
 
-- [docs/README.md](docs/README.md) — documentation index
-- [docs/API.md](docs/API.md) — API reference
-- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — architecture and design patterns
-- [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) — Docker Compose, env files, secrets
-- [docs/LOGGING.md](docs/LOGGING.md) — structured logging
-- [docs/SCRYFALL_PIPELINE.md](docs/SCRYFALL_PIPELINE.md) — Scryfall ETL pipeline
-- [docs/MTGJSON_PIPELINE.md](docs/MTGJSON_PIPELINE.md) — MTGJson daily price ingestion pipeline
-- [docs/MTGSTOCK_PIPELINE.md](docs/MTGSTOCK_PIPELINE.md) — MTGStocks price ingestion pipeline
+Full documentation index: [docs/README.md](docs/README.md)
+
+| Doc | Contents |
+|-----|----------|
+| [docs/API.md](docs/API.md) | Endpoint reference, auth model, response envelopes |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | Layer diagram, request flow (HTTP + Celery), module map |
+| [docs/DESIGN_PATTERNS.md](docs/DESIGN_PATTERNS.md) | Every design pattern used, with file locations and rationale |
+| [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Docker Compose (dev/prod), env vars, nginx, TLS, Flower |
+| [docs/LOGGING.md](docs/LOGGING.md) | Structured JSON logging, context vars, conventions |
+| [docs/SCRYFALL_PIPELINE.md](docs/SCRYFALL_PIPELINE.md) | Scryfall ETL pipeline |
+| [docs/MTGJSON_PIPELINE.md](docs/MTGJSON_PIPELINE.md) | MTGJson daily price ingestion pipeline |
+| [docs/MTGSTOCK_PIPELINE.md](docs/MTGSTOCK_PIPELINE.md) | MTGStocks price ingestion pipeline |
+| [docs/METRICS_REGISTRY.md](docs/METRICS_REGISTRY.md) | MetricRegistry and sanity-report runner |
+| [docs/HEALTH_METRICS.md](docs/HEALTH_METRICS.md) | card_catalog and pricing health metrics |
+| [docs/DATABASE_ROLES.md](docs/DATABASE_ROLES.md) | PostgreSQL roles and per-service DB users |
+| [docs/CLI_RUN_SERVICE.md](docs/CLI_RUN_SERVICE.md) | `automana-run` CLI and `automana-tui` terminal UI |
+| [docs/OPERATIONS.md](docs/OPERATIONS.md) | Day-2 runbook: logs, restarts, backup/restore |
+| [docs/TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md) | Common issues and fixes |
 
 ## Quickstart (Docker)
 
@@ -21,31 +33,141 @@ AutoMana is a FastAPI backend for tracking a Magic: The Gathering collection wit
 docker compose -f deploy/docker-compose.dev.yml up -d --build
 ```
 
-- API docs: http://localhost:8000/docs
-- Backend health: http://localhost:8000/health
-- Ports: backend `8000`, postgres `5433`, redis `6379`
+| Service | URL | Notes |
+|---------|-----|-------|
+| API (direct) | http://localhost:8000 | Swagger UI at `/docs` |
+| API (proxy) | https://localhost/api/ | Via nginx, HTTPS |
+| Swagger UI | https://localhost/docs | Via nginx |
+| Health | http://localhost:8000/health | Returns `{"status":"healthy"}` |
+| Flower | https://localhost/flower/ | Celery task monitor; auth from `FLOWER_BASIC_AUTH` |
+| Postgres | localhost:5433 | Host-side access only |
+| Redis | localhost:6379 | Host-side access only |
+
+Ports `80`/`443` on the proxy and `8000` on the backend are published in dev. Containers reach Postgres at `postgres:5432` over the internal Docker network.
 
 ### Prod
 
-Only nginx publishes ports (80/443). Postgres, Redis, and the backend stay internal.
+Only nginx publishes ports (80/443). The backend, Postgres, and Redis are network-internal.
 
 ```bash
 docker compose -f deploy/docker-compose.prod.yml up -d --build
 ```
 
+See [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for TLS cert setup, env var requirements, and the database backup container.
+
+## Dev rebuild (after DB schema changes)
+
+If you need to drop and recreate the dev database while Celery is running, follow the two-phase sequence to avoid stale asyncpg pool connections:
+
+```bash
+dcdev-automana down
+dcdev-automana up -d --build postgres redis
+# wait for postgres to be healthy
+bash ./src/automana/database/SQL/maintenance/rebuild_dev_db.sh --only rebuild
+dcdev-automana up -d --build celery-worker celery-beat
+# wait for celery to be healthy
+bash ./src/automana/database/SQL/maintenance/rebuild_dev_db.sh --skip-rebuild
+```
+
+`--only rebuild`: DROP + CREATE + schemas + grants, then exits.
+`--skip-rebuild`: runs Scryfall -> MTGStock -> MTGJson pipelines and verifies via `ops.ingestion_runs`.
+
+## Architecture
+
+Strict layered architecture:
+
+```
+API Router -> ServiceManager -> Services -> Repositories -> Database
+```
+
+- **Routers** (`src/automana/api/routers/`) — thin: validation, DI, call `service_manager.execute_service()`
+- **ServiceManager** (`src/automana/core/service_manager.py`) — singleton dispatcher; handles transactions, repository injection, service registry lookup
+- **Services** (`src/automana/core/services/`) — business logic; registered via `@ServiceRegistry.register("dotted.key", db_repositories=[...])` decorator
+- **Repositories** (`src/automana/core/repositories/`) — all DB and external API access; never called from routers directly
+- **Celery** (`src/automana/worker/`) — same service layer, same repositories, bridged async-to-sync via a thread-confined event loop
+
+The HTTP path and the Celery pipeline path go through identical code. The `run_service` task dispatches any registered service by string key.
+
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full layer diagram and request flow.
+
+## API overview
+
+All routes live under the `/api` prefix.
+
+| Area | Base path | Key endpoints |
+|------|-----------|---------------|
+| Auth | `/api/users/auth` | `POST /token` (login), `POST /logout`, `POST /token/refresh` |
+| Users | `/api/users/users` | CRUD, role assignment |
+| Sessions | `/api/users/session` | Get / search / deactivate |
+| Card reference | `/api/catalog/mtg/card-reference` | Search, suggest (fuzzy), CRUD, bulk insert |
+| Collections | `/api/catalog/mtg/collection` | CRUD (requires session) |
+| Set reference | `/api/catalog/mtg/set-reference` | Search, CRUD, bulk insert |
+| eBay | `/api/integrations/ebay` | OAuth, listing create/update/history |
+| Shopify | `/api/integrations/shopify` | Data load/stage, market/theme/collection meta |
+| MTGStock | `/api/integrations/mtg_stock` | Stage, load IDs, price load |
+| Ops integrity | `/api/ops/integrity` | Scryfall run-diff, integrity checks, public-schema-leak check |
+
+Auth uses a split-transport model: session cookie (`session_id`, httponly) for browser clients; `Authorization: Bearer <jwt>` for programmatic callers. The `secure` flag on the session cookie is active in all non-dev environments.
+
+For the full endpoint list see [docs/API.md](docs/API.md) or the live Swagger UI at `/docs`.
+
+## Developer tools
+
+Two tools ship as console-script entry points (installed via `pip install -e .`):
+
+- **`automana-run`** — call any registered service from the CLI without starting the full API server. Boots the same DB pool and `ServiceManager` as production and prints the result as JSON.
+- **`automana-tui`** — terminal UI with tabs for services, Celery, and API testing. Shares the same bootstrap as `automana-run`.
+
+```bash
+# Install entry points
+pip install -e .
+
+# List all registered services
+automana-run --list
+
+# Run a specific service
+automana-run staging.scryfall.start_pipeline --ingestion_run_id=null
+```
+
+See [docs/CLI_RUN_SERVICE.md](docs/CLI_RUN_SERVICE.md) for full usage, prerequisites, and examples.
+
 ## Repo layout
 
 ```
 src/automana/
-  api/          — FastAPI routers and schemas
-  core/         — services, repositories, settings, logging, storage
-  worker/       — Celery tasks and runtime
-  database/     — SQL schemas and migrations
-  tools/        — CLI utilities
+  api/              — FastAPI app, routers, schemas, request handling
+    routers/
+      users/        — auth, session, users
+      catalog/      — MTG card reference, collections, set reference
+      integrations/ — eBay, Shopify, MTGStock
+      ops/          — integrity checks
+  core/             — service layer, repositories, settings, logging, metrics
+    services/       — business logic (registered via @ServiceRegistry.register)
+    repositories/   — DB (asyncpg/psycopg2) and external API clients
+    metrics/        — MetricRegistry for sanity-report metrics
+  worker/           — Celery app, run_service task, pipeline definitions
+    tasks/          — pipeline chains (Scryfall, MTGJson, MTGStock, analytics)
+  database/
+    SQL/
+      schemas/      — DDL for all schemas
+      migrations/   — incremental migration files
+      maintenance/  — rebuild scripts
+  tools/
+    run_service.py  — automana-run CLI
+    tui/            — automana-tui terminal UI
+agentic_workflows/  — LangGraph-based AI SQL agent
 config/
-  env/          — environment files (.env.dev, .env.prod, ...)
-  secrets/      — Docker secret files (not committed)
-deploy/         — Docker Compose files and Dockerfiles
-infra/db/init/  — Postgres init SQL (extensions, roles)
-docs/           — documentation
+  env/              — .env.dev, .env.prod, .env.example, ...
+  secrets/          — Docker secret files (not committed)
+deploy/             — Docker Compose files and Dockerfiles
+docs/               — documentation
+tests/              — unit and integration tests
 ```
+
+## Configuration
+
+All config comes from `src/automana/core/settings.py` (Pydantic `BaseSettings`) via env vars or Docker secrets — no hardcoded credentials or paths. The active environment is set by the `ENV` env var (default: `dev`). Settings are cached via `@lru_cache`.
+
+Key vars: `POSTGRES_HOST`, `POSTGRES_PORT`, `DB_NAME`, `APP_BACKEND_DB_USER`, `DB_PASSWORD`, `BROKER_URL`, `ENV`, `MODULES_NAMESPACE`, `DATA_DIR`.
+
+See `config/env/.env.example` for the full list.

--- a/docs/API.md
+++ b/docs/API.md
@@ -202,15 +202,21 @@ MTGStock (`/api/integrations/mtg_stock`)
 - `POST /api/integrations/mtg_stock/load_ids`
 - `GET /api/integrations/mtg_stock/load` — accepts either `print_ids[]=...` or `range_start` + `range_end`
 
-### Logs
+### Ops / Integrity
 
-Base: `/api/logs`
+Base: `/api/ops`
 
-- `GET /api/logs/` — fetch logs with optional filters (`start_date`, `end_date`, `level`, `task_name`, `service_type`, `user`, `status`, `search`, `limit`, `offset`)
+Integrity (`/api/ops/integrity`)
+
+- `GET /api/ops/integrity/scryfall/run-diff?ingestion_run_id=<id>` — post-run diagnostic report for the most recent (or specified) Scryfall pipeline run; reads `ops.ingestion_runs`, `ops.ingestion_run_steps`, and `ops.ingestion_run_metrics`
+- `GET /api/ops/integrity/scryfall/checks` — runs 24 orphan/loose-data checks across `card_catalog`, `ops`, and `pricing` schemas; returns `errors` and `warnings` lists
+- `GET /api/ops/integrity/public-schema-leak` — confirms no app objects have leaked into the public schema (tables, views, sequences, functions, `search_path`); extension-owned objects excluded
+
+All three endpoints are pure SELECTs (zero side effects) and always return HTTP 200; severity is conveyed in the payload's `errors` and `warnings` arrays.
 
 ## What to keep updated
 
-- If you add/remove routers under `backend/api/*`, update the “Endpoints” section.
+- If you add/remove routers under `src/automana/api/routers/`, update the “Endpoints” section.
 - If auth changes (JWT header vs cookie), update the “Authentication” section and examples.
 - If you standardize error responses, update “Errors” with the canonical shape.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ AutoMana is a FastAPI application backed by PostgreSQL (+ TimescaleDB + pgvector
 
 ### Layer Diagram
 
-![Architecture Layers](diagrams/layer_diagramm.jpg)
+![Architecture Layers](diagrams/layer_Diagramm.jpg)
 
 ### Production topology (Docker)
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -31,17 +31,21 @@ Example env files:
 - `config/env/.env.staging`
 - `config/env/.env.prod`
 
-Start from `config/env/.env.example` and fill the required values (notably `DATABASE_URL`).
+Start from `config/env/.env.example` and fill the required values.
 
-### Database URL
+### Database connection
 
-The backend expects `DATABASE_URL` in the form:
+The backend composes its connection URL from individual env vars (not a single `DATABASE_URL` string):
 
-```
-postgresql+asyncpg://USER:PASSWORD@HOST:PORT/DB
-```
+| Env var | Alias in settings | Default | Purpose |
+|---------|-------------------|---------|---------|
+| `POSTGRES_HOST` | `DB_HOST` | `localhost` | Postgres host |
+| `POSTGRES_PORT` | `DB_PORT` | `5432` | Postgres port |
+| `DB_NAME` | `DB_NAME` | `automana` | Database name |
+| `APP_BACKEND_DB_USER` | `DB_USER` | `app_backend` | Application DB user |
+| `DB_PASSWORD` | (cascade) | — | Password (file path, env var, or well-known path) |
 
-In Docker Compose, `HOST` should be the **service name** (for example `postgres`).
+In Docker Compose, `POSTGRES_HOST` is overridden to the service name (`postgres`) in the `environment:` block of the `backend` and `celery-*` services. Host-side tools (e.g., psql, pgAdmin) use `localhost:5433` (the published port in dev).
 
 ## Local development (Docker Compose)
 
@@ -265,6 +269,6 @@ Task history is persisted via a named Docker volume (`flower-data-dev` or `flowe
 ## Operational notes / caveats
 
 - The backend container currently starts uvicorn with `--reload` (see `deploy/docker/backend/Backend.Dockerfile`). For production you usually want to remove `--reload`.
-- Cookie security flags in auth routes may be set to `secure=False` in code; in production behind HTTPS, you typically want `Secure` cookies.
-- Celery configuration currently loads a dev env file in `celery_app/celeryconfig.py`. If you deploy Celery for prod, align it with `ENV=prod` and your prod env file.
+- Cookie `secure` flag is set dynamically: `True` in all environments except `dev` (`get_settings().env != "dev"`). In dev, cookies are sent over plain HTTP; in staging/prod (behind the nginx TLS terminator) the `Secure` flag is active automatically.
+- Celery configuration lives at `src/automana/worker/celeryconfig.py`. The active env is determined by the `ENV` env var — ensure `ENV=prod` (and the corresponding `config/env/.env.prod`) is set when running Celery in production.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,10 @@
 - [DESIGN_PATTERNS.md](DESIGN_PATTERNS.md) — glossary of every design pattern used in the codebase, with file locations and rationale
 - [LOGGING.md](LOGGING.md) — structured logging setup, context vars, usage patterns
 - [SCRYFALL_PIPELINE.md](SCRYFALL_PIPELINE.md) — Scryfall ETL pipeline steps, file naming, storage
+- [MTGJSON_PIPELINE.md](MTGJSON_PIPELINE.md) — MTGJson daily price ingestion pipeline
+- [MTGSTOCK_PIPELINE.md](MTGSTOCK_PIPELINE.md) — MTGStocks price ingestion pipeline
+- [METRICS_REGISTRY.md](METRICS_REGISTRY.md) — MetricRegistry decorator API and sanity-report runner pattern
+- [HEALTH_METRICS.md](HEALTH_METRICS.md) — card_catalog and pricing health metrics, on-demand Scryfall audit
 - [DATABASE_ROLES.md](DATABASE_ROLES.md) — PostgreSQL roles, permissions, per-service DB users
 - [CLI_RUN_SERVICE.md](CLI_RUN_SERVICE.md) — running services manually via the CLI (`automana-run`) or the interactive TUI (`automana-tui`)
 - [DEPLOYMENT.md](DEPLOYMENT.md) — Docker Compose (dev/prod), env files, nginx, secrets

--- a/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
+++ b/src/automana/core/repositories/app_integration/mtg_stock/price_repository.py
@@ -55,12 +55,25 @@ class PriceRepository(AbstractRepository):
         16 made `source_name` a required positional argument.
         When `ingestion_run_id` is provided, the procedure writes per-batch rows
         to `ops.ingestion_step_batches` and updates `ops.ingestion_run_steps.progress`."""
+        # The procedure inserts into the compressed price_observation hypertable
+        # via ON CONFLICT DO UPDATE. Historical chunks require decompression to
+        # check for conflicts; the default limit (100 000 tuples) is exceeded on
+        # every 30-day batch of historical data. Disable the guard for this
+        # session-scoped bulk load, then reset so the pooled connection is clean.
         await self.connection.execute(
-            "CALL pricing.load_staging_prices_batched($1::varchar, $2::int, $3::int);",
-            source_name,
-            batch_days,
-            ingestion_run_id,
+            "SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0"
         )
+        try:
+            await self.connection.execute(
+                "CALL pricing.load_staging_prices_batched($1::varchar, $2::int, $3::int);",
+                source_name,
+                batch_days,
+                ingestion_run_id,
+            )
+        finally:
+            await self.connection.execute(
+                "RESET timescaledb.max_tuples_decompressed_per_dml_transaction"
+            )
 
     async def call_resolve_price_rejects(
         self,


### PR DESCRIPTION
# Summary

`pricing.load_staging_prices_batched` promotes raw price rows into the compressed `price_observation` hypertable via `INSERT ... ON CONFLICT DO UPDATE`. For historical chunks (any data older than the compression policy threshold), TimescaleDB must decompress rows to evaluate the conflict clause. The default limit of 100 000 decompressed tuples per DML transaction is exceeded on every single 30-day batch of historical data, causing every batch to roll back with zero rows staged — silently, because the procedure traps the error as a `WARNING` and advances to the next batch.

This fix sets `timescaledb.max_tuples_decompressed_per_dml_transaction = 0` (unlimited) on the connection before the `CALL`, using a session-level `SET` so the value survives the procedure's internal per-batch `COMMIT`s. A `finally` block issues `RESET` to return the pooled connection to the default state.

---

# Changes Introduced

- **`price_repository.py` — `call_load_stage_from_raw()`**: wraps the `CALL` in a `SET` / `try` / `finally RESET` pattern to disable and restore the decompression guard around the bulk load.

---

# How to Test

1. Run `automana-run mtg_stock.data_staging.from_raw_to_staging --source_name mtgstocks`
2. Watch `docker logs automana-postgres-dev` — confirm **no** `WARNING: Error processing batch … tuple decompression limit exceeded` lines appear
3. After completion, verify rows were staged: `SELECT count(*) FROM pricing.stg_price_observation;`

Before this fix every batch produced 0 rows and a WARNING. After the fix each batch logs `Batch X to Y: staged N, promoted M, drained M` via `RAISE NOTICE`.

---

# Acceptance Checklist
- [x] Code compiles without errors
- [x] No debug logs left behind
- [x] Follows project coding standards
- [x] Ready for review

---

# Additional Notes

The `RESET` in the `finally` block is critical: without it, the connection re-enters the pool with the unlimited decompression setting active for all subsequent operations on that connection. The `SET` (no `LOCAL`) is intentional — `SET LOCAL` would be reset by the procedure's own `COMMIT` statements, re-enabling the limit mid-run.