### PR TITLE
feat(collection): full collection + entry CRUD with card search

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -122,7 +122,7 @@ Sessions (`/api/users/session`)
 
 - `GET /api/users/session/{session_id}` — get one session
 - `GET /api/users/session/` — search sessions (paginated)
-- `DELETE /api/users/session/{session_id}/desactivate` — deactivate a session
+- `DELETE /api/users/session/{session_id}/deactivate` — deactivate a session
 
 Users (`/api/users/users`)
 

--- a/docs/TESTING_API_FLOW.md
+++ b/docs/TESTING_API_FLOW.md
@@ -6,42 +6,31 @@ Standard procedure for manual API testing using curl. Always use a throwaway tes
 
 ## 1. Create a test user
 
-The `hashed_password` field must be bcrypt-hashed by the caller before sending.
+Pass a plain-text password in the `hashed_password` field — the server bcrypt-hashes it on receipt.
 
 ```bash
-# Generate a bcrypt hash for a known test password
-TEST_PASS="test-$(date +%s)"
-HASHED=$(python3 -c "import bcrypt; print(bcrypt.hashpw(b'${TEST_PASS}', bcrypt.gensalt()).decode())")
-echo "Password: $TEST_PASS"
-echo "Hash:     $HASHED"
+TEST_PASS="Testpass123!"
+TEST_USER="apitest_$$"
 
-# Register the user
 curl -s -X POST http://localhost:8000/api/users/ \
   -H "Content-Type: application/json" \
-  -d "{\"username\": \"apitest_$$\", \"email\": \"apitest_$$@test.local\", \"hashed_password\": \"$HASHED\"}" \
+  -d "{\"username\": \"${TEST_USER}\", \"email\": \"${TEST_USER}@automana.dev\", \"hashed_password\": \"${TEST_PASS}\"}" \
   | python3 -m json.tool
 ```
 
-Save the returned `user_id` for the cleanup step.
+Save the returned `unique_id` for the cleanup step.
 
 ---
 
-## 2. Log in and capture tokens
+## 2. Log in and capture the access token
 
 ```bash
-# Login — returns access_token (Bearer) + sets session_id cookie
-curl -s -c /tmp/apitest_cookies.txt \
+ACCESS_TOKEN=$(curl -s \
   -X POST http://localhost:8000/api/users/auth/token \
   -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=apitest_$$&password=${TEST_PASS}" \
-  | python3 -m json.tool
-
-# Extract the access token
-ACCESS_TOKEN=$(curl -s -c /tmp/apitest_cookies.txt \
-  -X POST http://localhost:8000/api/users/auth/token \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -d "username=apitest_$$&password=${TEST_PASS}" \
+  -d "username=${TEST_USER}&password=${TEST_PASS}" \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+echo "Token: ${ACCESS_TOKEN:0:20}..."
 ```
 
 ---
@@ -66,19 +55,21 @@ curl -s -X DELETE \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   http://localhost:8000/api/users/<USER_ID>
 
-# Remove local cookie jar
-rm -f /tmp/apitest_cookies.txt
+unset TEST_PASS TEST_USER ACCESS_TOKEN
+```
 
-# Clear shell variables holding the password
-unset TEST_PASS HASHED ACCESS_TOKEN
+Or delete directly in psql:
+```bash
+docker exec automana-postgres-dev psql -U app_admin -d automana -c \
+  "DELETE FROM user_management.users WHERE username LIKE 'apitest%' RETURNING username;"
 ```
 
 ---
 
-## Collection test example (full round-trip)
+## Collection + entries round-trip
 
 ```bash
-# Create collection
+# Create a collection (returns collection_id, collection_name, user_id)
 COLLECTION_ID=$(curl -s -X POST \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
@@ -87,17 +78,39 @@ COLLECTION_ID=$(curl -s -X POST \
   | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['collection_id'])")
 echo "Collection: $COLLECTION_ID"
 
-# Get a card version ID to insert
-CARD_ID=$(docker exec automana-postgres-dev psql -U app_admin -d automana -t -c \
-  "SELECT card_version_id FROM card_catalog.card_version LIMIT 1;" | tr -d ' \n')
+# Find a card via typeahead suggest
+curl -s "http://localhost:8000/api/catalog/mtg/card/suggest?query=Sheoldred" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" | python3 -m json.tool
 
-# Add a card entry  (endpoint not yet implemented — placeholder)
+# Add a card entry — three supported identifier strategies:
+
+# (a) by card_version_id (from suggest)
 curl -s -X POST \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
-  -d "{\"unique_card_id\": \"$CARD_ID\", \"is_foil\": false, \"purchase_price\": \"1.50\", \"condition\": \"NM\", \"currency_code\": \"USD\"}" \
+  -d '{"card_version_id": "<uuid>", "condition": "NM", "finish": "NONFOIL", "purchase_price": "15.99"}' \
   http://localhost:8000/api/catalog/mtg/collection/${COLLECTION_ID}/entries \
   | python3 -m json.tool
+
+# (b) by scryfall_id
+curl -s -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"scryfall_id": "<uuid>", "condition": "LP", "finish": "FOIL", "purchase_price": "22.50"}' \
+  http://localhost:8000/api/catalog/mtg/collection/${COLLECTION_ID}/entries \
+  | python3 -m json.tool
+
+# (c) by set_code + collector_number
+curl -s -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"set_code": "dmu", "collector_number": "107", "condition": "MP", "finish": "NONFOIL", "purchase_price": "8.00"}' \
+  http://localhost:8000/api/catalog/mtg/collection/${COLLECTION_ID}/entries \
+  | python3 -m json.tool
+
+# List all entries
+curl -s "http://localhost:8000/api/catalog/mtg/collection/${COLLECTION_ID}/entries" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" | python3 -m json.tool
 
 # Delete the collection
 curl -s -X DELETE \
@@ -110,7 +123,8 @@ echo "Deleted collection $COLLECTION_ID"
 
 ## Notes
 
-- `bcrypt` must be available: `pip show bcrypt` or `docker exec automana-backend-dev pip show bcrypt`
+- `hashed_password` in the registration request is a misnomer — pass the **plain** password, the server hashes it
+- Valid `condition` values: `NM`, `LP`, `SP`, `MP`, `HP`, `DMG`
+- Valid `finish` values: `NONFOIL`, `FOIL`, `ETCHED`
 - The backend runs on port `8000` in dev; nginx proxies `80/443` in all other envs
-- Cookie jar (`/tmp/apitest_cookies.txt`) holds the `session_id` — delete it at end of session
 - Never commit test passwords; always `unset` them when done

--- a/docs/TESTING_API_FLOW.md
+++ b/docs/TESTING_API_FLOW.md
@@ -1,0 +1,116 @@
+# API Testing Flow
+
+Standard procedure for manual API testing using curl. Always use a throwaway test user — never the persistent `testuser` or `curltest` accounts.
+
+---
+
+## 1. Create a test user
+
+The `hashed_password` field must be bcrypt-hashed by the caller before sending.
+
+```bash
+# Generate a bcrypt hash for a known test password
+TEST_PASS="test-$(date +%s)"
+HASHED=$(python3 -c "import bcrypt; print(bcrypt.hashpw(b'${TEST_PASS}', bcrypt.gensalt()).decode())")
+echo "Password: $TEST_PASS"
+echo "Hash:     $HASHED"
+
+# Register the user
+curl -s -X POST http://localhost:8000/api/users/ \
+  -H "Content-Type: application/json" \
+  -d "{\"username\": \"apitest_$$\", \"email\": \"apitest_$$@test.local\", \"hashed_password\": \"$HASHED\"}" \
+  | python3 -m json.tool
+```
+
+Save the returned `user_id` for the cleanup step.
+
+---
+
+## 2. Log in and capture tokens
+
+```bash
+# Login — returns access_token (Bearer) + sets session_id cookie
+curl -s -c /tmp/apitest_cookies.txt \
+  -X POST http://localhost:8000/api/users/auth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=apitest_$$&password=${TEST_PASS}" \
+  | python3 -m json.tool
+
+# Extract the access token
+ACCESS_TOKEN=$(curl -s -c /tmp/apitest_cookies.txt \
+  -X POST http://localhost:8000/api/users/auth/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "username=apitest_$$&password=${TEST_PASS}" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+```
+
+---
+
+## 3. Make authenticated requests
+
+Use `Authorization: Bearer <token>` on all protected endpoints:
+
+```bash
+# Verify identity
+curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
+  http://localhost:8000/api/users/me | python3 -m json.tool
+```
+
+---
+
+## 4. Cleanup — delete the user and local state
+
+```bash
+# Delete the throwaway user (requires admin role or self-delete)
+curl -s -X DELETE \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  http://localhost:8000/api/users/<USER_ID>
+
+# Remove local cookie jar
+rm -f /tmp/apitest_cookies.txt
+
+# Clear shell variables holding the password
+unset TEST_PASS HASHED ACCESS_TOKEN
+```
+
+---
+
+## Collection test example (full round-trip)
+
+```bash
+# Create collection
+COLLECTION_ID=$(curl -s -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"collection_name": "test_col", "description": "api test"}' \
+  http://localhost:8000/api/catalog/mtg/collection/ \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['data']['collection_id'])")
+echo "Collection: $COLLECTION_ID"
+
+# Get a card version ID to insert
+CARD_ID=$(docker exec automana-postgres-dev psql -U app_admin -d automana -t -c \
+  "SELECT card_version_id FROM card_catalog.card_version LIMIT 1;" | tr -d ' \n')
+
+# Add a card entry  (endpoint not yet implemented — placeholder)
+curl -s -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"unique_card_id\": \"$CARD_ID\", \"is_foil\": false, \"purchase_price\": \"1.50\", \"condition\": \"NM\", \"currency_code\": \"USD\"}" \
+  http://localhost:8000/api/catalog/mtg/collection/${COLLECTION_ID}/entries \
+  | python3 -m json.tool
+
+# Delete the collection
+curl -s -X DELETE \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  http://localhost:8000/api/catalog/mtg/collection/${COLLECTION_ID}
+echo "Deleted collection $COLLECTION_ID"
+```
+
+---
+
+## Notes
+
+- `bcrypt` must be available: `pip show bcrypt` or `docker exec automana-backend-dev pip show bcrypt`
+- The backend runs on port `8000` in dev; nginx proxies `80/443` in all other envs
+- Cookie jar (`/tmp/apitest_cookies.txt`) holds the `session_id` — delete it at end of session
+- Never commit test passwords; always `unset` them when done

--- a/src/automana/api/routers/catalog/__init__.py
+++ b/src/automana/api/routers/catalog/__init__.py
@@ -1,5 +1,6 @@
-﻿from fastapi import APIRouter
+from fastapi import APIRouter
 from automana.api.routers.mtg import mtg_router
 
-catalog_router = APIRouter(prefix="/catalog", tags=["Catalog"])
+# No tags here — child routers own their tags to avoid tag accumulation in Swagger.
+catalog_router = APIRouter(prefix="/catalog")
 catalog_router.include_router(mtg_router)

--- a/src/automana/api/routers/mtg/__init__.py
+++ b/src/automana/api/routers/mtg/__init__.py
@@ -1,9 +1,11 @@
-﻿from fastapi import APIRouter
+from fastapi import APIRouter
 from automana.api.routers.mtg.card_reference import card_reference_router
 from automana.api.routers.mtg.collection import router as collection_router
 from automana.api.routers.mtg.set_reference import router as set_router
 
-mtg_router = APIRouter(prefix="/mtg", tags=["API", "MTG"])
+# No tags here — each child router declares its own canonical tag ("Card Catalogue",
+# "Collections") so Swagger groups them cleanly without accumulating duplicates.
+mtg_router = APIRouter(prefix="/mtg")
 
 mtg_router.include_router(card_reference_router)
 mtg_router.include_router(collection_router)

--- a/src/automana/api/routers/mtg/card_reference.py
+++ b/src/automana/api/routers/mtg/card_reference.py
@@ -1,33 +1,60 @@
-﻿import os,tempfile, logging
+import os
+import logging
 from typing import List
-from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status, BackgroundTasks
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from uuid import UUID
-from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo
+from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo, ErrorResponse
 from automana.core.models.card_catalog.card import BaseCard, CardSuggestionResponse, CreateCard, CreateCards
 from automana.api.dependancies.service_deps import ServiceManagerDep
-from automana.api.dependancies.query_deps import (sort_params
-                                             ,card_search_params
-                                             ,pagination_params
-                                             , date_range_params
-                                             ,PaginationParams
-                                             ,SortParams
-                                             , DateRangeParams)
+from automana.api.dependancies.query_deps import (
+    sort_params,
+    card_search_params,
+    pagination_params,
+    date_range_params,
+    PaginationParams,
+    SortParams,
+    DateRangeParams,
+)
+
+logger = logging.getLogger(__name__)
 
 BULK_INSERT_LIMIT = 50
 
+_CARD_ERRORS = {
+    422: {"description": "Validation error — malformed or missing fields"},
+    500: {"description": "Internal server error", "model": ErrorResponse},
+}
+
 card_reference_router = APIRouter(
     prefix="/card-reference",
-    tags=['cards'],
-    responses={404:{'description' : 'Not found'},
-               500: {'description': 'Internal Server Error'},
-               }
+    tags=["Card Catalogue"],
+    responses={
+        404: {"description": "Not found"},
+        500: {"description": "Internal Server Error"},
+    },
 )
 
-@card_reference_router.get('/suggest', response_model=ApiResponse[CardSuggestionResponse])
+
+@card_reference_router.get(
+    '/suggest',
+    summary="Autocomplete card names",
+    description=(
+        "Returns up to `limit` card-name suggestions matching the partial query `q` "
+        "using typo-tolerant fuzzy matching (pg_trgm). Minimum query length is 2 "
+        "characters. Results are cached for 10 minutes. Useful for search-as-you-type "
+        "UI components."
+    ),
+    response_model=ApiResponse[CardSuggestionResponse],
+    operation_id="cards_suggest",
+    responses={
+        400: {"description": "Query string too short (minimum 2 characters)"},
+        **_CARD_ERRORS,
+    },
+)
 async def suggest_cards(
     service_manager: ServiceManagerDep,
     q: str = Query(..., min_length=2, description="Partial card name to autocomplete"),
-    limit: int = Query(10, ge=1, le=20, description="Maximum suggestions to return"),
+    limit: int = Query(10, ge=1, le=20, description="Maximum number of suggestions to return (1–20)"),
 ) -> ApiResponse[CardSuggestionResponse]:
     try:
         result = await service_manager.execute_service(
@@ -42,44 +69,72 @@ async def suggest_cards(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@card_reference_router.get('/{card_id}', response_model=ApiResponse[BaseCard])
-async def get_card_info(card_id: UUID
-                        , service_manager: ServiceManagerDep
-                        ) -> ApiResponse[BaseCard]:
+@card_reference_router.get(
+    '/{card_id}',
+    summary="Get a card by its UUID",
+    description=(
+        "Returns the full card record for the given Scryfall-compatible UUID. "
+        "If no card matches, an empty `data` list is returned with a descriptive "
+        "message rather than a 404."
+    ),
+    response_model=ApiResponse[BaseCard],
+    operation_id="cards_get_by_id",
+    responses={
+        404: {"description": "Card not found"},
+        **_CARD_ERRORS,
+    },
+)
+async def get_card(
+    card_id: UUID,
+    service_manager: ServiceManagerDep,
+) -> ApiResponse[BaseCard]:
     try:
-        result =await service_manager.execute_service(
+        result = await service_manager.execute_service(
             "card_catalog.card.get",
-            card_id=card_id
+            card_id=card_id,
         )
-        #get the card
         card = result.cards[0] if result.cards else None
-        
         if not card:
-            return ApiResponse(data=[], message="No Card to retrieve")
+            return ApiResponse(data=[], message="No card found for the given ID")
         return ApiResponse(data=card, message="Card retrieved successfully")
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
-@card_reference_router.get('/', response_model=PaginatedResponse[BaseCard])
-async def get_cards(
-                    service_manager: ServiceManagerDep,
-                    pagination: PaginationParams = Depends(pagination_params),
-                    sorting: SortParams = Depends(sort_params),
-                    search: dict = Depends(card_search_params),
-                    date_range: DateRangeParams = Depends(date_range_params)
-                        ):
+
+@card_reference_router.get(
+    '/',
+    summary="Search and list cards (paginated)",
+    description=(
+        "Returns a paginated list of MTG cards. Supports full-text and field-level "
+        "filtering: `name`, `oracle_text`, `format`, `set`, `rarity`, and more. "
+        "Also accepts `released_after` / `released_before` date range filters and "
+        "standard `sort_by` / `sort_order` / `limit` / `offset` controls. "
+        "Results are cached for 60 minutes per unique filter combination."
+    ),
+    response_model=PaginatedResponse[BaseCard],
+    operation_id="cards_list",
+    responses=_CARD_ERRORS,
+)
+async def list_cards(
+    service_manager: ServiceManagerDep,
+    pagination: PaginationParams = Depends(pagination_params),
+    sorting: SortParams = Depends(sort_params),
+    search: dict = Depends(card_search_params),
+    date_range: DateRangeParams = Depends(date_range_params),
+):
     try:
         result = await service_manager.execute_service(
             "card_catalog.card.search",
-             limit=pagination.limit,
+            limit=pagination.limit,
             offset=pagination.offset,
             released_after=date_range.created_after,
             released_before=date_range.created_before,
             sort_by=sorting.sort_by,
             sort_order=sorting.sort_order,
-            **search)
+            **search,
+        )
         cards = result.cards if result else []
         total_count = result.total_count if result else 0
         return PaginatedResponse[BaseCard](
@@ -89,24 +144,41 @@ async def get_cards(
                 offset=pagination.offset,
                 total_count=total_count,
                 has_next=len(cards) == pagination.limit,
-                has_previous=pagination.offset > 0
-            )
+                has_previous=pagination.offset > 0,
+            ),
         )
     except HTTPException:
         raise
-    except Exception as e:
+    except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
-#not tested
-@card_reference_router.post('/', status_code=status.HTTP_201_CREATED)
-async def insert_card( card : CreateCard
-                      , service_manager: ServiceManagerDep
-                      ):
-    try:
-        result =await service_manager.execute_service("card_catalog.card.create"
-                                              , card=card)
-        
 
+@card_reference_router.post(
+    '/',
+    summary="Insert a single card",
+    description=(
+        "Inserts a new MTG card record into the catalogue. The request body must "
+        "conform to the `CreateCard` schema, which maps closely to the Scryfall card "
+        "object format. Returns the newly created card's UUID on success.\n\n"
+        "> **Note:** This endpoint is not yet covered by integration tests."
+    ),
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="cards_create",
+    responses={
+        409: {"description": "Card with this ID already exists"},
+        **_CARD_ERRORS,
+    },
+)
+async def insert_card(
+    card: CreateCard,
+    service_manager: ServiceManagerDep,
+):
+    try:
+        result = await service_manager.execute_service(
+            "card_catalog.card.create",
+            card=card,
+        )
         if not result:
             raise HTTPException(status_code=500, detail="Failed to insert card")
         return ApiResponse(data={"card_id": str(result)}, message="Card inserted successfully")
@@ -115,42 +187,83 @@ async def insert_card( card : CreateCard
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to insert card: {str(e)}")
 
-#not tested
-@card_reference_router.post('/bulk', response_model=None,)
-async def insert_cards( cards : List[CreateCard]
-                       , service_manager: ServiceManagerDep
-                       ):
-    validated_cards : CreateCards = CreateCards(items=cards)
+
+@card_reference_router.post(
+    '/bulk',
+    summary="Bulk-insert up to 50 cards",
+    description=(
+        "Inserts up to **50** MTG card records in a single request. Returns a summary "
+        "of successful and failed inserts along with the success rate. "
+        "For larger batches use `POST /card-reference/upload-file`.\n\n"
+        "> **Note:** This endpoint is not yet covered by integration tests."
+    ),
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="cards_bulk_create",
+    responses={
+        400: {"description": f"Payload exceeds the {BULK_INSERT_LIMIT}-card limit or is empty"},
+        **_CARD_ERRORS,
+    },
+)
+async def bulk_insert_cards(
+    cards: List[CreateCard],
+    service_manager: ServiceManagerDep,
+):
+    validated_cards: CreateCards = CreateCards(items=cards)
     try:
         if len(cards) > BULK_INSERT_LIMIT:
             raise HTTPException(
-                status_code=400, 
-                detail=f"Bulk insert limited to {BULK_INSERT_LIMIT} cards. "
-                       f"You provided {len(cards)} cards. "
-                       f"Use the file upload endpoint for larger batches."
+                status_code=400,
+                detail=(
+                    f"Bulk insert limited to {BULK_INSERT_LIMIT} cards. "
+                    f"You provided {len(cards)} cards. "
+                    "Use the file upload endpoint for larger batches."
+                ),
             )
         if len(cards) == 0:
             raise HTTPException(
                 status_code=400,
-                detail="No cards provided for bulk insert"
+                detail="No cards provided for bulk insert",
             )
-        
-        result = await service_manager.execute_service("card_catalog.card.create_many", cards=validated_cards)
+        result = await service_manager.execute_service(
+            "card_catalog.card.create_many",
+            cards=validated_cards,
+        )
         if not result:
             raise HTTPException(status_code=500, detail="Failed to insert cards")
-        return ApiResponse(data = {"InsertedCards": result.successful_inserts,
-                                   "NotInsertedCards": result.failed_inserts,
-                                   "PercentageSuccess": result.success_rate}
-                                   , message="Bulk insert completed")
+        return ApiResponse(
+            data={
+                "InsertedCards": result.successful_inserts,
+                "NotInsertedCards": result.failed_inserts,
+                "PercentageSuccess": result.success_rate,
+            },
+            message="Bulk insert completed",
+        )
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to insert cards: {str(e)}")
 
-#not tested
-@card_reference_router.delete('/{card_id}')
-async def delete_card(card_id : UUID
-                      , service_manager: ServiceManagerDep):
+
+@card_reference_router.delete(
+    '/{card_id}',
+    summary="Delete a card by its UUID",
+    description=(
+        "Permanently removes the card record identified by `card_id` from the "
+        "catalogue. Returns the deleted card's UUID in the response body.\n\n"
+        "> **Note:** This endpoint is not yet covered by integration tests."
+    ),
+    response_model=ApiResponse,
+    operation_id="cards_delete",
+    responses={
+        404: {"description": "Card not found"},
+        **_CARD_ERRORS,
+    },
+)
+async def delete_card(
+    card_id: UUID,
+    service_manager: ServiceManagerDep,
+):
     try:
         await service_manager.execute_service("card_catalog.card.delete", card_id=card_id)
         return ApiResponse(data={"card_id": str(card_id)}, message="Card deleted successfully")
@@ -158,29 +271,38 @@ async def delete_card(card_id : UUID
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to delete card: {str(e)}")
-    
-@card_reference_router.post("/test-service", response_model=ApiResponse)
-async def test_service_only(
+
+
+@card_reference_router.post(
+    "/test-service",
+    summary="[Dev] Test the large-JSON processing service",
+    description=(
+        "**Development/diagnostic endpoint.** Invokes the "
+        "`card_catalog.card.process_large_json` service with a server-side file path "
+        "and returns the raw result. The file must already exist on the server "
+        "filesystem. **Do not expose in production.**"
+    ),
+    response_model=ApiResponse,
+    operation_id="cards_test_service",
+    responses={
+        400: {"description": "File not found at the provided path"},
+        **_CARD_ERRORS,
+    },
+)
+async def test_service(
     file_path: str,
-    service_manager: ServiceManagerDep
+    service_manager: ServiceManagerDep,
 ):
-    """
-    Simple test of the service with minimal parameters
-    """
     try:
         if not os.path.exists(file_path):
             raise HTTPException(status_code=400, detail=f"File not found: {file_path}")
-        
-        
-        # Call service with minimal parameters
         result = await service_manager.execute_service(
             "card_catalog.card.process_large_json",
-            file_path=file_path
+            file_path=file_path,
         )
-        
         return ApiResponse(
             data={"raw_result": str(result)},
-            message="Service test completed"
+            message="Service test completed",
         )
     except HTTPException:
         raise

--- a/src/automana/api/routers/mtg/collection.py
+++ b/src/automana/api/routers/mtg/collection.py
@@ -1,70 +1,129 @@
-﻿from fastapi import APIRouter, HTTPException, Depends, status, Query
+from fastapi import APIRouter, HTTPException, Depends, status, Query
 from typing import List, Optional
 from uuid import UUID
-from automana.core.models.collections.collection import CreateCollection, UpdateCollection, PublicCollection, PublicCollectionEntry, UpdateCollectionEntry, NewCollectionEntry
+from automana.core.exceptions.service_layer_exceptions.card_catalogue.card_catalog_exceptions import (
+    CollectionNotFoundError,
+    CollectionAccessDeniedError,
+)
+from automana.core.models.collections.collection import (
+    CreateCollection,
+    UpdateCollection,
+    PublicCollection,
+    PublicCollectionEntry,
+    UpdateCollectionEntry,
+    NewCollectionEntry,
+)
 from automana.api.dependancies.service_deps import ServiceManagerDep
-from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, ErrorResponse, PaginationInfo
+from automana.api.schemas.StandardisedQueryResponse import (
+    ApiResponse,
+    PaginatedResponse,
+    ErrorResponse,
+    PaginationInfo,
+)
 from automana.api.dependancies.auth.users import CurrentUserDep, get_current_active_user
 
+_COLLECTION_ERRORS = {
+    401: {"description": "Not authenticated — valid session_id cookie required", "model": ErrorResponse},
+    403: {"description": "Forbidden — collection belongs to a different user", "model": ErrorResponse},
+    422: {"description": "Validation error — malformed or missing fields"},
+    500: {"description": "Internal server error", "model": ErrorResponse},
+}
+
 router = APIRouter(
-     prefix='/collection',
-    tags=['collection'],
+    prefix='/collection',
+    tags=["Collections"],
     dependencies=[Depends(get_current_active_user)],
-    responses={401: {'description': 'Unauthorized', 'model': ErrorResponse},
-        403: {'description': 'Forbidden', 'model': ErrorResponse},
-        404: {'description': 'Not found', 'model': ErrorResponse},
-        500: {'description': 'Internal server error', 'model': ErrorResponse}
-        }
+    responses={
+        401: {"description": "Unauthorized", "model": ErrorResponse},
+        403: {"description": "Forbidden", "model": ErrorResponse},
+        404: {"description": "Not found", "model": ErrorResponse},
+        500: {"description": "Internal server error", "model": ErrorResponse},
+    },
 )
 
-@router.post('/', response_model=ApiResponse, status_code=status.HTTP_201_CREATED)
-async def add_collection(
-    created_collection: CreateCollection, 
+
+@router.post(
+    '/',
+    summary="Create a new collection",
+    description=(
+        "Creates a new MTG card collection owned by the currently authenticated user. "
+        "The collection name must be unique per user and is limited to 20 characters. "
+        "Returns the newly created collection data."
+    ),
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="collections_create",
+    responses={
+        409: {"description": "A collection with this name already exists for this user"},
+        **_COLLECTION_ERRORS,
+    },
+)
+async def create_collection(
+    created_collection: CreateCollection,
     current_user: CurrentUserDep,
-    service_manager: ServiceManagerDep
+    service_manager: ServiceManagerDep,
 ) -> ApiResponse:
     result = await service_manager.execute_service(
-        "card_catalog.collection.add"
-        ,created_collection= created_collection
-        ,user=current_user
-        )
+        "card_catalog.collection.add",
+        created_collection=created_collection,
+        user=current_user,
+    )
     return ApiResponse(data=result)
 
-@router.delete('/{collection_id}', status_code=status.HTTP_204_NO_CONTENT)
-async def remove_collection(
-    collection_id: UUID, 
-    current_user: CurrentUserDep,
-    service_manager: ServiceManagerDep
-):
-    result = await service_manager.execute_service(
-        "card_catalog.collection.delete"
-        , user=current_user
-        ,collection_id= collection_id)
-    if result is not True:
-        return ApiResponse(status=404, message="Collection not found")
 
-
-@router.get('/{collection_id}', response_model=ApiResponse, status_code=status.HTTP_200_OK)
+@router.get(
+    '/{collection_id}',
+    summary="Get a collection by ID",
+    description=(
+        "Returns the full details of the collection identified by `collection_id`. "
+        "The collection must belong to the currently authenticated user."
+    ),
+    response_model=ApiResponse,
+    status_code=status.HTTP_200_OK,
+    operation_id="collections_get_by_id",
+    responses={
+        404: {"description": "Collection not found or does not belong to this user"},
+        **_COLLECTION_ERRORS,
+    },
+)
 async def get_collection(
-    collection_id: UUID, 
+    collection_id: UUID,
     current_user: CurrentUserDep,
-    service_manager: ServiceManagerDep
+    service_manager: ServiceManagerDep,
 ):
-    result = await service_manager.execute_service(
-        "card_catalog.collection.get"
-        , collection_id =collection_id
-        , user = current_user)
-    if not result:
+    try:
+        result = await service_manager.execute_service(
+            "card_catalog.collection.get",
+            collection_id=collection_id,
+            user=current_user,
+        )
+    except CollectionNotFoundError:
         raise HTTPException(status_code=404, detail="Collection not found")
+    except CollectionAccessDeniedError:
+        raise HTTPException(status_code=403, detail="Forbidden")
     return ApiResponse(data=result)
 
-@router.get('/', response_model=PaginatedResponse)
+
+@router.get(
+    '/',
+    summary="List collections for the current user",
+    description=(
+        "Returns a paginated list of all collections owned by the authenticated user. "
+        "Optionally accepts a `collection_ids` query parameter to retrieve specific "
+        "collections by UUID. Supports `limit` and `offset` for pagination."
+    ),
+    response_model=PaginatedResponse,
+    operation_id="collections_list",
+    responses=_COLLECTION_ERRORS,
+)
 async def list_collections(
     current_user: CurrentUserDep,
     service_manager: ServiceManagerDep,
-    collection_ids: Optional[List[UUID]] = Query(None, description="Specific collection IDs to retrieve"),
-    limit: int = Query(100, le=100, description="Maximum number of collections"),
-    offset: int = Query(0, ge=0, description="Number of collections to skip")
+    collection_ids: Optional[List[UUID]] = Query(
+        None, description="Specific collection UUIDs to retrieve"
+    ),
+    limit: int = Query(100, le=100, description="Maximum number of collections to return"),
+    offset: int = Query(0, ge=0, description="Number of collections to skip"),
 ):
     try:
         if collection_ids:
@@ -106,43 +165,116 @@ async def list_collections(
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-    
-@router.put('/{collection_id}', status_code=204)
-async def change_collection(
-    collection_id: str, 
-    updated_collection: UpdateCollection, 
+
+
+@router.put(
+    '/{collection_id}',
+    summary="Update a collection",
+    description=(
+        "Updates the `collection_name`, `description`, and/or `is_active` flag of "
+        "the specified collection. The collection must belong to the authenticated "
+        "user. Partial updates are supported — only provided fields are changed. "
+        "Returns 204 No Content on success."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="collections_update",
+    responses={
+        404: {"description": "Collection not found or does not belong to this user"},
+        **_COLLECTION_ERRORS,
+    },
+)
+async def update_collection(
+    collection_id: UUID,
+    updated_collection: UpdateCollection,
     current_user: CurrentUserDep,
-    service_manager: ServiceManagerDep
+    service_manager: ServiceManagerDep,
 ):
     return await service_manager.execute_service(
-        "card_catalog.collection.update",  collection_id=collection_id, updated_collection=updated_collection, user=current_user)
+        "card_catalog.collection.update",
+        collection_id=collection_id,
+        updated_collection=updated_collection,
+        user=current_user,
+    )
 
-#########################to complete#######################
-@router.delete('{collection_id}/{entry_id}')
-async def delete_entry(
-    collection_id: str, 
-    entry_id: UUID,
-    service_manager: ServiceManagerDep
+
+@router.delete(
+    '/{collection_id}',
+    summary="Delete a collection",
+    description=(
+        "Permanently deletes the collection identified by `collection_id`. "
+        "The collection must belong to the currently authenticated user. "
+        "Returns 204 No Content on success."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="collections_delete",
+    responses={
+        404: {"description": "Collection not found or does not belong to this user"},
+        **_COLLECTION_ERRORS,
+    },
+)
+async def delete_collection(
+    collection_id: UUID,
+    current_user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
 ):
-    return await service_manager.execute_service(
-        "card_catalog.collection.delete_entry", collection_id, entry_id)
-    
-@router.get('{collection_id}/{entry_id}', response_model=PublicCollectionEntry)
-async def get_entry(
-    collection_id: str, 
-    entry_id: UUID,
-    service_manager: ServiceManagerDep
-):
-    return await service_manager.execute_service(
-        "card_catalog.collection.get_entry", collection_id, entry_id)
-    
-    query = """ SELECT c.item_id, c.collection_id,  c.unique_card_id, c.is_foil, c.purchase_date,c.purchase_price, rc.condition_description AS condition
-                FROM collectionItems c
-                JOIN Ref_Condition rc ON rc.condition_code = c.condition
-                WHERE item_id = %s
-            """
     try:
-        return  execute_select_query(conn, query, (entry_id,), select_all=False)
-    except Exception:
-            raise 
+        await service_manager.execute_service(
+            "card_catalog.collection.delete",
+            user=current_user,
+            collection_id=collection_id,
+        )
+    except CollectionNotFoundError:
+        raise HTTPException(status_code=404, detail="Collection not found")
 
+
+# ---------------------------------------------------------------------------
+# Collection entry endpoints (TODO: incomplete — service calls use positional
+# args which is incorrect; paths were also missing a leading slash which caused
+# malformed routes. Both issues are flagged; routing is fixed here.)
+# ---------------------------------------------------------------------------
+
+@router.delete(
+    '/{collection_id}/{entry_id}',
+    summary="[TODO] Delete a collection entry",
+    description=(
+        "**Incomplete endpoint.** Removes a single entry from a collection. "
+        "The service call currently passes positional arguments; this must be fixed "
+        "before this endpoint is production-ready."
+    ),
+    operation_id="collection_entries_delete",
+    responses=_COLLECTION_ERRORS,
+)
+async def delete_entry(
+    collection_id: str,
+    entry_id: UUID,
+    service_manager: ServiceManagerDep,
+):
+    return await service_manager.execute_service(
+        "card_catalog.collection.delete_entry", collection_id, entry_id
+    )
+
+
+@router.get(
+    '/{collection_id}/{entry_id}',
+    summary="[TODO] Get a collection entry",
+    description=(
+        "**Incomplete endpoint.** Returns a single entry from a collection. "
+        "The service call currently passes positional arguments; this must be fixed "
+        "before this endpoint is production-ready."
+    ),
+    response_model=PublicCollectionEntry,
+    response_model_exclude_unset=True,
+    operation_id="collection_entries_get",
+    responses={
+        404: {"description": "Entry not found"},
+        **_COLLECTION_ERRORS,
+    },
+)
+async def get_entry(
+    collection_id: str,
+    entry_id: UUID,
+    service_manager: ServiceManagerDep,
+):
+    return await service_manager.execute_service(
+        "card_catalog.collection.get_entry", collection_id, entry_id
+    )

--- a/src/automana/api/routers/mtg/collection.py
+++ b/src/automana/api/routers/mtg/collection.py
@@ -11,7 +11,7 @@ from automana.core.models.collections.collection import (
     PublicCollection,
     PublicCollectionEntry,
     UpdateCollectionEntry,
-    NewCollectionEntry,
+    AddCollectionEntryRequest,
 )
 from automana.api.dependancies.service_deps import ServiceManagerDep
 from automana.api.schemas.StandardisedQueryResponse import (
@@ -227,43 +227,71 @@ async def delete_collection(
         raise HTTPException(status_code=404, detail="Collection not found")
 
 
-# ---------------------------------------------------------------------------
-# Collection entry endpoints (TODO: incomplete — service calls use positional
-# args which is incorrect; paths were also missing a leading slash which caused
-# malformed routes. Both issues are flagged; routing is fixed here.)
-# ---------------------------------------------------------------------------
-
-@router.delete(
-    '/{collection_id}/{entry_id}',
-    summary="[TODO] Delete a collection entry",
+@router.post(
+    '/{collection_id}/entries',
+    summary="Add a card to a collection",
     description=(
-        "**Incomplete endpoint.** Removes a single entry from a collection. "
-        "The service call currently passes positional arguments; this must be fixed "
-        "before this endpoint is production-ready."
+        "Adds a card version to the specified collection. The card can be identified by "
+        "`card_version_id` (from `/suggest`), by `scryfall_id`, or by `set_code` + "
+        "`collector_number`. Returns the created entry with resolved card details."
     ),
-    operation_id="collection_entries_delete",
-    responses=_COLLECTION_ERRORS,
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="collection_entries_add",
+    responses={
+        404: {"description": "Collection or card not found"},
+        **_COLLECTION_ERRORS,
+    },
 )
-async def delete_entry(
-    collection_id: str,
-    entry_id: UUID,
+async def add_entry(
+    collection_id: UUID,
+    request: AddCollectionEntryRequest,
+    current_user: CurrentUserDep,
     service_manager: ServiceManagerDep,
 ):
-    return await service_manager.execute_service(
-        "card_catalog.collection.delete_entry", collection_id, entry_id
-    )
+    try:
+        result = await service_manager.execute_service(
+            "card_catalog.collection.add_entry",
+            collection_id=collection_id,
+            user=current_user,
+            request=request,
+        )
+        return ApiResponse(data=result)
+    except CollectionNotFoundError:
+        raise HTTPException(status_code=404, detail="Collection not found")
 
 
 @router.get(
-    '/{collection_id}/{entry_id}',
-    summary="[TODO] Get a collection entry",
-    description=(
-        "**Incomplete endpoint.** Returns a single entry from a collection. "
-        "The service call currently passes positional arguments; this must be fixed "
-        "before this endpoint is production-ready."
-    ),
-    response_model=PublicCollectionEntry,
-    response_model_exclude_unset=True,
+    '/{collection_id}/entries',
+    summary="List all entries in a collection",
+    description="Returns all cards in the specified collection owned by the authenticated user.",
+    response_model=ApiResponse,
+    operation_id="collection_entries_list",
+    responses={
+        404: {"description": "Collection not found"},
+        **_COLLECTION_ERRORS,
+    },
+)
+async def list_entries(
+    collection_id: UUID,
+    current_user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    try:
+        result = await service_manager.execute_service(
+            "card_catalog.collection.list_entries",
+            collection_id=collection_id,
+            user=current_user,
+        )
+        return ApiResponse(data=result)
+    except CollectionNotFoundError:
+        raise HTTPException(status_code=404, detail="Collection not found")
+
+
+@router.get(
+    '/{collection_id}/entries/{entry_id}',
+    summary="Get a single collection entry",
+    response_model=ApiResponse,
     operation_id="collection_entries_get",
     responses={
         404: {"description": "Entry not found"},
@@ -271,10 +299,45 @@ async def delete_entry(
     },
 )
 async def get_entry(
-    collection_id: str,
+    collection_id: UUID,
     entry_id: UUID,
+    current_user: CurrentUserDep,
     service_manager: ServiceManagerDep,
 ):
-    return await service_manager.execute_service(
-        "card_catalog.collection.get_entry", collection_id, entry_id
-    )
+    try:
+        result = await service_manager.execute_service(
+            "card_catalog.collection.get_entry",
+            collection_id=collection_id,
+            entry_id=entry_id,
+            user=current_user,
+        )
+        return ApiResponse(data=result)
+    except CollectionNotFoundError:
+        raise HTTPException(status_code=404, detail="Entry not found")
+
+
+@router.delete(
+    '/{collection_id}/entries/{entry_id}',
+    summary="Remove a card from a collection",
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="collection_entries_delete",
+    responses={
+        404: {"description": "Entry not found"},
+        **_COLLECTION_ERRORS,
+    },
+)
+async def delete_entry(
+    collection_id: UUID,
+    entry_id: UUID,
+    current_user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    try:
+        await service_manager.execute_service(
+            "card_catalog.collection.delete_entry",
+            collection_id=collection_id,
+            entry_id=entry_id,
+            user=current_user,
+        )
+    except CollectionNotFoundError:
+        raise HTTPException(status_code=404, detail="Entry not found")

--- a/src/automana/api/routers/mtg/set_reference.py
+++ b/src/automana/api/routers/mtg/set_reference.py
@@ -1,56 +1,95 @@
-﻿from dataclasses import dataclass
-from  datetime import datetime
-from fastapi import APIRouter, File, Query, Depends, HTTPException, Response, UploadFile, UploadFile, logger, status
-from typing import Any, Callable, Dict, List, Annotated, Optional
-import tempfile, os, logging
-
-import ijson
-from automana.api.dependancies.service_deps import ServiceManagerDep
-from automana.api.schemas.StandardisedQueryResponse import (    ApiResponse
-                                                                ,PaginatedResponse
-                                                                ,ErrorResponse
-                                                                ,PaginationInfo)
+import logging
+from fastapi import APIRouter, Query, Depends, HTTPException, Response, status
+from typing import List, Optional
 from uuid import UUID
-logger = logging.getLogger(__name__)
+
+from automana.api.dependancies.service_deps import ServiceManagerDep
+from automana.api.schemas.StandardisedQueryResponse import (
+    ApiResponse,
+    PaginatedResponse,
+    ErrorResponse,
+    PaginationInfo,
+)
 from automana.core.models.card_catalog.set import NewSet, NewSets, UpdatedSet
 
+logger = logging.getLogger(__name__)
+
+_SET_ERRORS = {
+    422: {"description": "Validation error — malformed or missing fields"},
+    500: {"description": "Internal server error", "model": ErrorResponse},
+}
+
 router = APIRouter(
-        prefix="/set-reference",
-        tags=['sets'], 
-        responses={
-            404: {'description': 'Not found', 'model': ErrorResponse},
-            500: {'description': 'Internal server error', 'model': ErrorResponse}
-        }
+    prefix="/set-reference",
+    tags=["Card Catalogue"],
+    responses={
+        404: {"description": "Not found", "model": ErrorResponse},
+        500: {"description": "Internal server error", "model": ErrorResponse},
+    },
 )
 
-@router.get('/{set_id}', response_model=ApiResponse)
-async def get_set(set_id: UUID
-                  , service_manager: ServiceManagerDep):
+
+@router.get(
+    '/{set_id}',
+    summary="Get a set by its UUID",
+    description=(
+        "Returns the full details of the MTG set identified by `set_id`. "
+        "Raises 404 if the set does not exist."
+    ),
+    response_model=ApiResponse,
+    operation_id="sets_get_by_id",
+    responses={
+        404: {"description": "Set not found"},
+        **_SET_ERRORS,
+    },
+)
+async def get_set(
+    set_id: UUID,
+    service_manager: ServiceManagerDep,
+):
     try:
-        result = await service_manager.execute_service("card_catalog.set.get", set_id=set_id)
+        result = await service_manager.execute_service(
+            "card_catalog.set.get",
+            set_id=set_id,
+        )
         if result is None:
             raise HTTPException(status_code=404, detail="Set not found")
-        
         return ApiResponse(
             success=True,
             data=result,
-            message="Set retrieved successfully"
+            message="Set retrieved successfully",
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@router.get('/')
-async def get_sets(
-                    service_manager: ServiceManagerDep,
-                    limit: int = Query(default=100, le=100, ge=1),
-                    offset: int = Query(default=0, ge=0),
-                    ids: Optional[List[str]] = Query(default=None, title='Optional set_ids')
-                    ):
+
+@router.get(
+    '/',
+    summary="List sets (paginated)",
+    description=(
+        "Returns a paginated list of MTG sets. Optionally accepts a list of "
+        "`ids` (set code strings) to filter results to specific sets. "
+        "Supports `limit` (max 100) and `offset` for pagination."
+    ),
+    response_model=PaginatedResponse,
+    operation_id="sets_list",
+    responses=_SET_ERRORS,
+)
+async def list_sets(
+    service_manager: ServiceManagerDep,
+    limit: int = Query(default=100, le=100, ge=1, description="Maximum number of sets to return (1–100)"),
+    offset: int = Query(default=0, ge=0, description="Number of sets to skip"),
+    ids: Optional[List[str]] = Query(default=None, description="Optional list of set codes to filter by"),
+):
     try:
-        result = await service_manager.execute_service("card_catalog.set.get_all"
-                                                       , limit=limit
-                                                       , offset=offset
-                                                       , ids=ids)
+        result = await service_manager.execute_service(
+            "card_catalog.set.get_all",
+            limit=limit,
+            offset=offset,
+            ids=ids,
+        )
         return PaginatedResponse(
             success=True,
             data=result,
@@ -60,69 +99,132 @@ async def get_sets(
                 offset=offset,
                 total_count=len(result),
                 has_next=len(result) > limit,
-                has_previous=offset > 0
-            )
+                has_previous=offset > 0,
+            ),
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
-
-@router.delete('/{set_id}'
-               , status_code=status.HTTP_204_NO_CONTENT
-               , description='Delete a set by its ID')
-async def delete_set(
-                    set_id : UUID
-                    , service_manager: ServiceManagerDep
-                    ):
-    try:
-        await service_manager.execute_service(
-            "card_catalog.set.delete",
-            set_id=set_id
-        )   
-    except HTTPException:
-        raise
-    except Exception:
-        raise
-
-@router.post('/', description='An endpoint to add a new set', status_code=status.HTTP_201_CREATED)
-async def insert_set(new_set : NewSet
-                     , service_manager: ServiceManagerDep):
+@router.post(
+    '/',
+    summary="Insert a new set",
+    description=(
+        "Adds a new MTG set to the reference catalogue. The set must not already "
+        "exist (unique set code). Returns 201 Created on success."
+    ),
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="sets_create",
+    responses={
+        409: {"description": "Set with this code already exists"},
+        **_SET_ERRORS,
+    },
+)
+async def insert_set(
+    new_set: NewSet,
+    service_manager: ServiceManagerDep,
+):
     try:
         await service_manager.execute_service(
             "card_catalog.set.add",
-            new_set=new_set
-        )
-    except HTTPException:
-        raise
-    except Exception:
-        raise
-  
-@router.post('/bulk', description='An endpoint to add multiple sets to the database', status_code=status.HTTP_201_CREATED)
-async def insert_sets(sets : NewSets
-                      , service_manager: ServiceManagerDep):
-    try:
-        await service_manager.execute_service(
-            "card_catalog.set.create_bulk",
-            sets=sets
+            new_set=new_set,
         )
     except HTTPException:
         raise
     except Exception:
         raise
 
-@router.put('/{set_id}')
+
+@router.post(
+    '/bulk',
+    summary="Bulk-insert multiple sets",
+    description=(
+        "Inserts multiple MTG sets into the reference catalogue in a single request. "
+        "Useful for seeding the database from external data sources. "
+        "Returns 201 Created on success."
+    ),
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="sets_bulk_create",
+    responses={
+        400: {"description": "Empty sets list provided"},
+        **_SET_ERRORS,
+    },
+)
+async def bulk_insert_sets(
+    sets: NewSets,
+    service_manager: ServiceManagerDep,
+):
+    try:
+        await service_manager.execute_service(
+            "card_catalog.set.create_bulk",
+            sets=sets,
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        raise
+
+
+@router.put(
+    '/{set_id}',
+    summary="Update a set",
+    description=(
+        "Updates the fields of the MTG set identified by `set_id`. "
+        "Partial updates are supported — only provided fields are changed. "
+        "Returns 204 No Content on success."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="sets_update",
+    responses={
+        404: {"description": "Set not found"},
+        **_SET_ERRORS,
+    },
+)
 async def update_set(
-                    set_id  : UUID, 
-                    update_set : UpdatedSet,
-                    service_manager: ServiceManagerDep):
+    set_id: UUID,
+    update_set: UpdatedSet,
+    service_manager: ServiceManagerDep,
+):
     try:
         await service_manager.execute_service(
             "card_catalog.set.update",
             set_id=set_id,
-            update_set=update_set
+            update_set=update_set,
         )
         return Response(status_code=status.HTTP_204_NO_CONTENT)
+    except HTTPException:
+        raise
+    except Exception:
+        raise
+
+
+@router.delete(
+    '/{set_id}',
+    summary="Delete a set by its UUID",
+    description=(
+        "Permanently removes the MTG set identified by `set_id` from the "
+        "reference catalogue. Returns 204 No Content on success."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="sets_delete",
+    responses={
+        404: {"description": "Set not found"},
+        **_SET_ERRORS,
+    },
+)
+async def delete_set(
+    set_id: UUID,
+    service_manager: ServiceManagerDep,
+):
+    try:
+        await service_manager.execute_service(
+            "card_catalog.set.delete",
+            set_id=set_id,
+        )
     except HTTPException:
         raise
     except Exception:

--- a/src/automana/api/routers/users/__init__.py
+++ b/src/automana/api/routers/users/__init__.py
@@ -1,9 +1,11 @@
-﻿from fastapi import APIRouter
+from fastapi import APIRouter
 from automana.api.routers.users.auth import authentification_router
 from automana.api.routers.users.session import session_router
 from automana.api.routers.users.users import router as users_router
 
-user_router = APIRouter(prefix="/users", tags=["Users"])
+# No tags here — each child router declares its own canonical tag so Swagger
+# groups them cleanly without accumulating duplicate tag labels.
+user_router = APIRouter(prefix="/users")
 
 user_router.include_router(authentification_router)
 user_router.include_router(session_router)

--- a/src/automana/api/routers/users/auth.py
+++ b/src/automana/api/routers/users/auth.py
@@ -1,4 +1,4 @@
-﻿from fastapi import APIRouter, Response, Depends, HTTPException, Request
+from fastapi import APIRouter, Response, Depends, HTTPException, Request
 from typing import Annotated
 
 from fastapi.responses import JSONResponse
@@ -6,6 +6,7 @@ from automana.api.dependancies.general import ipDep
 from fastapi.security import OAuth2PasswordRequestForm
 from automana.api.schemas.auth.token import Token, TokenResponse
 from automana.api.dependancies.service_deps import ServiceManagerDep
+from automana.api.schemas.StandardisedQueryResponse import ErrorResponse
 from automana.core.settings import get_settings
 import logging
 
@@ -13,67 +14,61 @@ logger = logging.getLogger(__name__)
 
 authentification_router = APIRouter(
     prefix='/auth',
-    tags=['authentificate'])
+    tags=['Auth'],
+)
 
-@authentification_router.post('/logout'
-                              , status_code=204
-                              , description='remove a refresh token')
-async def logout(ip_address : ipDep
-                ,response : Response
-                 ,request : Request
-                 ,service_manager: ServiceManagerDep
-                 ):
-    session_id = request.cookies.get("session_id")
-    if session_id:
-        returned = await service_manager.execute_service('auth.auth.logout'
-                                                         , session_id=session_id
-                                                         , ip_address=ip_address)
-        if returned.get("status") == "error":
-            logger.warning(f"Logout failed for session {session_id}: {returned.get('message')}")
-    response.delete_cookie('session_id')
-    return None
+_AUTH_ERRORS = {
+    422: {"description": "Validation error — missing or malformed request fields"},
+    500: {"description": "Internal server error", "model": ErrorResponse},
+}
 
-   
-@authentification_router.post('/token/refresh', description='exanges the refresh token in a cookie for a auth token')
-async def do_read_cookie(ip_address: ipDep, 
-                        response: Response, 
-                        request: Request,
-                        service_manager: ServiceManagerDep):
-    return await service_manager.execute_service('auth.cookie.read_cookie'
-                                                 , ip_address=ip_address
-                                                 , response=response
-                                                 , request=request)
 
-@authentification_router.post('/token'
-                              , description='Using an authorization form, authentificate a user against the database and return a bearer token and a cookie with a refresh token'
-                              , response_model=TokenResponse)
-async def do_login(ip_address : ipDep
-                   , request: Request
-                    , service_manager: ServiceManagerDep
-                   , form_data:Annotated[OAuth2PasswordRequestForm, Depends()]
-
-                   ) :
-    #check if active session exists
-    result = await service_manager.execute_service("auth.auth.login"
-                                             , username=form_data.username
-                                             , password=form_data.password
-                                             , ip_address=ip_address
-                                             , user_agent=request.headers.get("User-Agent"))
+@authentification_router.post(
+    '/token',
+    summary="Log in and obtain access and refresh tokens",
+    description=(
+        "Authenticates a user with username/password via an OAuth2 password form. "
+        "On success, returns a JSON payload containing `access_token` (use as "
+        "`Authorization: Bearer <token>` for API callers) and sets an `httponly` "
+        "`session_id` cookie for browser-based clients. "
+        "The `secure` cookie flag is enabled in all non-`dev` environments."
+    ),
+    response_model=TokenResponse,
+    response_model_exclude_unset=True,
+    status_code=200,
+    operation_id="auth_login",
+    responses={
+        401: {"description": "Invalid credentials"},
+        **_AUTH_ERRORS,
+    },
+)
+async def login(
+    ip_address: ipDep,
+    request: Request,
+    service_manager: ServiceManagerDep,
+    form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
+):
+    result = await service_manager.execute_service(
+        "auth.auth.login",
+        username=form_data.username,
+        password=form_data.password,
+        ip_address=ip_address,
+        user_agent=request.headers.get("User-Agent"),
+    )
     if result is None:
-        raise HTTPException(status_code=401, detail='Invalid credentials')
-    
-    # Return the token
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+
     token_response = TokenResponse(
         access_token=result["access_token"],
         refresh_token=result["refresh_token"],
         token_type="bearer",
-        expires_in=3600
+        expires_in=3600,
     )
     json_response = JSONResponse(
-            content=token_response.model_dump(),
-            status_code=200
-        )
-    
+        content=token_response.model_dump(),
+        status_code=200,
+    )
+
     # Secure flag requires HTTPS — dev runs over plain HTTP so the browser
     # would silently drop Secure cookies. All other envs (staging, prod) sit
     # behind the nginx TLS terminator and must have Secure on.
@@ -85,9 +80,74 @@ async def do_login(ip_address : ipDep
             httponly=True,
             secure=secure_cookies,
             samesite="strict",
-            max_age=60*60*24*7,
+            max_age=60 * 60 * 24 * 7,
         )
     return json_response
-   
 
 
+@authentification_router.post(
+    '/token/refresh',
+    summary="Refresh the access token using the session cookie",
+    description=(
+        "Exchanges the `session_id` cookie (containing the refresh token) for a "
+        "new access token. The cookie must be present and valid. "
+        "Returns a new `TokenResponse` with an updated `access_token`."
+    ),
+    response_model=TokenResponse,
+    response_model_exclude_unset=True,
+    operation_id="auth_refresh_token",
+    responses={
+        401: {"description": "Missing or invalid session cookie / refresh token expired"},
+        **_AUTH_ERRORS,
+    },
+)
+async def refresh_token(
+    ip_address: ipDep,
+    response: Response,
+    request: Request,
+    service_manager: ServiceManagerDep,
+):
+    return await service_manager.execute_service(
+        'auth.cookie.read_cookie',
+        ip_address=ip_address,
+        response=response,
+        request=request,
+    )
+
+
+@authentification_router.post(
+    '/logout',
+    summary="Log out and invalidate the current session",
+    description=(
+        "Clears the `session_id` cookie and marks the session as inactive in the "
+        "database. If no session cookie is present the endpoint still returns 204 "
+        "(idempotent). Errors during server-side invalidation are logged but do not "
+        "prevent the cookie from being cleared."
+    ),
+    status_code=204,
+    operation_id="auth_logout",
+    responses={
+        204: {"description": "Session cleared successfully (or no active session found)"},
+        **_AUTH_ERRORS,
+    },
+)
+async def logout(
+    ip_address: ipDep,
+    response: Response,
+    request: Request,
+    service_manager: ServiceManagerDep,
+):
+    session_id = request.cookies.get("session_id")
+    if session_id:
+        returned = await service_manager.execute_service(
+            'auth.auth.logout',
+            session_id=session_id,
+            ip_address=ip_address,
+        )
+        if returned.get("status") == "error":
+            logger.warning(
+                "logout_failed",
+                extra={"session_id": session_id, "reason": returned.get("message")},
+            )
+    response.delete_cookie('session_id')
+    return None

--- a/src/automana/api/routers/users/session.py
+++ b/src/automana/api/routers/users/session.py
@@ -1,8 +1,7 @@
-﻿from fastapi import APIRouter, Depends,  HTTPException, Request, Response, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from uuid import UUID
 from automana.api.dependancies.service_deps import ServiceManagerDep
-from automana.api.dependancies.general import ipDep
-from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse,PaginationInfo
+from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo, ErrorResponse
 
 from automana.api.dependancies.query_deps import (
     session_search_params,
@@ -11,73 +10,128 @@ from automana.api.dependancies.query_deps import (
     date_range_params,
     PaginationParams,
     SortParams,
-    DateRangeParams
+    DateRangeParams,
 )
 
 session_router = APIRouter(
     prefix='/session',
-    tags=['sessions']
+    tags=['Sessions'],
 )
 
-@session_router.get('/{session_id}', response_model= ApiResponse)
-async def get_sessions(session_id : UUID
-                       , service_manager: ServiceManagerDep):
+_SESSION_ERRORS = {
+    401: {"description": "Not authenticated", "model": ErrorResponse},
+    403: {"description": "Insufficient permissions", "model": ErrorResponse},
+    500: {"description": "Internal server error", "model": ErrorResponse},
+}
+
+
+@session_router.get(
+    '/{session_id}',
+    summary="Retrieve a session by ID",
+    description=(
+        "Returns metadata for a single session identified by its UUID. "
+        "If the session does not exist, an empty `data` field is returned "
+        "with a descriptive message rather than a 404."
+    ),
+    response_model=ApiResponse,
+    operation_id="sessions_get_by_id",
+    responses={
+        404: {"description": "Session not found"},
+        **_SESSION_ERRORS,
+    },
+)
+async def get_session(
+    session_id: UUID,
+    service_manager: ServiceManagerDep,
+):
     try:
-        result =  await service_manager.execute_service(
+        result = await service_manager.execute_service(
             "auth.session.read",
-            session_id=session_id
+            session_id=session_id,
         )
         if not result:
             return ApiResponse(data=result, message="Session not found")
         return ApiResponse(data=result, message="Session retrieved successfully")
     except HTTPException:
-        raise 
+        raise
     except Exception:
         raise
 
-@session_router.get('/', response_model=PaginatedResponse,status_code=status.HTTP_200_OK)
-async def get_sessions(
-                        service_manager: ServiceManagerDep,
-                       search_params: dict = Depends(session_search_params),
-                       pagination: PaginationParams = Depends(pagination_params),
-                       sorting: SortParams = Depends(sort_params),
-                       date_range: DateRangeParams = Depends(date_range_params),
-                       
-                       ):
+
+@session_router.get(
+    '/',
+    summary="Search and list sessions (paginated)",
+    description=(
+        "Returns a paginated list of sessions filtered by the provided query "
+        "parameters. Supports searching by user, status, date range, and common "
+        "sort/pagination controls. Returns 404 when no sessions match the filter."
+    ),
+    response_model=PaginatedResponse,
+    status_code=status.HTTP_200_OK,
+    operation_id="sessions_list",
+    responses={
+        404: {"description": "No sessions match the provided filters"},
+        **_SESSION_ERRORS,
+    },
+)
+async def list_sessions(
+    service_manager: ServiceManagerDep,
+    search_params: dict = Depends(session_search_params),
+    pagination: PaginationParams = Depends(pagination_params),
+    sorting: SortParams = Depends(sort_params),
+    date_range: DateRangeParams = Depends(date_range_params),
+):
     try:
         results = await service_manager.execute_service(
             "auth.session.search_sessions",
             search_params=search_params,
             pagination=pagination,
             sorting=sorting,
-            date_range=date_range
+            date_range=date_range,
         )
         if results:
-            return PaginatedResponse(data=results
-                                     , message="Sessions retrieved successfully"
-                                     , pagination_info=PaginationInfo(
-                                         limit=pagination.limit,
-                                         offset=pagination.offset,
-                                         total_count=len(results),
-                                         has_next=len(results) == pagination.limit,
-                                         has_previous=pagination.offset > 0
-                                     ))
+            return PaginatedResponse(
+                data=results,
+                message="Sessions retrieved successfully",
+                pagination_info=PaginationInfo(
+                    limit=pagination.limit,
+                    offset=pagination.offset,
+                    total_count=len(results),
+                    has_next=len(results) == pagination.limit,
+                    has_previous=pagination.offset > 0,
+                ),
+            )
         else:
             raise HTTPException(status_code=404, detail="No sessions found")
     except HTTPException:
         raise
-    except Exception: 
+    except Exception:
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@session_router.delete('/{session_id}/desactivate', status_code=status.HTTP_204_NO_CONTENT)
-async def delete_session( 
-                           session_id : UUID
-                         ,service_manager: ServiceManagerDep):
+@session_router.delete(
+    '/{session_id}/deactivate',
+    summary="Deactivate a session",
+    description=(
+        "Marks the specified session as inactive, effectively invalidating it. "
+        "This is distinct from logout — the session record is retained for audit "
+        "purposes. Returns 204 No Content on success."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="sessions_deactivate",
+    responses={
+        404: {"description": "Session not found"},
+        **_SESSION_ERRORS,
+    },
+)
+async def deactivate_session(
+    session_id: UUID,
+    service_manager: ServiceManagerDep,
+):
     try:
         await service_manager.execute_service(
             "auth.session.delete",
-            session_id=session_id
+            session_id=session_id,
         )
     except HTTPException:
         raise

--- a/src/automana/api/routers/users/users.py
+++ b/src/automana/api/routers/users/users.py
@@ -1,38 +1,72 @@
-
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
-from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo
+from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo, ErrorResponse
 from automana.api.schemas.user_management.user import BaseUser, UserPublic, UserUpdatePublic, UserInDB
 from automana.api.dependancies.service_deps import ServiceManagerDep
 from automana.api.dependancies.auth.users import CurrentUserDep
 from automana.api.schemas.user_management.role import AssignRoleRequest, Role
-from automana.api.dependancies.query_deps import (sort_params,
-                                                   user_search_params,
-                                                   pagination_params,
-                                                   PaginationParams,
-                                                   SortParams)
+from automana.api.dependancies.query_deps import (
+    sort_params,
+    user_search_params,
+    pagination_params,
+    PaginationParams,
+    SortParams,
+)
 import logging
 
 logger = logging.getLogger(__name__)
 
+_USER_ERRORS = {
+    401: {"description": "Not authenticated", "model": ErrorResponse},
+    403: {"description": "Insufficient permissions", "model": ErrorResponse},
+    422: {"description": "Validation error — malformed or missing fields"},
+    500: {"description": "Internal server error", "model": ErrorResponse},
+}
+
 router = APIRouter(
-    prefix='/users',
-    tags=['users'],
-    responses={404: {'description': 'Not found'}}
+    prefix='',
+    tags=['Users'],
+    responses={404: {'description': 'Not found'}},
 )
 
 
-@router.get('/me', response_model=UserPublic)
-async def get_me_user(current_user: CurrentUserDep):
+@router.get(
+    '/me',
+    summary="Get the currently authenticated user",
+    description=(
+        "Returns the profile of the user identified by the `session_id` cookie. "
+        "Requires an active session. The response excludes sensitive fields such as "
+        "`hashed_password`."
+    ),
+    response_model=UserPublic,
+    response_model_exclude_unset=True,
+    operation_id="users_get_me",
+    responses={
+        401: {"description": "Not authenticated — missing or expired session cookie", "model": ErrorResponse},
+        **{k: v for k, v in _USER_ERRORS.items() if k not in (401,)},
+    },
+)
+async def get_me(current_user: CurrentUserDep):
     return current_user
 
 
-@router.get('/', response_model=PaginatedResponse[UserInDB])
-async def get_users(
+@router.get(
+    '/',
+    summary="Search and list users (paginated)",
+    description=(
+        "Returns a paginated list of users. Supports filtering by username, email, "
+        "or other search fields, plus common sort and pagination controls. "
+        "Intended for admin use."
+    ),
+    response_model=PaginatedResponse[UserInDB],
+    operation_id="users_list",
+    responses=_USER_ERRORS,
+)
+async def list_users(
     service_manager: ServiceManagerDep,
     pagination: PaginationParams = Depends(pagination_params),
     sorting: SortParams = Depends(sort_params),
-    search: dict = Depends(user_search_params)
+    search: dict = Depends(user_search_params),
 ):
     try:
         result = await service_manager.execute_service(
@@ -64,8 +98,23 @@ async def get_users(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@router.post('/')
-async def add_user(user: BaseUser, service_manager: ServiceManagerDep):
+@router.post(
+    '/',
+    summary="Register a new user",
+    description=(
+        "Creates a new user account. The `hashed_password` field must be provided "
+        "pre-hashed by the caller. Returns the newly created user record wrapped in "
+        "an `ApiResponse` envelope."
+    ),
+    response_model=ApiResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="users_register",
+    responses={
+        409: {"description": "Username or email already exists"},
+        **_USER_ERRORS,
+    },
+)
+async def register_user(user: BaseUser, service_manager: ServiceManagerDep):
     try:
         result = await service_manager.execute_service("auth.auth.register", user=user)
         return ApiResponse(data=result)
@@ -76,8 +125,22 @@ async def add_user(user: BaseUser, service_manager: ServiceManagerDep):
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@router.put('/')
-async def modify_user(
+@router.put(
+    '/',
+    summary="Update the currently authenticated user",
+    description=(
+        "Updates mutable profile fields (`username`, `email`, `fullname`) for the "
+        "user identified by the active session cookie. Partial updates are supported "
+        "— only provided fields are changed."
+    ),
+    response_model=ApiResponse,
+    operation_id="users_update_me",
+    responses={
+        401: {"description": "Not authenticated", "model": ErrorResponse},
+        **_USER_ERRORS,
+    },
+)
+async def update_user(
     user_update: UserUpdatePublic,
     service_manager: ServiceManagerDep,
     current_user: CurrentUserDep,
@@ -96,11 +159,23 @@ async def modify_user(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@router.delete('/{user_id}', status_code=204)
+@router.delete(
+    '/{user_id}',
+    summary="Delete a user by ID",
+    description=(
+        "Permanently deletes the user account identified by `user_id`. "
+        "This action is irreversible. Returns 204 No Content on success."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="users_delete",
+    responses={
+        404: {"description": "User not found"},
+        **_USER_ERRORS,
+    },
+)
 async def delete_user(user_id: UUID, service_manager: ServiceManagerDep):
     try:
         await service_manager.execute_service("user_management.user.delete", user_id=user_id)
-        return ApiResponse(data=None)
     except HTTPException:
         raise
     except Exception as e:
@@ -108,7 +183,23 @@ async def delete_user(user_id: UUID, service_manager: ServiceManagerDep):
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@router.post('/{user_id}/roles', status_code=status.HTTP_201_CREATED)
+@router.post(
+    '/{user_id}/roles',
+    summary="Assign a role to a user",
+    description=(
+        "Grants the specified role to the target user. The caller must be "
+        "authenticated and have sufficient privileges (typically `admin`). "
+        "The role assignment can optionally include an expiry date and an "
+        "effective-from date."
+    ),
+    status_code=status.HTTP_201_CREATED,
+    operation_id="users_assign_role",
+    responses={
+        404: {"description": "User not found"},
+        409: {"description": "Role already assigned to this user"},
+        **_USER_ERRORS,
+    },
+)
 async def assign_role(
     user_id: UUID,
     role: AssignRoleRequest,
@@ -129,7 +220,21 @@ async def assign_role(
         raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
-@router.delete('/{user_id}/roles/{role_name}', status_code=status.HTTP_204_NO_CONTENT)
+@router.delete(
+    '/{user_id}/roles/{role_name}',
+    summary="Revoke a role from a user",
+    description=(
+        "Removes the specified role from the target user. The caller must be "
+        "authenticated and have sufficient privileges. Returns 204 No Content "
+        "on success."
+    ),
+    status_code=status.HTTP_204_NO_CONTENT,
+    operation_id="users_revoke_role",
+    responses={
+        404: {"description": "User or role assignment not found"},
+        **_USER_ERRORS,
+    },
+)
 async def revoke_role(
     user_id: UUID,
     role_name: Role,

--- a/src/automana/core/models/card_catalog/card.py
+++ b/src/automana/core/models/card_catalog/card.py
@@ -332,7 +332,9 @@ class CardSuggestion(BaseModel):
     card_version_id: UUID
     card_name: str
     set_code: str
+    collector_number: str
     rarity_name: str
+    scryfall_id: Optional[str] = None
     score: float
 
 

--- a/src/automana/core/models/collections/collection.py
+++ b/src/automana/core/models/collections/collection.py
@@ -2,24 +2,18 @@ from pydantic import BaseModel, Field, field_validator
 from enum import Enum
 from typing import Optional
 from datetime import date, datetime
+from decimal import Decimal
 from uuid import UUID, uuid4
 
 ### Collections schemas
 
 class PublicCollection(BaseModel):
-    username : str = Field(
-        title='The collection owner',
-    )
-    description : str=Field(
-        title='The description of the collection'
-    )
-    collection_name : str=Field(
-        title='The name of the collection'
-    )
-    
-    is_active : bool=Field(
-        default=True, title='Has the collection been deleted'
-    )
+    collection_id: UUID = Field(title='The unique collection ID')
+    username: str = Field(title='The collection owner')
+    description: str = Field(title='The description of the collection')
+    collection_name: str = Field(title='The name of the collection')
+    created_at: datetime = Field(title='The date the collection was created')
+    is_active: bool = Field(default=True, title='Has the collection been deleted')
 
 class CreateCollection(BaseModel):
     collection_name : str=Field(
@@ -32,24 +26,12 @@ class CreateCollection(BaseModel):
     )
 
 class CollectionInDB(BaseModel):
-    collection_id : UUID=Field(
-        title='The unique secret collection id'
-    )
-    collection_name : str=Field(
-        title='The name of the collection'
-    )
-    description : str=Field(
-        title='The description of the collection'
-    )
-    user_id : str=Field(
-        title='The secret user id'
-    )
-    created_at : datetime=Field(
-        title='The date of the collection creation'
-    )
-    is_active : bool=Field(
-        default=True, title='Has the collection been deleted'
-    )
+    collection_id: UUID = Field(title='The unique secret collection id')
+    collection_name: str = Field(title='The name of the collection')
+    description: str = Field(title='The description of the collection')
+    user_id: UUID = Field(title='The secret user id')
+    created_at: datetime = Field(title='The date of the collection creation')
+    is_active: bool = Field(default=True, title='Has the collection been deleted')
 
 class UpdateCollection(BaseModel):
     collection_name : str | None=Field(
@@ -62,33 +44,34 @@ class UpdateCollection(BaseModel):
     )
     is_active : bool | None=None
 
-class Conditions(Enum):
-    D = 'D'
-    G = 'G'
-    LP = 'LP'
+class Conditions(str, Enum):
     NM = 'NM'
-    Grd = 'Grd'
+    LP = 'LP'
+    MP = 'MP'
+    HP = 'HP'
+    DMG = 'DMG'
+    SP = 'SP'
 
 class PublicCollectionEntry(BaseModel):
-    unique_card_id : UUID=Field(title='The card version ID')
-    is_foil : bool=Field(
-        default=False, title='Is the card foil'
-    )
-    purchase_date : date = Field(default_factory=date.today)
-    purchase_price : float = Field(ge=0)
-    condition : Conditions = Field(
-        default='NM', title='The condition of the card, must be one of NM (near Mint), Grd (graded), G (good), D(Damaged)' 
-    )
+    unique_card_id: UUID = Field(title='The card version ID')
+    is_foil: bool = Field(default=False, title='Is the card foil')
+    purchase_date: date = Field(default_factory=date.today)
+    purchase_price: Decimal = Field(ge=0, decimal_places=2)
+    condition: Conditions = Field(default=Conditions.NM, title='Card condition')
+    currency_code: str = Field(default='USD', max_length=3, title='Purchase currency')
+    language_id: Optional[int] = Field(default=None, title='Card language (language_id from card_catalog.language_ref)')
 
 class NewCollectionEntry(PublicCollectionEntry):
-    collection_id : UUID=Field(title='The collection ID')
-   
+    collection_id: UUID = Field(title='The collection ID')
+
 class CollectionEntryInDB(NewCollectionEntry):
-    item_id : UUID
+    item_id: UUID
 
 class UpdateCollectionEntry(BaseModel):
-    is_foil : Optional[bool] =None
-    purchase_date : Optional[date] = None
-    purchase_price : Optional[float] = None
-    condition : Optional[Conditions] = None
+    is_foil: Optional[bool] = None
+    purchase_date: Optional[date] = None
+    purchase_price: Optional[Decimal] = None
+    condition: Optional[Conditions] = None
+    currency_code: Optional[str] = Field(default=None, max_length=3)
+    language_id: Optional[int] = None
    

--- a/src/automana/core/models/collections/collection.py
+++ b/src/automana/core/models/collections/collection.py
@@ -1,9 +1,9 @@
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from enum import Enum
 from typing import Optional
 from datetime import date, datetime
 from decimal import Decimal
-from uuid import UUID, uuid4
+from uuid import UUID
 
 ### Collections schemas
 
@@ -52,26 +52,75 @@ class Conditions(str, Enum):
     DMG = 'DMG'
     SP = 'SP'
 
-class PublicCollectionEntry(BaseModel):
-    unique_card_id: UUID = Field(title='The card version ID')
-    is_foil: bool = Field(default=False, title='Is the card foil')
-    purchase_date: date = Field(default_factory=date.today)
+
+class Finish(str, Enum):
+    NONFOIL = 'NONFOIL'
+    FOIL = 'FOIL'
+    ETCHED = 'ETCHED'
+
+
+class AddCollectionEntryRequest(BaseModel):
+    """
+    Identifies a card version by one of three strategies, then attaches entry metadata.
+    Exactly one identifier group must be provided.
+    """
+    # --- identifier (one of the three must be set) ---
+    card_version_id: Optional[UUID] = Field(default=None, description="Internal card_version_id (returned by /suggest)")
+    scryfall_id: Optional[str] = Field(default=None, description="Scryfall UUID for the printing")
+    set_code: Optional[str] = Field(default=None, max_length=10, description="Set code (e.g. 'dmu'), use with collector_number")
+    collector_number: Optional[str] = Field(default=None, max_length=50, description="Collector number (e.g. '108'), use with set_code")
+
+    # --- entry metadata ---
+    condition: Conditions = Field(default=Conditions.NM)
+    finish: Finish = Field(default=Finish.NONFOIL)
     purchase_price: Decimal = Field(ge=0, decimal_places=2)
-    condition: Conditions = Field(default=Conditions.NM, title='Card condition')
-    currency_code: str = Field(default='USD', max_length=3, title='Purchase currency')
-    language_id: Optional[int] = Field(default=None, title='Card language (language_id from card_catalog.language_ref)')
+    currency_code: str = Field(default='USD', max_length=3)
+    purchase_date: date = Field(default_factory=date.today)
+    language_id: Optional[int] = Field(default=None)
 
-class NewCollectionEntry(PublicCollectionEntry):
-    collection_id: UUID = Field(title='The collection ID')
+    @model_validator(mode='after')
+    def check_identifier(self) -> 'AddCollectionEntryRequest':
+        has_internal = self.card_version_id is not None
+        has_scryfall = self.scryfall_id is not None
+        has_tuple = self.set_code is not None and self.collector_number is not None
+        if not (has_internal or has_scryfall or has_tuple):
+            raise ValueError(
+                "Provide one of: card_version_id, scryfall_id, or set_code+collector_number"
+            )
+        return self
 
-class CollectionEntryInDB(NewCollectionEntry):
+
+class PublicCollectionEntry(BaseModel):
     item_id: UUID
+    card_version_id: UUID
+    card_name: str
+    set_code: str
+    collector_number: str
+    finish: Finish
+    purchase_date: date
+    purchase_price: Decimal
+    condition: Conditions
+    currency_code: str
+    language_id: Optional[int] = None
+
 
 class UpdateCollectionEntry(BaseModel):
-    is_foil: Optional[bool] = None
+    finish: Optional[Finish] = None
     purchase_date: Optional[date] = None
     purchase_price: Optional[Decimal] = None
     condition: Optional[Conditions] = None
     currency_code: Optional[str] = Field(default=None, max_length=3)
+    language_id: Optional[int] = None
+
+
+class CollectionEntryInDB(BaseModel):
+    item_id: UUID
+    collection_id: UUID
+    card_version_id: UUID
+    finish_id: int
+    purchase_date: date
+    purchase_price: Decimal
+    condition: str
+    currency_code: str
     language_id: Optional[int] = None
    

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -94,22 +94,44 @@ class CardReferenceRepository(AbstractRepository[Any]):
         return result[0] if result else None
 
     async def suggest(self, query: str, limit: int = 10) -> list[dict]:
-        """Return fuzzy name suggestions from the trigram-indexed suggest view.
-
-        Uses pg_trgm ``%`` operator for similarity matching and orders results
-        by descending ``word_similarity`` score. Callers should treat the
-        results as display hints, not authoritative search results.
-        """
         sql = """
-            SELECT card_version_id, card_name, set_code, rarity_name,
-                   word_similarity($1, card_name) AS score
-            FROM card_catalog.v_card_name_suggest
-            WHERE $1 % card_name
+            SELECT v.card_version_id, v.card_name, v.set_code, v.rarity_name,
+                   cv.collector_number,
+                   cei.value AS scryfall_id,
+                   word_similarity($1, v.card_name) AS score
+            FROM card_catalog.v_card_name_suggest v
+            JOIN card_catalog.card_version cv ON cv.card_version_id = v.card_version_id
+            LEFT JOIN card_catalog.card_external_identifier cei
+                ON cei.card_version_id = v.card_version_id AND cei.card_identifier_ref_id = 1
+            WHERE $1 % v.card_name
             ORDER BY score DESC
             LIMIT $2
         """
         rows = await self.execute_query(sql, (query, limit))
         return [dict(r) for r in rows]
+
+    async def get_version_by_scryfall_id(self, scryfall_id: str) -> Optional[dict]:
+        sql = """
+            SELECT cv.card_version_id, uc.card_name, s.set_code, cv.collector_number
+            FROM card_catalog.card_external_identifier cei
+            JOIN card_catalog.card_version cv ON cv.card_version_id = cei.card_version_id
+            JOIN card_catalog.unique_cards_ref uc ON uc.unique_card_id = cv.unique_card_id
+            JOIN card_catalog.sets s ON s.set_id = cv.set_id
+            WHERE cei.card_identifier_ref_id = 1 AND cei.value = $1
+        """
+        rows = await self.execute_query(sql, (scryfall_id,))
+        return dict(rows[0]) if rows else None
+
+    async def get_version_by_set_collector(self, set_code: str, collector_number: str) -> Optional[dict]:
+        sql = """
+            SELECT cv.card_version_id, uc.card_name, s.set_code, cv.collector_number
+            FROM card_catalog.card_version cv
+            JOIN card_catalog.sets s ON s.set_id = cv.set_id
+            JOIN card_catalog.unique_cards_ref uc ON uc.unique_card_id = cv.unique_card_id
+            WHERE s.set_code = $1 AND cv.collector_number = $2
+        """
+        rows = await self.execute_query(sql, (set_code, collector_number))
+        return dict(rows[0]) if rows else None
 
     async def search(
             self,

--- a/src/automana/core/repositories/card_catalog/collection_repository.py
+++ b/src/automana/core/repositories/card_catalog/collection_repository.py
@@ -27,7 +27,7 @@ class CollectionRepository(AbstractRepository):
                   , collection_name:str
                   , description: str
                   , user_id: UUID) -> Optional[dict]:
-        query = "INSERT INTO user_collection.collections (collection_name, description, user_id) VALUES ($1, $2, $3) RETURNING collection_id;"
+        query = "INSERT INTO user_collection.collections (collection_name, description, user_id) VALUES ($1, $2, $3) RETURNING collection_id, collection_name, description, user_id, created_at, is_active;"
         result = await self.execute_query(query, (collection_name, description, user_id))
         return result[0] if result else None
 
@@ -71,4 +71,104 @@ class CollectionRepository(AbstractRepository):
 
     async def list():
         raise NotImplementedError("This method is not implemented yet")
+
+    # ------------------------------------------------------------------
+    # Collection entry methods (all ownership-guarded via collections join)
+    # ------------------------------------------------------------------
+
+    async def add_entry(
+        self,
+        collection_id: UUID,
+        user_id: UUID,
+        card_version_id: UUID,
+        finish_id: int,
+        condition: str,
+        purchase_price,
+        currency_code: str,
+        purchase_date,
+        language_id,
+    ) -> Optional[dict]:
+        query = """
+            INSERT INTO user_collection.collection_items
+                (collection_id, unique_card_id, finish_id, condition,
+                 purchase_price, currency_code, purchase_date, language_id)
+            SELECT $1, $3, $4, $5, $6, $7, $8, $9
+            FROM user_collection.collections
+            WHERE collection_id = $1 AND user_id = $2
+            RETURNING item_id, collection_id, unique_card_id AS card_version_id,
+                      finish_id, condition, purchase_price, currency_code,
+                      purchase_date, language_id;
+        """
+        rows = await self.execute_query(
+            query,
+            (collection_id, user_id, card_version_id, finish_id, condition,
+             purchase_price, currency_code, purchase_date, language_id),
+        )
+        return dict(rows[0]) if rows else None
+
+    async def get_entry(self, item_id: UUID, collection_id: UUID, user_id: UUID) -> Optional[dict]:
+        query = """
+            SELECT ci.item_id,
+                   ci.collection_id,
+                   ci.unique_card_id AS card_version_id,
+                   uc.card_name,
+                   s.set_code,
+                   cv.collector_number,
+                   ci.finish_id,
+                   cf.code AS finish,
+                   ci.condition,
+                   ci.purchase_price,
+                   ci.currency_code,
+                   ci.purchase_date,
+                   ci.language_id
+            FROM user_collection.collection_items ci
+            JOIN user_collection.collections col
+                ON col.collection_id = ci.collection_id AND col.user_id = $3
+            JOIN card_catalog.card_version cv ON cv.card_version_id = ci.unique_card_id
+            JOIN card_catalog.unique_cards_ref uc ON uc.unique_card_id = cv.unique_card_id
+            JOIN card_catalog.sets s ON s.set_id = cv.set_id
+            JOIN pricing.card_finished cf ON cf.finish_id = ci.finish_id
+            WHERE ci.item_id = $1 AND ci.collection_id = $2;
+        """
+        rows = await self.execute_query(query, (item_id, collection_id, user_id))
+        return dict(rows[0]) if rows else None
+
+    async def get_all_entries(self, collection_id: UUID, user_id: UUID) -> List[dict]:
+        query = """
+            SELECT ci.item_id,
+                   ci.collection_id,
+                   ci.unique_card_id AS card_version_id,
+                   uc.card_name,
+                   s.set_code,
+                   cv.collector_number,
+                   ci.finish_id,
+                   cf.code AS finish,
+                   ci.condition,
+                   ci.purchase_price,
+                   ci.currency_code,
+                   ci.purchase_date,
+                   ci.language_id
+            FROM user_collection.collection_items ci
+            JOIN user_collection.collections col
+                ON col.collection_id = ci.collection_id AND col.user_id = $2
+            JOIN card_catalog.card_version cv ON cv.card_version_id = ci.unique_card_id
+            JOIN card_catalog.unique_cards_ref uc ON uc.unique_card_id = cv.unique_card_id
+            JOIN card_catalog.sets s ON s.set_id = cv.set_id
+            JOIN pricing.card_finished cf ON cf.finish_id = ci.finish_id
+            WHERE ci.collection_id = $1;
+        """
+        rows = await self.execute_query(query, (collection_id, user_id))
+        return [dict(r) for r in rows]
+
+    async def delete_entry(self, item_id: UUID, collection_id: UUID, user_id: UUID) -> bool:
+        query = """
+            DELETE FROM user_collection.collection_items ci
+            USING user_collection.collections col
+            WHERE ci.item_id = $1
+              AND ci.collection_id = $2
+              AND col.collection_id = ci.collection_id
+              AND col.user_id = $3;
+        """
+        result = await self.execute_command(query, (item_id, collection_id, user_id))
+        return result != "DELETE 0"
 

--- a/src/automana/core/repositories/card_catalog/collection_repository.py
+++ b/src/automana/core/repositories/card_catalog/collection_repository.py
@@ -13,21 +13,22 @@ class CollectionRepository(AbstractRepository):
         return "CollectionRepository"
     
     async def get(self, collection_id: UUID, user_id: UUID) -> Optional[dict]:
-        query = """ SELECT u.username, c.description, c.collection_name, c.is_active 
-                    FROM user_collection.collections c JOIN user_management.users u 
-                    ON c.user_id = u.unique_id 
+        query = """ SELECT c.collection_id, u.username, c.description, c.collection_name,
+                           c.created_at, c.is_active
+                    FROM user_collection.collections c JOIN user_management.users u
+                    ON c.user_id = u.unique_id
                     WHERE c.user_id = $1
                     AND c.is_active = True
-                    AND c.collection_id =  $2;"""
+                    AND c.collection_id = $2;"""
         result = await self.execute_query(query, (user_id, collection_id))
         return result[0] if result else None
 
     async def add(self
                   , collection_name:str
                   , description: str
-                  , user_id: UUID) -> Optional[UUID]:
-        query = "INSERT INTO user_collection.collections (collection_name, description, user_id) VALUES ($1, $2, $3)  RETURNING collection_id ;"
-        result =await self.execute_command(query, (collection_name, description, user_id))
+                  , user_id: UUID) -> Optional[dict]:
+        query = "INSERT INTO user_collection.collections (collection_name, description, user_id) VALUES ($1, $2, $3) RETURNING collection_id;"
+        result = await self.execute_query(query, (collection_name, description, user_id))
         return result[0] if result else None
 
     async def add_many(self, values: List[CreateCollection]):
@@ -35,20 +36,22 @@ class CollectionRepository(AbstractRepository):
         return await self.execute_command(query, (values.collection_name, values.description,    values.user_id))
 
     async def get_all(self, user_id: UUID) -> List[dict]:
-        query = """ SELECT u.username, c.collection_name, c.is_active
+        query = """ SELECT c.collection_id, c.user_id, u.username, c.collection_name,
+                           c.description, c.created_at, c.is_active
                     FROM user_collection.collections c JOIN user_management.users u
                     ON c.user_id = u.unique_id
                     WHERE c.user_id = $1 AND c.is_active = True;"""
         return await self.execute_query(query, (user_id,))
     
-    async def get_many(self, user,  collection_id :List[UUID]):
-        counter = 1
-        query = f""" SELECT u.username, c.collection_name, c.is_active 
-                    FROM user_collection.collections c JOIN user_management.users u 
-                    ON c.user_id = u.unique_id 
-                    WHERE c.user_id = ${counter} AND c.is_active = True AND c.collection_id IN ({', '.join([f'${counter + i}' for i in range(len(collection_id))])});"""
-        values= (user.unique_id, *collection_id)
-        return await self.execute_query( query, values=values)
+    async def get_many(self, user_id: UUID, collection_id: List[UUID]):
+        placeholders = ', '.join(f'${i + 2}' for i in range(len(collection_id)))
+        query = f""" SELECT c.collection_id, c.user_id, u.username, c.collection_name,
+                           c.description, c.created_at, c.is_active
+                    FROM user_collection.collections c JOIN user_management.users u
+                    ON c.user_id = u.unique_id
+                    WHERE c.user_id = $1 AND c.is_active = True AND c.collection_id IN ({placeholders});"""
+        values = (user_id, *collection_id)
+        return await self.execute_query(query, values=values)
    
         
     async def delete(self, collection_id : UUID, user_id : UUID):
@@ -56,8 +59,9 @@ class CollectionRepository(AbstractRepository):
         return await self.execute_command(query, (collection_id, user_id))
 
     async def delete_many(self, collection_ids: List[UUID], user_id: UUID):
-        query = "UPDATE user_collection.collections SET is_active = False WHERE collection_id IN ($1) AND user_id = $2;"
-        return self.execute_command(query, (collection_ids, user_id))
+        placeholders = ', '.join(f'${i + 2}' for i in range(len(collection_ids)))
+        query = f"UPDATE user_collection.collections SET is_active = False WHERE collection_id IN ({placeholders}) AND user_id = $1;"
+        return await self.execute_command(query, (user_id, *collection_ids))
     
     async def update(self, update_fields, collection_id, user_id):
         counter = 1

--- a/src/automana/core/services/card_catalog/collection_service.py
+++ b/src/automana/core/services/card_catalog/collection_service.py
@@ -1,10 +1,13 @@
 ﻿from automana.core.repositories.card_catalog import collection_repository
 from automana.api.schemas.user_management.user import UserInDB
-from automana.core.models.collections.collection import CreateCollection, PublicCollection, UpdateCollection, CollectionInDB
+from automana.core.models.collections.collection import (
+    CreateCollection, PublicCollection, UpdateCollection, CollectionInDB,
+    AddCollectionEntryRequest, PublicCollectionEntry,
+)
 from automana.core.repositories.card_catalog.collection_repository import CollectionRepository
-from typing import  Optional, List
+from automana.core.repositories.card_catalog.card_repository import CardReferenceRepository
+from typing import Optional, List
 from uuid import UUID
-from automana.api.schemas.StandardisedQueryResponse import ApiResponse
 from automana.core.exceptions.service_layer_exceptions.card_catalogue import card_catalog_exceptions
 from automana.core.service_registry import ServiceRegistry
 import logging
@@ -121,3 +124,126 @@ async def delete_collection(user_collection_repository: CollectionRepository
     except Exception as e:
         raise card_catalog_exceptions.CollectionDeleteError(f"Failed to delete collection: {str(e)}")
     
+
+
+# Finish code → finish_id lookup (pricing.card_finished)
+_FINISH_CODE_TO_ID = {"NONFOIL": 1, "FOIL": 2, "ETCHED": 3}
+
+
+@ServiceRegistry.register(
+    "card_catalog.collection.add_entry",
+    db_repositories=["user_collection", "card"]
+)
+async def add_entry(
+    user_collection_repository: CollectionRepository,
+    card_repository: CardReferenceRepository,
+    collection_id: UUID,
+    user: UserInDB,
+    request: AddCollectionEntryRequest,
+) -> PublicCollectionEntry:
+    # 1. Resolve card_version_id
+    if request.card_version_id:
+        card_version_id = request.card_version_id
+    elif request.scryfall_id:
+        row = await card_repository.get_version_by_scryfall_id(request.scryfall_id)
+        if not row:
+            raise card_catalog_exceptions.CollectionCreationError(
+                f"No card found for scryfall_id={request.scryfall_id}"
+            )
+        card_version_id = row["card_version_id"]
+    else:
+        row = await card_repository.get_version_by_set_collector(
+            request.set_code, request.collector_number
+        )
+        if not row:
+            raise card_catalog_exceptions.CollectionCreationError(
+                f"No card found for {request.set_code}/{request.collector_number}"
+            )
+        card_version_id = row["card_version_id"]
+
+    # 2. Verify collection belongs to user
+    col = await user_collection_repository.get(collection_id, user.unique_id)
+    if not col:
+        raise card_catalog_exceptions.CollectionNotFoundError(
+            f"Collection {collection_id} not found"
+        )
+
+    # 3. Resolve finish_id
+    finish_id = _FINISH_CODE_TO_ID.get(request.finish.value)
+    if finish_id is None:
+        raise card_catalog_exceptions.CollectionCreationError(
+            f"Unknown finish: {request.finish}"
+        )
+
+    # 4. Insert
+    row = await user_collection_repository.add_entry(
+        collection_id=collection_id,
+        user_id=user.unique_id,
+        card_version_id=card_version_id,
+        finish_id=finish_id,
+        condition=request.condition.value,
+        purchase_price=request.purchase_price,
+        currency_code=request.currency_code,
+        purchase_date=request.purchase_date,
+        language_id=request.language_id,
+    )
+    if not row:
+        raise card_catalog_exceptions.CollectionCreationError("Failed to insert entry")
+
+    entry = await user_collection_repository.get_entry(
+        row["item_id"], collection_id, user.unique_id
+    )
+    return PublicCollectionEntry.model_validate(entry)
+
+
+@ServiceRegistry.register(
+    "card_catalog.collection.list_entries",
+    db_repositories=["user_collection"]
+)
+async def list_entries(
+    user_collection_repository: CollectionRepository,
+    collection_id: UUID,
+    user: UserInDB,
+) -> List[PublicCollectionEntry]:
+    col = await user_collection_repository.get(collection_id, user.unique_id)
+    if not col:
+        raise card_catalog_exceptions.CollectionNotFoundError(
+            f"Collection {collection_id} not found"
+        )
+    rows = await user_collection_repository.get_all_entries(collection_id, user.unique_id)
+    return [PublicCollectionEntry.model_validate(r) for r in rows]
+
+
+@ServiceRegistry.register(
+    "card_catalog.collection.get_entry",
+    db_repositories=["user_collection"]
+)
+async def get_entry(
+    user_collection_repository: CollectionRepository,
+    collection_id: UUID,
+    entry_id: UUID,
+    user: UserInDB,
+) -> PublicCollectionEntry:
+    row = await user_collection_repository.get_entry(entry_id, collection_id, user.unique_id)
+    if not row:
+        raise card_catalog_exceptions.CollectionNotFoundError(
+            f"Entry {entry_id} not found"
+        )
+    return PublicCollectionEntry.model_validate(row)
+
+
+@ServiceRegistry.register(
+    "card_catalog.collection.delete_entry",
+    db_repositories=["user_collection"]
+)
+async def delete_entry(
+    user_collection_repository: CollectionRepository,
+    collection_id: UUID,
+    entry_id: UUID,
+    user: UserInDB,
+) -> None:
+    deleted = await user_collection_repository.delete_entry(entry_id, collection_id, user.unique_id)
+    if not deleted:
+        raise card_catalog_exceptions.CollectionNotFoundError(
+            f"Entry {entry_id} not found"
+        )

--- a/src/automana/core/utils/get_hash_password.py
+++ b/src/automana/core/utils/get_hash_password.py
@@ -1,15 +1,5 @@
-from passlib.context import CryptContext
+import bcrypt
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
-def get_hash_password(password: str):
-    """
-    Hashes a plain password using bcrypt.
-
-    Args:
-        password (str): Plaintext password.
-
-    Returns:
-        str: Hashed password.
-    """
-    return pwd_context.hash(password)
+def get_hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode("utf-8"), bcrypt.gensalt()).decode("utf-8")

--- a/src/automana/database/SQL/schemas/04_online_shop.sql
+++ b/src/automana/database/SQL/schemas/04_online_shop.sql
@@ -38,7 +38,7 @@ CREATE TABLE IF NOT EXISTS user_collection.collection_items (
     item_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     collection_id UUID REFERENCES user_collection.collections(collection_id) ON DELETE CASCADE,
     unique_card_id UUID REFERENCES card_catalog.card_version(card_version_id) ON DELETE CASCADE,
-    is_foil BOOLEAN DEFAULT FALSE,
+    finish_id SMALLINT NOT NULL DEFAULT 1 REFERENCES pricing.card_finished(finish_id),
     purchase_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     purchase_price DECIMAL(10,2),
     condition VARCHAR(5) NOT NULL DEFAULT 'NM' REFERENCES pricing.card_condition(code),

--- a/src/automana/database/SQL/schemas/04_online_shop.sql
+++ b/src/automana/database/SQL/schemas/04_online_shop.sql
@@ -21,12 +21,6 @@ CREATE TABLE Customers (
 */
 BEGIN;
 CREATE SCHEMA IF NOT EXISTS user_collection;
--- Reference: Card Conditions
-CREATE TABLE IF NOT EXISTS user_collection.ref_condition (
-    condition_code SERIAL PRIMARY KEY,
-    condition_description VARCHAR(10) UNIQUE NOT NULL
-);
-
 
 CREATE TABLE IF NOT EXISTS user_collection.collections (
     collection_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -40,14 +34,16 @@ CREATE TABLE IF NOT EXISTS user_collection.collections (
 
 
 -- Collection Items (Tracks Owned Cards)
-CREATE TABLE  IF NOT EXISTS user_collection.collection_items (
+CREATE TABLE IF NOT EXISTS user_collection.collection_items (
     item_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     collection_id UUID REFERENCES user_collection.collections(collection_id) ON DELETE CASCADE,
     unique_card_id UUID REFERENCES card_catalog.card_version(card_version_id) ON DELETE CASCADE,
     is_foil BOOLEAN DEFAULT FALSE,
     purchase_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    purchase_price DECIMAL(10,2),  -- Using DECIMAL for better financial precision
-    condition INT REFERENCES user_collection.ref_condition(condition_code) DEFAULT 1  -- Assuming 1 = NM (Near Mint)
+    purchase_price DECIMAL(10,2),
+    condition VARCHAR(5) NOT NULL DEFAULT 'NM' REFERENCES pricing.card_condition(code),
+    currency_code VARCHAR(3) NOT NULL DEFAULT 'USD' REFERENCES pricing.currency_ref(currency_code),
+    language_id INT REFERENCES card_catalog.language_ref(language_id)
 );
 
 


### PR DESCRIPTION
## Summary

- **Schema**: `collection_items.condition` converted from `INT` FK to `VARCHAR(5)` FK on `pricing.card_condition(code)`; `is_foil` replaced by `finish_id` (FK to `pricing.card_finished`); `currency_code` and `language_id` columns added
- **Entry CRUD**: `POST/GET/DELETE /{collection_id}/entries` and `GET/DELETE /{collection_id}/entries/{entry_id}` fully implemented and tested
- **Card resolution**: entries accept three identifier strategies — `card_version_id` (from suggest), `scryfall_id`, or `set_code + collector_number`
- **Suggest**: extended to return `collector_number` and `scryfall_id` alongside existing fields
- **POST /collection/**: now returns the full created collection (name, user_id, description, timestamps) instead of just the UUID
- **Routers**: standardised OpenAPI `operation_id` and response models across all MTG and user routers
- **Docs**: `TESTING_API_FLOW.md` rewritten with correct field semantics (`hashed_password` takes plain text) and a full entries round-trip example

## Test plan

- [x] `POST /collection/` returns `collection_name`, `user_id`, `created_at`
- [x] `GET /collection/{id}` and `GET /collection/` return correct fields
- [x] `POST /entries` with `card_version_id`
- [x] `POST /entries` with `scryfall_id`
- [x] `POST /entries` with `set_code + collector_number`
- [x] `GET /entries` returns all 3 entries with resolved card details
- [x] `GET /entries/{entry_id}` returns single entry
- [x] `DELETE /entries/{entry_id}` returns 204, entry removed from list
- [x] `DELETE /collection/{id}` returns 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)