### PR TITLE
fix(security): harden users subsystem — auth, SQLi, privilege escalation

### DIFF
--- a/src/automana/api/dependancies/auth/users.py
+++ b/src/automana/api/dependancies/auth/users.py
@@ -1,6 +1,7 @@
 from typing import Annotated, NoReturn, Optional
 
 from fastapi import Cookie, Depends, HTTPException, Request, status
+from fastapi.security import OAuth2PasswordBearer
 
 from automana.api.dependancies.general import ipDep
 from automana.api.dependancies.service_deps import ServiceManagerDep
@@ -14,6 +15,11 @@ import logging
 logger = logging.getLogger(__name__)
 
 LOGIN_URL = "/login"
+
+# auto_error=False: the function handles its own 401s; this declaration
+# exists solely so FastAPI emits an OAuth2 security scheme in OpenAPI,
+# enabling the Swagger UI padlock.
+_oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/users/auth/token", auto_error=False)
 
 
 class BrowserAuthRequired(Exception):
@@ -31,9 +37,14 @@ async def get_current_active_user(
     request: Request,
     ip_address: ipDep,
     service_manager: ServiceManagerDep,
-    session_id: Optional[str] = Cookie(None),
+    session_cookie: Optional[str] = Cookie(None, alias="session_id"),
+    _token: Optional[str] = Depends(_oauth2_scheme),
 ) -> UserInDB:
     user_agent = request.headers.get("User-Agent", "")
+    # session_cookie holds the value of the 'session_id' cookie (alias keeps
+    # the cookie name intact while avoiding a name clash with /{session_id}
+    # path parameters in routes that use this dependency).
+    session_id = session_cookie
 
     # --- Cookie path ---
     if session_id:
@@ -46,7 +57,10 @@ async def get_current_active_user(
             )
             if not user:
                 _raise_auth_error(request, "Invalid session")
-            return UserInDB.model_validate(user)
+            validated = UserInDB.model_validate(user)
+            if validated.disabled:
+                _raise_auth_error(request, "Account is disabled")
+            return validated
         except session_exceptions.SessionError:
             _raise_auth_error(request, "Invalid or expired session")
 
@@ -77,6 +91,11 @@ async def get_current_active_user(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="User not found",
             )
+        if user.disabled:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Account is disabled",
+            )
         return user
 
     # --- No credentials ---
@@ -84,3 +103,22 @@ async def get_current_active_user(
 
 
 CurrentUserDep = Annotated[UserInDB, Depends(get_current_active_user)]
+
+
+async def require_admin(
+    current_user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+) -> UserInDB:
+    is_admin_user = await service_manager.execute_service(
+        "user_management.role.is_admin",
+        user=current_user,
+    )
+    if not is_admin_user:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin access required",
+        )
+    return current_user
+
+
+AdminUserDep = Annotated[UserInDB, Depends(require_admin)]

--- a/src/automana/api/main.py
+++ b/src/automana/api/main.py
@@ -83,7 +83,7 @@ settings = get_settings()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=settings.ALLOWED_ORIGINS if hasattr(settings, 'ALLOWED_ORIGINS') else ["http://localhost:8080"],
+    allow_origins=settings.ALLOWED_ORIGINS,
     allow_credentials=True,
     allow_methods=['*'],
     allow_headers=['*']

--- a/src/automana/api/repositories/user_management/user_repository.py
+++ b/src/automana/api/repositories/user_management/user_repository.py
@@ -125,8 +125,14 @@ class UserRepository(AbstractRepository):
         # Build WHERE clause
         where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
         
+        # Whitelist-guard sort_by to prevent SQL injection
+        _SORTABLE_COLUMNS = {"username", "email", "created_at", "updated_at", "fullname"}
+        if sort_by not in _SORTABLE_COLUMNS:
+            sort_by = "username"
+        sort_order = sort_order.upper() if sort_order.upper() in ("ASC", "DESC") else "ASC"
+
         # Build ORDER BY clause
-        order_clause = f"ORDER BY {sort_by} {sort_order.upper()}"
+        order_clause = f"ORDER BY {sort_by} {sort_order}"
         
         # Get users
         query = f"""

--- a/src/automana/api/routers/users/session.py
+++ b/src/automana/api/routers/users/session.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from uuid import UUID
 from automana.api.dependancies.service_deps import ServiceManagerDep
 from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo, ErrorResponse
+from automana.api.dependancies.auth.users import get_current_active_user, CurrentUserDep
+from automana.api.dependancies.general import ipDep
 
 from automana.api.dependancies.query_deps import (
     session_search_params,
@@ -30,8 +32,7 @@ _SESSION_ERRORS = {
     summary="Retrieve a session by ID",
     description=(
         "Returns metadata for a single session identified by its UUID. "
-        "If the session does not exist, an empty `data` field is returned "
-        "with a descriptive message rather than a 404."
+        "Raises 404 if the session does not exist."
     ),
     response_model=ApiResponse,
     operation_id="sessions_get_by_id",
@@ -43,6 +44,7 @@ _SESSION_ERRORS = {
 async def get_session(
     session_id: UUID,
     service_manager: ServiceManagerDep,
+    _current_user: CurrentUserDep,
 ):
     try:
         result = await service_manager.execute_service(
@@ -50,12 +52,12 @@ async def get_session(
             session_id=session_id,
         )
         if not result:
-            return ApiResponse(data=result, message="Session not found")
+            raise HTTPException(status_code=404, detail="Session not found")
         return ApiResponse(data=result, message="Session retrieved successfully")
     except HTTPException:
         raise
     except Exception:
-        raise
+        raise HTTPException(status_code=500, detail="Internal Server Error")
 
 
 @session_router.get(
@@ -76,6 +78,7 @@ async def get_session(
 )
 async def list_sessions(
     service_manager: ServiceManagerDep,
+    _current_user: CurrentUserDep,
     search_params: dict = Depends(session_search_params),
     pagination: PaginationParams = Depends(pagination_params),
     sorting: SortParams = Depends(sort_params),
@@ -93,7 +96,7 @@ async def list_sessions(
             return PaginatedResponse(
                 data=results,
                 message="Sessions retrieved successfully",
-                pagination_info=PaginationInfo(
+                pagination=PaginationInfo(
                     limit=pagination.limit,
                     offset=pagination.offset,
                     total_count=len(results),
@@ -127,13 +130,23 @@ async def list_sessions(
 async def deactivate_session(
     session_id: UUID,
     service_manager: ServiceManagerDep,
+    current_user: CurrentUserDep,
+    ip_address: ipDep,
 ):
     try:
+        existing = await service_manager.execute_service(
+            "auth.session.read",
+            session_id=session_id,
+        )
+        if not existing:
+            raise HTTPException(status_code=404, detail="Session not found")
         await service_manager.execute_service(
             "auth.session.delete",
             session_id=session_id,
+            user_id=current_user.unique_id,
+            ip_address=ip_address,
         )
     except HTTPException:
         raise
     except Exception:
-        raise
+        raise HTTPException(status_code=500, detail="Internal Server Error")

--- a/src/automana/api/routers/users/users.py
+++ b/src/automana/api/routers/users/users.py
@@ -1,9 +1,9 @@
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo, ErrorResponse
-from automana.api.schemas.user_management.user import BaseUser, UserPublic, UserUpdatePublic, UserInDB
+from automana.api.schemas.user_management.user import BaseUser, UserPublic, UserUpdatePublic, UserInDB, UserAdminPublic
 from automana.api.dependancies.service_deps import ServiceManagerDep
-from automana.api.dependancies.auth.users import CurrentUserDep
+from automana.api.dependancies.auth.users import CurrentUserDep, AdminUserDep
 from automana.api.schemas.user_management.role import AssignRoleRequest, Role
 from automana.api.dependancies.query_deps import (
     sort_params,
@@ -34,9 +34,10 @@ router = APIRouter(
     '/me',
     summary="Get the currently authenticated user",
     description=(
-        "Returns the profile of the user identified by the `session_id` cookie. "
-        "Requires an active session. The response excludes sensitive fields such as "
-        "`hashed_password`."
+        "Returns the profile of the currently authenticated user. "
+        "Authentication is accepted via the `session_id` cookie or an "
+        "`Authorization: Bearer <token>` header. "
+        "The response excludes sensitive fields such as `hashed_password`."
     ),
     response_model=UserPublic,
     response_model_exclude_unset=True,
@@ -54,15 +55,15 @@ async def get_me(current_user: CurrentUserDep):
     '/',
     summary="Search and list users (paginated)",
     description=(
-        "Returns a paginated list of users. Supports filtering by username, email, "
-        "or other search fields, plus common sort and pagination controls. "
-        "Intended for admin use."
+        "Admin-only. Returns a paginated list of users. Supports filtering by username, "
+        "email, or other search fields, plus common sort and pagination controls."
     ),
-    response_model=PaginatedResponse[UserInDB],
+    response_model=PaginatedResponse[UserAdminPublic],
     operation_id="users_list",
     responses=_USER_ERRORS,
 )
 async def list_users(
+    _admin: AdminUserDep,
     service_manager: ServiceManagerDep,
     pagination: PaginationParams = Depends(pagination_params),
     sorting: SortParams = Depends(sort_params),
@@ -81,7 +82,7 @@ async def list_users(
         total_count = result.get("total_count", 0) if isinstance(result, dict) else len(users)
         return PaginatedResponse(
             success=True,
-            data=[UserInDB.model_validate(user) for user in users],
+            data=[UserAdminPublic.model_validate(user) for user in users],
             pagination=PaginationInfo(
                 limit=pagination.limit,
                 offset=pagination.offset,
@@ -102,9 +103,9 @@ async def list_users(
     '/',
     summary="Register a new user",
     description=(
-        "Creates a new user account. The `hashed_password` field must be provided "
-        "pre-hashed by the caller. Returns the newly created user record wrapped in "
-        "an `ApiResponse` envelope."
+        "Creates a new user account. Pass the plain-text password in `hashed_password` "
+        "— the server hashes it on receipt. Returns the newly created user record "
+        "wrapped in an `ApiResponse` envelope."
     ),
     response_model=ApiResponse,
     status_code=status.HTTP_201_CREATED,
@@ -163,7 +164,7 @@ async def update_user(
     '/{user_id}',
     summary="Delete a user by ID",
     description=(
-        "Permanently deletes the user account identified by `user_id`. "
+        "Admin-only. Permanently deletes the user account identified by `user_id`. "
         "This action is irreversible. Returns 204 No Content on success."
     ),
     status_code=status.HTTP_204_NO_CONTENT,
@@ -173,7 +174,7 @@ async def update_user(
         **_USER_ERRORS,
     },
 )
-async def delete_user(user_id: UUID, service_manager: ServiceManagerDep):
+async def delete_user(user_id: UUID, _admin: AdminUserDep, service_manager: ServiceManagerDep):
     try:
         await service_manager.execute_service("user_management.user.delete", user_id=user_id)
     except HTTPException:
@@ -187,8 +188,7 @@ async def delete_user(user_id: UUID, service_manager: ServiceManagerDep):
     '/{user_id}/roles',
     summary="Assign a role to a user",
     description=(
-        "Grants the specified role to the target user. The caller must be "
-        "authenticated and have sufficient privileges (typically `admin`). "
+        "Admin-only. Grants the specified role to the target user. "
         "The role assignment can optionally include an expiry date and an "
         "effective-from date."
     ),
@@ -203,7 +203,7 @@ async def delete_user(user_id: UUID, service_manager: ServiceManagerDep):
 async def assign_role(
     user_id: UUID,
     role: AssignRoleRequest,
-    current_user: CurrentUserDep,
+    current_user: AdminUserDep,
     service_manager: ServiceManagerDep,
 ):
     try:
@@ -224,9 +224,8 @@ async def assign_role(
     '/{user_id}/roles/{role_name}',
     summary="Revoke a role from a user",
     description=(
-        "Removes the specified role from the target user. The caller must be "
-        "authenticated and have sufficient privileges. Returns 204 No Content "
-        "on success."
+        "Admin-only. Removes the specified role from the target user. "
+        "Returns 204 No Content on success."
     ),
     status_code=status.HTTP_204_NO_CONTENT,
     operation_id="users_revoke_role",
@@ -238,7 +237,7 @@ async def assign_role(
 async def revoke_role(
     user_id: UUID,
     role_name: Role,
-    current_user: CurrentUserDep,
+    current_user: AdminUserDep,
     service_manager: ServiceManagerDep,
 ):
     try:

--- a/src/automana/api/schemas/user_management/user.py
+++ b/src/automana/api/schemas/user_management/user.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, EmailStr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, EmailStr, model_validator
 from typing import Optional
 from uuid import UUID, uuid4
 from enum import Enum
@@ -27,6 +27,18 @@ class UserInDB(BaseUser):
     created_at : Optional[datetime]=None
     updated_at : Optional[datetime]=None
    
+class UserAdminPublic(BaseModel):
+    unique_id: UUID
+    username: str
+    email: Optional[str] = None
+    fullname: Optional[str] = None
+    disabled: Optional[bool] = False
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
 class UserUpdatePublic(BaseModel):
     username: str | None=None
     email: str | None=None

--- a/src/automana/api/services/auth/auth_service.py
+++ b/src/automana/api/services/auth/auth_service.py
@@ -14,7 +14,7 @@ from automana.api.services.auth.auth import (verify_password, create_access_toke
 logger = logging.getLogger(__name__)
 
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/auth/token")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/users/auth/token")
 
 async def check_token_validity(request : Request):
     # Accepts Bearer tokens only. Session-cookie auth for HTML/browser clients

--- a/src/automana/api/services/user_management/role_service.py
+++ b/src/automana/api/services/user_management/role_service.py
@@ -67,3 +67,14 @@ async def has_role(repository: RoleRepository, role : str,user : user.UserInDB )
             raise
         except Exception as e:
             raise role_exceptions.RoleRepositoryError(f"Error checking role: {str(e)}")
+
+
+@ServiceRegistry.register(
+    "user_management.role.is_admin",
+    db_repositories=["role"]
+)
+async def is_admin(role_repository: RoleRepository, user: user.UserInDB) -> bool:
+    result = await role_repository.user_has_role(user.unique_id, "admin")
+    if not result:
+        return False
+    return bool(result[0].get("exists", False))

--- a/src/automana/api/services/user_management/user_service.py
+++ b/src/automana/api/services/user_management/user_service.py
@@ -74,11 +74,9 @@ async def search_users(user_repository : UserRepository,
     # Sorting
     sort_by: str = "username",
     sort_order: str = "asc",) -> Union[list[UserPublic], UserPublic]:
-    print(f"Searching users with parameters: {locals()}")
     try:
         # If searching for specific user ID, use get method
         if user_id:
-            print("Fetching user by ID")
             user = await user_repository.get_by_id(user_id)
             if not user:
                 return {"users": [], "total_count": 0}

--- a/src/automana/core/settings.py
+++ b/src/automana/core/settings.py
@@ -66,6 +66,7 @@ class Settings(BaseSettings):
     modules_namespace: str = Field(default="backend", alias="MODULES_NAMESPACE")
 
     ALLOW_DESTRUCTIVE_ENDPOINTS: bool = False
+    ALLOWED_ORIGINS: list[str] = Field(default=["http://localhost:8080"])
     # Security / JWT
     jwt_secret_key: Optional[str] = Field(default_factory=lambda: read_secret("jwt_secret_key"))
     jwt_algorithm: str = "HS256"


### PR DESCRIPTION
## Summary

- **Session router was fully unauthenticated** — all 3 endpoints (get, list, deactivate) now require a valid session or Bearer token
- **`sort_by` SQL injection** — whitelisted against `{username, email, created_at, updated_at, fullname}` in `user_repository.search_users`; any unrecognised value silently falls back to `username`
- **`UserInDB` leaking `hashed_password`** in `GET /users/` — response model changed to `UserAdminPublic` (new schema, omits the password field)
- **Disabled users authenticated successfully** — `get_current_active_user` now rejects disabled accounts on both cookie and Bearer paths
- **`list_users`, `delete_user`, `assign_role`, `revoke_role` had no privilege check** — gated behind new `AdminUserDep` (calls registered `user_management.role.is_admin` service via `user_roles_permission_view`)
- **CORS `ALLOWED_ORIGINS` missing from settings** — was silently falling back to `localhost:8080` with `allow_credentials=True` in every environment
- **Swagger UI had no padlock** — `OAuth2PasswordBearer` now registered as an unused dep in `get_current_active_user`; tokenUrl corrected to `/api/users/auth/token`
- **PII leak** — removed `print()` calls in `user_service.search_users` that dumped email/username to stdout

## Out of scope (separate PRs)

- `BaseUser.hashed_password` rename → `password` (breaking API change)
- `expires_in=3600` hardcoded in login response
- Session list cross-user enumeration (needs service-layer scoping)
- `refresh_token` passing `Request`/`Response` into service layer

## Test plan

- [ ] Unauthenticated `GET /api/users/session/` returns 401
- [ ] Disabled user login attempt returns 401 after authenticating once and disabling the account
- [ ] `GET /api/users/` returns 403 for non-admin authenticated user
- [ ] `GET /api/users/` returns `UserAdminPublic` shape (no `hashed_password` field)
- [ ] `GET /api/users/?sort_by=1;DROP TABLE users--` returns results sorted by `username` (injection neutralised)
- [ ] Swagger UI `/docs` shows the padlock and Authorize dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)