### PR TITLE
fix(auth): resolve major session/auth architectural issues

### DIFF
--- a/src/automana/api/repositories/auth/session_repository.py
+++ b/src/automana/api/repositories/auth/session_repository.py
@@ -65,3 +65,57 @@ class SessionRepository(AbstractRepository):
     async def invalidate_session(self, session_id: UUID, ip_address: str):
         query = "SELECT user_management.inactivate_session($1, $2)"
         return await self.execute_query(query, (session_id, ip_address))
+
+    async def search(
+        self,
+        user_id=None,
+        username: str = None,
+        session_id_filter=None,
+        ip_address: str = None,
+        user_agent: str = None,
+        token_id=None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> dict:
+        conditions = []
+        values = []
+        counter = 1
+
+        if user_id is not None:
+            conditions.append(f"user_id = ${counter}")
+            values.append(user_id)
+            counter += 1
+        if username is not None:
+            conditions.append(f"username ILIKE ${counter}")
+            values.append(f"%{username}%")
+            counter += 1
+        if session_id_filter is not None:
+            conditions.append(f"session_id = ${counter}")
+            values.append(session_id_filter)
+            counter += 1
+        if ip_address is not None:
+            conditions.append(f"ip_address = ${counter}")
+            values.append(ip_address)
+            counter += 1
+        if user_agent is not None:
+            conditions.append(f"user_agent ILIKE ${counter}")
+            values.append(f"%{user_agent}%")
+            counter += 1
+        if token_id is not None:
+            conditions.append(f"token_id = ${counter}")
+            values.append(token_id)
+            counter += 1
+
+        where_clause = "WHERE " + " AND ".join(conditions) if conditions else ""
+        query = f"""
+            SELECT *, COUNT(*) OVER() AS total_count
+            FROM user_management.v_active_sessions
+            {where_clause}
+            ORDER BY created_at DESC
+            LIMIT ${counter} OFFSET ${counter + 1}
+        """
+        values.extend([limit, offset])
+        rows = await self.execute_query(query, tuple(values))
+        total_count = rows[0]["total_count"] if rows else 0
+        sessions = [{k: v for k, v in dict(r).items() if k != "total_count"} for r in rows]
+        return {"sessions": sessions, "total_count": total_count}

--- a/src/automana/api/routers/users/auth.py
+++ b/src/automana/api/routers/users/auth.py
@@ -58,11 +58,12 @@ async def login(
     if result is None:
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
+    settings = get_settings()
     token_response = TokenResponse(
         access_token=result["access_token"],
         refresh_token=result["refresh_token"],
         token_type="bearer",
-        expires_in=3600,
+        expires_in=settings.access_token_expiry * 60,
     )
     json_response = JSONResponse(
         content=token_response.model_dump(),
@@ -103,16 +104,36 @@ async def login(
 )
 async def refresh_token(
     ip_address: ipDep,
-    response: Response,
     request: Request,
+    response: Response,
     service_manager: ServiceManagerDep,
 ):
-    return await service_manager.execute_service(
-        'auth.cookie.read_cookie',
+    session_id = request.cookies.get("session_id")
+    if not session_id:
+        raise HTTPException(status_code=401, detail="No session cookie")
+    user_agent = request.headers.get("User-Agent", "")
+    result = await service_manager.execute_service(
+        "auth.session.refresh",
+        session_id=session_id,
         ip_address=ip_address,
-        response=response,
-        request=request,
+        user_agent=user_agent,
     )
+    token_response = TokenResponse(
+        access_token=result["access_token"],
+        refresh_token=result["refresh_token"],
+        token_type="bearer",
+        expires_in=result["expires_in"],
+    )
+    secure_cookies = get_settings().env != "dev"
+    response.set_cookie(
+        key="session_id",
+        value=result["session_id"],
+        httponly=True,
+        secure=secure_cookies,
+        samesite="strict",
+        max_age=60 * 60 * 24 * 7,
+    )
+    return token_response
 
 
 @authentification_router.post(

--- a/src/automana/api/routers/users/session.py
+++ b/src/automana/api/routers/users/session.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from uuid import UUID
 from automana.api.dependancies.service_deps import ServiceManagerDep
 from automana.api.schemas.StandardisedQueryResponse import ApiResponse, PaginatedResponse, PaginationInfo, ErrorResponse
-from automana.api.dependancies.auth.users import get_current_active_user, CurrentUserDep
+from automana.api.dependancies.auth.users import get_current_active_user, CurrentUserDep, AdminUserDep
 from automana.api.dependancies.general import ipDep
 
 from automana.api.dependancies.query_deps import (
@@ -31,6 +31,7 @@ _SESSION_ERRORS = {
     '/{session_id}',
     summary="Retrieve a session by ID",
     description=(
+        "Admin-only. "
         "Returns metadata for a single session identified by its UUID. "
         "Raises 404 if the session does not exist."
     ),
@@ -44,7 +45,7 @@ _SESSION_ERRORS = {
 async def get_session(
     session_id: UUID,
     service_manager: ServiceManagerDep,
-    _current_user: CurrentUserDep,
+    _admin: AdminUserDep,
 ):
     try:
         result = await service_manager.execute_service(
@@ -64,6 +65,7 @@ async def get_session(
     '/',
     summary="Search and list sessions (paginated)",
     description=(
+        "Admin-only. "
         "Returns a paginated list of sessions filtered by the provided query "
         "parameters. Supports searching by user, status, date range, and common "
         "sort/pagination controls. Returns 404 when no sessions match the filter."
@@ -78,34 +80,35 @@ async def get_session(
 )
 async def list_sessions(
     service_manager: ServiceManagerDep,
-    _current_user: CurrentUserDep,
+    _admin: AdminUserDep,
     search_params: dict = Depends(session_search_params),
     pagination: PaginationParams = Depends(pagination_params),
     sorting: SortParams = Depends(sort_params),
     date_range: DateRangeParams = Depends(date_range_params),
 ):
     try:
-        results = await service_manager.execute_service(
+        result = await service_manager.execute_service(
             "auth.session.search_sessions",
             search_params=search_params,
             pagination=pagination,
             sorting=sorting,
             date_range=date_range,
         )
-        if results:
-            return PaginatedResponse(
-                data=results,
-                message="Sessions retrieved successfully",
-                pagination=PaginationInfo(
-                    limit=pagination.limit,
-                    offset=pagination.offset,
-                    total_count=len(results),
-                    has_next=len(results) == pagination.limit,
-                    has_previous=pagination.offset > 0,
-                ),
-            )
-        else:
+        sessions = result.get("sessions", []) if isinstance(result, dict) else []
+        total_count = result.get("total_count", 0) if isinstance(result, dict) else 0
+        if not sessions:
             raise HTTPException(status_code=404, detail="No sessions found")
+        return PaginatedResponse(
+            data=sessions,
+            message="Sessions retrieved successfully",
+            pagination=PaginationInfo(
+                limit=pagination.limit,
+                offset=pagination.offset,
+                total_count=total_count,
+                has_next=pagination.offset + pagination.limit < total_count,
+                has_previous=pagination.offset > 0,
+            ),
+        )
     except HTTPException:
         raise
     except Exception:
@@ -116,6 +119,7 @@ async def list_sessions(
     '/{session_id}/deactivate',
     summary="Deactivate a session",
     description=(
+        "Admin-only. "
         "Marks the specified session as inactive, effectively invalidating it. "
         "This is distinct from logout — the session record is retained for audit "
         "purposes. Returns 204 No Content on success."
@@ -130,7 +134,7 @@ async def list_sessions(
 async def deactivate_session(
     session_id: UUID,
     service_manager: ServiceManagerDep,
-    current_user: CurrentUserDep,
+    current_user: AdminUserDep,
     ip_address: ipDep,
 ):
     try:

--- a/src/automana/api/services/auth/session_service.py
+++ b/src/automana/api/services/auth/session_service.py
@@ -1,4 +1,5 @@
 ﻿from automana.api.repositories.auth.session_repository import SessionRepository
+from automana.api.repositories.user_management.user_repository import UserRepository
 from uuid import UUID, uuid4
 from automana.api.schemas.auth.session import CreateSession
 from automana.api.services.auth.auth import create_access_token, decode_access_token
@@ -172,6 +173,77 @@ async def read_session(session_repository: SessionRepository, session_id: UUID):
     """Reads a session from the database."""
     session = await session_repository.get(session_id)
     if not session:
-        logger.error(f"Session not found: {session_id}")
+        logger.error("session_not_found", extra={"session_id": str(session_id)})
         return None
     return session
+
+
+@ServiceRegistry.register(
+    "auth.session.search_sessions",
+    db_repositories=["session"],
+)
+async def search_sessions(
+    session_repository: SessionRepository,
+    search_params: dict,
+    pagination,
+    sorting,
+    date_range,
+) -> dict:
+    """Returns a paginated list of sessions matching the supplied filters."""
+    return await session_repository.search(
+        user_id=search_params.get("user_id"),
+        username=search_params.get("username"),
+        session_id_filter=search_params.get("session_id"),
+        ip_address=search_params.get("ip_address"),
+        user_agent=search_params.get("user_agent"),
+        token_id=search_params.get("token_id"),
+        limit=pagination.limit,
+        offset=pagination.offset,
+    )
+
+
+@ServiceRegistry.register(
+    "auth.session.refresh",
+    db_repositories=["session", "user"],
+)
+async def refresh_session(
+    session_repository: SessionRepository,
+    user_repository: UserRepository,
+    session_id: str,
+    ip_address: str,
+    user_agent: str,
+) -> dict:
+    """Validates a session, rotates the refresh token, and issues a new access token."""
+    settings = get_general_settings()
+    try:
+        session = await validate_session_credentials(
+            session_repository, UUID(session_id), ip_address, user_agent
+        )
+    except session_exceptions.SessionError:
+        raise
+
+    user_id = session.get("user_id")
+    user = await user_repository.get_by_id(user_id)
+    if not user:
+        raise session_exceptions.SessionUserNotFoundError("User not found for session")
+
+    expire_time = datetime.now(timezone.utc) + timedelta(days=7)
+    rotated = await rotate_session_token(
+        session_repository,
+        session["session_id"],
+        session["refresh_token"],
+        expire_time,
+        session["token_id"],
+    )
+    access_token = create_access_token(
+        data={"sub": user["username"], "user_id": str(user["unique_id"])},
+        secret_key=settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+        expires_delta=timedelta(minutes=int(settings.access_token_expiry)),
+    )
+    return {
+        "session_id": str(rotated["session_id"]),
+        "refresh_token": rotated["refresh_token"],
+        "access_token": access_token,
+        "expires_in": settings.access_token_expiry * 60,
+    }


### PR DESCRIPTION
## Summary

- **`auth.cookie.read_cookie` didn't exist** — `POST /auth/token/refresh` always failed at runtime. Registered `auth.session.refresh` service; router now extracts `session_id` cookie and `User-Agent` header before calling service (no HTTP objects in service layer)
- **`expires_in=3600` hardcoded** — login response now uses `settings.access_token_expiry * 60`; client-side token refresh schedule stays in sync with server config
- **`auth.session.search_sessions` not registered** — `GET /session/` always failed at runtime. Implemented `session_repository.search()` with parameterized WHERE clause and `COUNT(*) OVER()` window function for accurate total count; pagination `has_next` now uses `offset + limit < total_count` arithmetic
- **Cross-user session enumeration** — all 3 session management endpoints now require `AdminUserDep` (regular authenticated users can no longer browse other users' session metadata)

## Bases on PR #159

This PR targets `fix/users-security-hardening` (PR #159). Merge #159 first.

## Test plan

- [ ] `POST /api/users/auth/token/refresh` with a valid session cookie returns a new `access_token` and rotated `session_id` cookie
- [ ] `POST /api/users/auth/token/refresh` without cookie returns 401
- [ ] `POST /api/users/auth/token` response `expires_in` matches `ACCESS_TOKEN_EXPIRY * 60` from settings
- [ ] `GET /api/users/session/` as non-admin returns 403
- [ ] `GET /api/users/session/` as admin returns paginated sessions with correct `total_count`
- [ ] `GET /api/users/session/?limit=1&offset=0` with 3 sessions: `has_next=true`, `total_count=3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)