### PR TITLE
fix(security): block disabled-user login and prevent hash serialisation

### DIFF
--- a/src/automana/api/schemas/user_management/user.py
+++ b/src/automana/api/schemas/user_management/user.py
@@ -21,11 +21,12 @@ class BaseUser(UserPublic):
 
 class UserInDB(BaseUser):
     unique_id : UUID
-    disabled : bool | None = Field(
-    default=False, title='Is the user account still active'
-)
+    disabled : bool | None = Field(default=False, title='Is the user account still active')
     created_at : Optional[datetime]=None
     updated_at : Optional[datetime]=None
+    hashed_password: str = Field(exclude=True)  # never serialise the hash in any response
+
+    model_config = ConfigDict(from_attributes=True)
    
 class UserAdminPublic(BaseModel):
     unique_id: UUID

--- a/src/automana/api/services/auth/auth_service.py
+++ b/src/automana/api/services/auth/auth_service.py
@@ -44,6 +44,8 @@ async def authenticate_user(repository : UserRepository
         return None
     if not verify_password(password, user['hashed_password']):
         return None
+    if user.get('disabled'):
+        return None
     return UserInDB.model_validate(user)
 
 @ServiceRegistry.register(


### PR DESCRIPTION
## Summary

Two security bugs discovered during post-PR-160 integration testing:

- **Disabled users could log in** — `authenticate_user()` verified the password but never checked the `disabled` flag, so deactivated accounts could still obtain access and refresh tokens. Fixed by returning `None` early when `user['disabled']` is truthy.
- **`hashed_password` leaked in API responses** — `UserInDB` serialised `hashed_password` whenever the model appeared as the `data` payload (register endpoint, etc.). Fixed by overriding the inherited field with `Field(exclude=True)` on `UserInDB`, stripping it from all serialisation at the model level regardless of caller.

## Test plan

- [x] Disabled user `POST /api/users/auth/token` → `{"detail": "Invalid credentials"}` (401)
- [x] `POST /api/users/` register response → no `hashed_password` field in `data`
- [x] `GET /api/users/me` (still works, returns `username` + `fullname`)
- [x] `GET /api/users/` admin list → no `hashed_password` in any user object
- [x] Re-enabled user login → access token issued normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)