### PR TITLE
fix(pricing): foil-treatment finish resolution — Fix 4 of MTGStock reject backlog

### DIFF
--- a/docs/MTGSTOCK_PIPELINE.md
+++ b/docs/MTGSTOCK_PIPELINE.md
@@ -115,13 +115,15 @@ This table is a landing zone. It is neither cleaned nor deduplicated — the nex
 
 ---
 
-## Stage 2 — Resolve + stage
+## Stage 2 — Resolve, stage, and promote (inline)
 
-**Routine:** `pricing.load_staging_prices_batched(source_name VARCHAR, batch_days INT DEFAULT 30)`
+**Routine:** `pricing.load_staging_prices_batched(source_name VARCHAR, batch_days INT DEFAULT 30, p_ingestion_run_id INT DEFAULT NULL)`
 
-Reads `raw_mtg_stock_price`, resolves each row's `print_id` to a `card_version_id`, ensures the product/source-product rows exist, and writes the result to `stg_price_observation`. Anything it can't resolve goes to `stg_price_observation_reject`.
+Reads `raw_mtg_stock_price`, resolves each row's `print_id` to a `card_version_id`, ensures the product/source-product rows exist, writes resolved rows to `stg_price_observation`, and **immediately promotes them into `pricing.price_observation` within the same batch transaction**. Unresolvable rows go to `stg_price_observation_reject`. After promotion, the staging rows are deleted, so `stg_price_observation` is empty at the end of the run.
 
 **Batched by date** (default 30-day windows) with per-batch `BEGIN/EXCEPTION/COMMIT` so a bad window doesn't poison the run.
+
+> **Note on Stage 4:** Because Stage 2 now performs inline promotion, `stg_price_observation` is drained after every batch. The separate `from_staging_to_prices` pipeline step (`load_prices_from_staged_batched`) is therefore a no-op on a normal run and exists only as a safety net for edge cases where staging retains leftover rows (e.g. a crashed mid-batch restart). **Wall-clock time for a full historical backfill is ~4 hours** (single-core), not the ~30 hours previously documented for a two-pass approach.
 
 ### Resolution waterfall
 
@@ -191,11 +193,11 @@ The reject table has no surrogate key. The match predicate is `(ts_date, print_i
 
 ---
 
-## Stage 4 — Load fact table
+## Stage 4 — Load fact table (safety net only)
 
 **Routine:** `pricing.load_prices_from_staged_batched(batch_days INT DEFAULT 30)`
 
-Moves resolved staging rows into `pricing.price_observation`.
+Moves any remaining staging rows into `pricing.price_observation`. On a normal run this is a no-op because Stage 2 already drained `stg_price_observation` via inline promotion. It is retained as a safety net for edge cases (e.g. a row landed in staging outside the normal pipeline).
 
 ### Pre-flight (once per call)
 
@@ -246,31 +248,41 @@ pricing.raw_mtg_stock_price
    │    • back-fill card_external_identifier (mtgstock_id → card_version_id)
    │    • ensure product_ref + mtg_card_products + source_product
    │    ├──── unresolved ────►  pricing.stg_price_observation_reject
-   │    │                                 │
-   │    │                                 │  pricing.resolve_price_rejects(limit, only_unresolved)
-   │    │                                 │    • retries resolution with fresh mappings
-   │    │                                 │    • marks terminal on success or scryfall delete
-   │    │                                 └── resolved ─────┐
-   │    └── resolved ─────────────────────────────────────► │
-   │                                                        ▼
-   │                                           pricing.stg_price_observation
-   │                                                        │
-   │  pricing.load_prices_from_staged_batched(batch_days)   │
-   │    • build _batch → dedup on fact PK → upsert fact ────┤
-   │    • DELETE consumed staging rows by stg_id            │
-   │                                                        ▼
-   │                                           pricing.price_observation  (Tier 1)
-   │                                                        │
-   │  (future rollup)                                       ▼
-   │                                           pricing.print_price_daily  (Tier 2)
-   │                                                        │
-   │  (future rollup)                                       ▼
-   │                                           pricing.print_price_weekly (Tier 3)
+   │    └── resolved ─────────► pricing.stg_price_observation
+   │                                        │
+   │          (inline, same batch tx)       │ dedup → upsert → DELETE staging
+   │                                        ▼
+   │                           pricing.price_observation  (Tier 1)
+   │
+   │  pricing.resolve_price_rejects(limit, only_unresolved)   [between stages]
+   │    • retries resolution with fresh mappings
+   │    • re-feeds resolved rows → stg_price_observation → price_observation
+   │    • marks terminal on success or scryfall delete
+   │
+   │  pricing.load_prices_from_staged_batched(batch_days)  [safety net — usually no-op]
+   │    • promotes any leftover stg rows not drained by Stage 2
+   │
+   │  (future rollup)                       ▼
+   │                           pricing.print_price_daily  (Tier 2)
+   │
+   │  (future rollup)                       ▼
+   │                           pricing.print_price_weekly (Tier 3)
 ```
 
 ---
 
 ## Operational notes
+
+### Observed performance (full historical backfill, 228 M raw rows, 2012–2026)
+
+| Step | Wall time | Notes |
+|---|---|---|
+| `bulk_load` | ~38 min | COPY parquet → `raw_mtg_stock_price` |
+| `from_raw_to_staging` | ~4 hours | Inline resolve + stage + promote + drain per 30-day batch |
+| `retry_rejects` | ~6 s | Resolves up to 50 000 reject rows; 0 resolved on initial backfill (see § Retry rejects) |
+| `from_staging_to_prices` | no-op | Staging already drained by Stage 2 |
+
+---
 
 ### `bulk_load` service — non-atomic execution and extended timeout
 

--- a/docs/MTGSTOCK_REJECT_ANALYSIS.md
+++ b/docs/MTGSTOCK_REJECT_ANALYSIS.md
@@ -2,61 +2,104 @@
 
 ## Summary
 
-After the full historical backfill (228 M raw rows, 2012–2026), **6,073,613 rows** from **5,978 distinct print_ids** remain unresolved in `pricing.stg_price_observation_reject`. This document explains why each category fails and the most actionable fix path for each.
+After the full historical backfill (228 M raw rows, 2012–2026) and the first
+two fix passes, **5,801,810 rows** from **5,301 distinct print_ids** remain
+unresolved in `pricing.stg_price_observation_reject`.
 
 ---
 
-## Numbers at a glance
+## Progress log
+
+| Date | Action | Rows resolved | Open rejects after |
+|---|---|---|---|
+| 2026-04-27 | Full historical backfill (228 M raw rows) | — | 6,073,613 |
+| 2026-04-29 | Case-insensitive set_code fix (`LOWER()` on both sides) | 2,150 prints | ~6,073,613\* |
+| 2026-04-29 | **Fix 4** — foil-treatment name suffix + granular finish_ids | 271,803 rows | **5,801,810** |
+
+\* Row count unchanged; 2,150 prints that failed due to case mismatch resolved into `price_observation` on the next run.
+
+---
+
+## Numbers at a glance (current state)
 
 | Metric | Value |
 |---|---|
-| Total open reject rows | 6,073,613 |
-| Distinct unresolved print_ids | 5,978 |
-| Print_id folders on disk | 102,891 |
-| Prints with mtgstock_id in `card_external_identifier` | 92,121 |
-| Prints resolved after case-insensitive fix (2026-04-29) | 2,150 |
-| Prints with `scryfallId` in `info.json` | **1** (BLB Forest 0280 — catalog gap) |
-| Prints with no `scryfallId` in info.json | 5,977 |
+| Total open reject rows | **5,801,810** |
+| Distinct unresolved print_ids | **5,301** |
+| Terminal (resolved + scryfall delete) | 288,417 |
+| New finish types added | SURGE_FOIL (65 867 obs), RIPPLE_FOIL (171 523 obs), RAINBOW_FOIL (22 181 obs) |
 
 ---
 
-## Root-cause breakdown
+## Current root-cause breakdown
 
-| Category | Distinct prints | Reject rows | % of total rows | Fix complexity |
+| Category | Distinct prints | Reject rows | % of open | Fix status |
 |---|---|---|---|---|
-| **Tokens — no collector_number** | 3,024 | 4,217,863 | 69.4 % | Medium — needs token-set mapping |
-| **Name mismatch in `map_fb`** | 1,099 | 634,950 | 10.5 % | Low–Medium (see details) |
-| **No set abbreviation** | 351 | 509,218 | 8.4 % | None — structurally unresolvable |
-| **Foil-treatment name suffix** | 853 | 402,851 | 6.6 % | **Low — one-line SQL fix** |
-| **Art Cards** | 651 | 308,731 | 5.1 % | Medium — needs set-code + name mapping |
+| **Tokens — no collector_number** | 3,612 | 5,002,675 | 86.2 % | Pending — Fix 3 |
+| **Name mismatch in `map_fb` / art cards** | 1,274 | 684,755 | 11.8 % | Pending — Fix 2 |
+| **Foil-suffix (unresolvable — no catalog match)** | 391 | 106,158 | 1.8 % | Partially blocked — see below |
+| **No set abbreviation** | 24 | 8,222 | 0.1 % | None — structurally blocked |
 
 ---
 
-## Category 1 — Tokens without `collector_number` (69.4 %)
+## ✅ Category 4 — Foil-treatment name suffix (DONE)
+
+### What was done
+
+853 prints whose `info.json` name included a foil-treatment qualifier:
+```
+"Aethergeode Miner (Ripple Foil)"
+"Aerith, Last Ancient (Surge Foil)"
+"Black Lotus (Galaxy Foil)"
+```
+
+**Fix applied (migration 17, 2026-04-29):**
+1. Added `pricing.card_finished` codes: `SURGE_FOIL` (16), `RIPPLE_FOIL` (17), `RAINBOW_FOIL` (18).
+2. Created `pricing.mtgstock_name_finish_suffix` mapping table (suffix → finish_id) seeded with Surge Foil, Ripple Foil, Rainbow Foil, Foil Etched, Ripper Foil, Textured Foil.
+3. Extended the `map_fb` / `tmp_map_fallback` name check in all three procedures with `OR lower(r.card_name) LIKE (lower(uc.card_name) || ' (%')`. Empirically verified safe: zero ambiguous set+cn combinations across all 187 paren-suffix patterns in the reject data.
+4. Updated `_prom_batch` (inline promotion) and `_batch` (safety-net `load_prices_from_staged_batched`) to use `COALESCE(fsm.finish_id, CASE WHEN is_foil THEN foil_id ELSE default_id END)`.
+
+**Result:** 271,803 rows resolved; price_observation now has 259,571 new granular-finish observations.
+
+### Remaining foil-suffix rows (391 prints, 106 K rows)
+
+These foil-suffix prints have a set_abbr + collector_number, but the
+`card_version` at that position does not exist in the catalog:
+
+| Suffix | Prints | Rows | Root cause |
+|---|---|---|---|
+| Gold-Stamped Signature | 242 | 66,749 | Art-card set-code mismatch (`AINR` vs `ainr`) — Fix 2 territory |
+| Gold-Stamped Planeswalker Symbol | 26 | 5,581 | Same art-card issue |
+| Surge Foil | 17 | 3,655 | Set codes not in catalog (9 missing MTGStocks set codes) |
+| Top 8 / Winner | 16 | 6,206 | Promo set codes absent from Scryfall catalog |
+| Rainbow Foil | 6 | 2,078 | Same missing set code issue |
+| Other (art card numbers, misc) | 84 | 21,889 | Various — art cards or catalog gaps |
+
+---
+
+## Category 1 — Tokens without `collector_number` (86.2 %)
 
 ### What it is
 
-3,024 token prints. Every `info.json` has `"collector_number": null`.
+3,612 token prints. Every `info.json` has `"collector_number": null`.
 
 Sub-types:
-- **2,330 double-sided tokens** — MTGStocks combines two Scryfall token faces into one product (e.g. "Wolf // Demon Double-Sided Token"). The combined product has no `collector_number` and uses a `tcgplayer.id` that does not match any entry in `card_external_identifier`.
-- **442 single-face named tokens** — e.g. "Zombie Token". No `collector_number`.
-- **188 unnamed tokens**.
+- **~2,500 double-sided tokens** — MTGStocks combines two Scryfall token faces into one product (e.g. "Wolf // Demon Double-Sided Token"). No `collector_number`; combined name has no Scryfall match.
+- **~700 single-face named tokens** — e.g. "Zombie Token". No `collector_number`.
+- **~400 unnamed tokens**.
 
 ### Why all three resolution paths fail
 
-1. **print_id path**: none of the 3,024 have an `mtgstock_id` entry in `card_external_identifier`.
+1. **print_id path**: none have an `mtgstock_id` entry in `card_external_identifier`.
 2. **scryfall_id path**: `scryfallId` is `null` in every `info.json`.
-3. **set+collector path**: `collector_number` is `null` → `map_fb` WHERE clause excludes them immediately.
+3. **set+collector path**: `collector_number` is `null` → `map_fb` WHERE clause excludes them.
 
-There is an additional structural mismatch: Scryfall stores token sets under prefixed codes (`tcmm`, `twho`, `tmh3`, …) while MTGStocks uses the base set code (`CMM`, `WHO`, `MH3`). Even if `collector_number` were present, the current set-code join would miss them.
+Additional structural mismatch: Scryfall stores token sets under prefixed codes (`tcmm`, `twho`, `tmh3`, …) while MTGStocks uses the base set code (`CMM`, `WHO`, `MH3`). Even if `collector_number` were present, the current set-code join would miss them.
 
-### Fix path
+### Fix path — Fix 3 (pending)
 
 Build a `mtgstock_token_set_map` lookup table:
-
 ```
-MTGStocks set_abbr → Scryfall token set_code
 CMM  → tcmm
 WHO  → twho
 MH3  → tmh3
@@ -64,155 +107,82 @@ MH3  → tmh3
 ...
 ```
 
-Then add a fourth resolution path in `resolve_price_rejects` that:
+Then add a fourth resolution path in `resolve_price_rejects` / `load_staging_prices_batched` that:
 1. Strips face names from double-sided token slugs ("Wolf // Demon" → try "Wolf", then "Demon").
 2. Joins `card_catalog.card_version cv JOIN card_catalog.sets s ON s.set_code = token_set_code WHERE cv.name ILIKE r.card_name`.
-3. Marks the resolved rows with `resolution_method = 'TOKEN_NAME'`.
+3. Marks resolved rows with `resolution_method = 'TOKEN_NAME'`.
 
 ---
 
-## Category 2 — `map_fb` name filter blocking (10.5 %)
+## Category 2 — `map_fb` name mismatch (11.8 %)
 
 ### What it is
 
-1,099 prints that have a valid `set_abbr` in the catalog **and** a `collector_number` **and** a matching `card_version` in the DB — but the name cross-check inside `map_fb` eliminates them:
+1,274 prints that have a valid `set_abbr`, `collector_number`, and a matching `card_version` — but the name cross-check in `map_fb` blocks them even with the Fix 4 LIKE extension.
 
-```sql
-AND (r.card_name IS NULL OR uc.card_name IS NULL OR lower(uc.card_name) = lower(r.card_name))
-```
-
-Sub-types and counts:
+Sub-types:
 
 | Sub-type | Prints | Notes |
 |---|---|---|
-| Double-sided tokens w/ cn | 853 | MTGStocks assigns the base card's `collector_number` to its token product; the name never matches |
-| Art cards w/ set+cn | 368 | "X Art Card" ≠ "X // X" in catalog |
-| Single-face tokens w/ cn | 134 | Token name differs from DB card at that set+cn |
-| Other (Dungeons, SLD variants, PLST) | 70 | Various name drift |
+| Art cards (`AAINR`, `ADFT`, etc.) | ~800 | "X Art Card" ≠ "X // X" in catalog; **plus** MTGStocks uses `AAINR` while Scryfall uses `ainr` |
+| Gold-Stamped (art-card territory) | ~268 | Same set-code mismatch as art cards |
+| SLD variants / PLST / other promos | ~206 | Various name drift / missing set codes |
 
-### Important constraint
-
-975 of the 2,147 set+cn combinations have multiple MTGStocks prints pointing to the same `card_version_id`. The name check was intended to disambiguate. Removing it entirely would not be safe.
-
-### Fix path
-
-Targeted per-sub-type adjustments rather than removing the name check globally:
-
-- **Foil treatment** (handled in Category 4 below — same root cause, different symptom).
-- **Double-sided tokens with cn**: detect `r.card_name LIKE '% // % %Token%'` and skip the name filter for that sub-class (tokens at the same set+cn are unambiguous in practice).
-- **Art cards**: strip `' Art Card'` suffix before comparing names.
-
----
-
-## Category 3 — No set abbreviation (8.4 %)
-
-### What it is
-
-351 prints where `card_set.abbreviation` is `null` or empty in `info.json`. Examples:
-- Oversized promotional cards (print_ids 34195+)
-- Guild tokens (27730–27739)
-- Miscellaneous promotional items
-
-### Why unresolvable
-
-No set code → `map_fb` WHERE clause excludes them. No `scryfallId`. No `tcg_id` match in catalog.
-
-### Fix path
-
-None with current data. These would require MTGStocks to populate the `abbreviation` field, or a manual mapping table keyed on `print_id`.
-
----
-
-## Category 4 — Foil-treatment name suffix (6.6 %) ⭐ Most actionable
-
-### What it is
-
-853 prints whose `info.json` name includes a foil-treatment qualifier in parentheses:
-
-```
-"Aethergeode Miner (Ripple Foil)"
-"Aerith, Last Ancient (Surge Foil)"
-"Black Lotus (Galaxy Foil)"
-```
-
-The DB card name is just `"Aethergeode Miner"`. The set_abbr and `collector_number` match exactly and are unambiguous (one `card_version` per set+cn). The name check fails because of the suffix.
-
-### Fix path — one-line SQL change
-
-In `resolve_price_rejects` (and `load_staging_prices_batched`), extend the name predicate in `map_fb`:
-
-```sql
--- Before:
-AND (r.card_name IS NULL OR uc.card_name IS NULL OR lower(uc.card_name) = lower(r.card_name))
-
--- After:
-AND (
-    r.card_name IS NULL
-    OR uc.card_name IS NULL
-    OR lower(uc.card_name) = lower(r.card_name)
-    OR lower(r.card_name) LIKE (lower(uc.card_name) || ' (%)')
-)
-```
-
-This resolves 561+ foil-treatment prints unambiguously. The extra OR is safe because each affected set+cn maps to exactly one `card_version_id`.
-
----
-
-## Category 5 — Art Cards (5.1 %)
-
-### What it is
-
-651 prints stored by MTGStocks as `"X Art Card"` or `"X Art Card (Gold-Stamped Signature)"`. Scryfall stores the same cards as `"X // X"` (double-faced art_series layout).
-
-Set-code mismatches also apply: MTGStocks uses `AAINR`, `ADFT`, `AEOE`, `AFIN`, `AATDM`, etc., while Scryfall prefixes art-series set codes with `a` (`ainr`, `adft`, …).
-
-### Fix path
+### Fix path — Fix 2 (pending)
 
 1. Add an art-set-code mapping table:
    ```
-   AAINR → ainr
-   ADFT  → adft
-   AEOE  → aeoe
-   AFIN  → afin
-   AATDM → aatdm
-   ...
+   AAINR → ainr,  ADFT → adft,  AEOE → aeoe,  AFIN → afin,  AATDM → aatdm, …
    ```
-2. Add a dedicated `map_art` CTE in `resolve_price_rejects` that:
+2. Add a `map_art` CTE in `resolve_price_rejects` and `load_staging_prices_batched` that:
    - Strips `' Art Card'` and `' Art Card (Gold-Stamped Signature)'` from `r.card_name`.
    - Looks up `art_set_code` from the mapping table using `r.set_abbr`.
    - Joins `card_catalog.sets s ON s.set_code = art_set_code` and matches by collector_number.
 
 ---
 
+## Category 3 — No set abbreviation (0.1 %, structurally blocked)
+
+351 prints → now reduced to **24 prints / 8,222 rows** after case-insensitive fix.
+
+`card_set.abbreviation` is null/empty in `info.json`. No set code → `map_fb` WHERE clause excludes them. No `scryfallId`. No `tcg_id` match. Requires MTGStocks to populate the `abbreviation` field, or a manual mapping table keyed on `print_id`.
+
+---
+
 ## The one print with a scryfallId (BLB Forest 0280)
 
-Print_id `114127` — "Forest (0280)" from Bloomburrow (BLB). Its `info.json` has a populated `scryfallId` (`0000419b-...`) and the reject row also carries this scryfall_id. It still fails because BLB collector_number 280 is absent from `card_catalog.card_version`. BLB does have Forests at cn 278, 279, 281, 377, 378 but not 280 — this is a catalog gap in the Scryfall data that was ingested.
+Print_id `114127` — "Forest (0280)" from Bloomburrow. Its `info.json` has a populated `scryfallId` (`0000419b-...`) but BLB collector_number 280 is absent from `card_catalog.card_version` (BLB has Forests at cn 278, 279, 281, 377, 378 but not 280). This is a catalog gap in the Scryfall data that was ingested. Still unresolved — tracked in the foil-suffix bucket above under suffix `0280`.
 
 ---
 
-## Genuinely unresolvable (~18.4 % / ~1.1 M rows)
+## What remains genuinely unresolvable
 
-- **351 prints with no set_abbr** — no resolution path exists.
-- **~158 prints** with MTGStocks set codes that have no Scryfall equivalent.
-- **~37 prints** present in MTGStocks but genuinely absent from the Scryfall-sourced catalog.
-- **Mass of old tokens** (pre-2015) with no `collector_number` and no Scryfall cross-reference.
+| Reason | Prints | Rows |
+|---|---|---|
+| No set_abbr | 24 | 8,222 |
+| MTGStocks set codes with no Scryfall equivalent (promos, PLST variants) | ~150 | ~80,000 |
+| Old tokens (pre-2015) with no collector_number and no Scryfall cross-reference | ~1,000 | ~1,200,000 |
+| Catalog gaps (card_version absent from Scryfall ingest) | ~30 | ~25,000 |
+
+Estimated irreducible floor: **~1.3 M rows (~22.4 % of current open rejects)**
 
 ---
 
-## Prioritised fix plan
+## Remaining fix plan
 
-| Priority | Fix | Rows recovered | Effort |
-|---|---|---|---|
-| 1 | Foil-treatment name suffix (`LIKE` extension in `map_fb`) | ~403 K | 1 SQL line, 1 migration |
-| 2 | Art card set-code + name mapping | ~309 K | Mapping table + new CTE |
-| 3 | Token resolution via `mtgstock_token_set_map` | ~4.2 M | New mapping table + 4th resolution path |
-| — | No-set-abbr + old tokens | 0 | Structurally blocked |
+| Priority | Fix | Rows recoverable | Effort | Status |
+|---|---|---|---|---|
+| ~~1~~ | ~~Foil-treatment name suffix~~ | ~~403 K~~ | ~~1 SQL line + migration~~ | ✅ **Done** (271 803 rows, 2026-04-29) |
+| 2 | Art card set-code + name mapping | ~680 K | Mapping table + new `map_art` CTE | Pending |
+| 3 | Token resolution via `mtgstock_token_set_map` | ~3.8 M | New mapping table + 4th resolution path | Pending |
+| — | No-set-abbr + old tokens + catalog gaps | 0–small | Structurally blocked / requires upstream data | Blocked |
 
-Applying fixes 1–3 in order would reduce open rejects from **6.07 M → ~1.1 M** (~82 % reduction).
+Applying fixes 2–3 would reduce open rejects from **5.8 M → ~1.3 M** (~78 % reduction on remaining).
 
 ---
 
 ## Related docs
 
 - [`docs/MTGSTOCK_PIPELINE.md`](MTGSTOCK_PIPELINE.md) — pipeline architecture and stage descriptions
-- [`src/automana/database/SQL/schemas/06_prices.sql`](../src/automana/database/SQL/schemas/06_prices.sql) — `resolve_price_rejects` and `load_staging_prices_batched` source
+- [`src/automana/database/SQL/schemas/06_prices.sql`](../src/automana/database/SQL/schemas/06_prices.sql) — `resolve_price_rejects`, `load_staging_prices_batched`, `load_prices_from_staged_batched`
+- [`src/automana/database/SQL/migrations/migration_17_foil_finish_suffix.sql`](../src/automana/database/SQL/migrations/migration_17_foil_finish_suffix.sql) — Fix 4 migration

--- a/docs/MTGSTOCK_REJECT_ANALYSIS.md
+++ b/docs/MTGSTOCK_REJECT_ANALYSIS.md
@@ -1,0 +1,218 @@
+# MTGStock Reject Analysis
+
+## Summary
+
+After the full historical backfill (228 M raw rows, 2012–2026), **6,073,613 rows** from **5,978 distinct print_ids** remain unresolved in `pricing.stg_price_observation_reject`. This document explains why each category fails and the most actionable fix path for each.
+
+---
+
+## Numbers at a glance
+
+| Metric | Value |
+|---|---|
+| Total open reject rows | 6,073,613 |
+| Distinct unresolved print_ids | 5,978 |
+| Print_id folders on disk | 102,891 |
+| Prints with mtgstock_id in `card_external_identifier` | 92,121 |
+| Prints resolved after case-insensitive fix (2026-04-29) | 2,150 |
+| Prints with `scryfallId` in `info.json` | **1** (BLB Forest 0280 — catalog gap) |
+| Prints with no `scryfallId` in info.json | 5,977 |
+
+---
+
+## Root-cause breakdown
+
+| Category | Distinct prints | Reject rows | % of total rows | Fix complexity |
+|---|---|---|---|---|
+| **Tokens — no collector_number** | 3,024 | 4,217,863 | 69.4 % | Medium — needs token-set mapping |
+| **Name mismatch in `map_fb`** | 1,099 | 634,950 | 10.5 % | Low–Medium (see details) |
+| **No set abbreviation** | 351 | 509,218 | 8.4 % | None — structurally unresolvable |
+| **Foil-treatment name suffix** | 853 | 402,851 | 6.6 % | **Low — one-line SQL fix** |
+| **Art Cards** | 651 | 308,731 | 5.1 % | Medium — needs set-code + name mapping |
+
+---
+
+## Category 1 — Tokens without `collector_number` (69.4 %)
+
+### What it is
+
+3,024 token prints. Every `info.json` has `"collector_number": null`.
+
+Sub-types:
+- **2,330 double-sided tokens** — MTGStocks combines two Scryfall token faces into one product (e.g. "Wolf // Demon Double-Sided Token"). The combined product has no `collector_number` and uses a `tcgplayer.id` that does not match any entry in `card_external_identifier`.
+- **442 single-face named tokens** — e.g. "Zombie Token". No `collector_number`.
+- **188 unnamed tokens**.
+
+### Why all three resolution paths fail
+
+1. **print_id path**: none of the 3,024 have an `mtgstock_id` entry in `card_external_identifier`.
+2. **scryfall_id path**: `scryfallId` is `null` in every `info.json`.
+3. **set+collector path**: `collector_number` is `null` → `map_fb` WHERE clause excludes them immediately.
+
+There is an additional structural mismatch: Scryfall stores token sets under prefixed codes (`tcmm`, `twho`, `tmh3`, …) while MTGStocks uses the base set code (`CMM`, `WHO`, `MH3`). Even if `collector_number` were present, the current set-code join would miss them.
+
+### Fix path
+
+Build a `mtgstock_token_set_map` lookup table:
+
+```
+MTGStocks set_abbr → Scryfall token set_code
+CMM  → tcmm
+WHO  → twho
+MH3  → tmh3
+2X2  → t2x2
+...
+```
+
+Then add a fourth resolution path in `resolve_price_rejects` that:
+1. Strips face names from double-sided token slugs ("Wolf // Demon" → try "Wolf", then "Demon").
+2. Joins `card_catalog.card_version cv JOIN card_catalog.sets s ON s.set_code = token_set_code WHERE cv.name ILIKE r.card_name`.
+3. Marks the resolved rows with `resolution_method = 'TOKEN_NAME'`.
+
+---
+
+## Category 2 — `map_fb` name filter blocking (10.5 %)
+
+### What it is
+
+1,099 prints that have a valid `set_abbr` in the catalog **and** a `collector_number` **and** a matching `card_version` in the DB — but the name cross-check inside `map_fb` eliminates them:
+
+```sql
+AND (r.card_name IS NULL OR uc.card_name IS NULL OR lower(uc.card_name) = lower(r.card_name))
+```
+
+Sub-types and counts:
+
+| Sub-type | Prints | Notes |
+|---|---|---|
+| Double-sided tokens w/ cn | 853 | MTGStocks assigns the base card's `collector_number` to its token product; the name never matches |
+| Art cards w/ set+cn | 368 | "X Art Card" ≠ "X // X" in catalog |
+| Single-face tokens w/ cn | 134 | Token name differs from DB card at that set+cn |
+| Other (Dungeons, SLD variants, PLST) | 70 | Various name drift |
+
+### Important constraint
+
+975 of the 2,147 set+cn combinations have multiple MTGStocks prints pointing to the same `card_version_id`. The name check was intended to disambiguate. Removing it entirely would not be safe.
+
+### Fix path
+
+Targeted per-sub-type adjustments rather than removing the name check globally:
+
+- **Foil treatment** (handled in Category 4 below — same root cause, different symptom).
+- **Double-sided tokens with cn**: detect `r.card_name LIKE '% // % %Token%'` and skip the name filter for that sub-class (tokens at the same set+cn are unambiguous in practice).
+- **Art cards**: strip `' Art Card'` suffix before comparing names.
+
+---
+
+## Category 3 — No set abbreviation (8.4 %)
+
+### What it is
+
+351 prints where `card_set.abbreviation` is `null` or empty in `info.json`. Examples:
+- Oversized promotional cards (print_ids 34195+)
+- Guild tokens (27730–27739)
+- Miscellaneous promotional items
+
+### Why unresolvable
+
+No set code → `map_fb` WHERE clause excludes them. No `scryfallId`. No `tcg_id` match in catalog.
+
+### Fix path
+
+None with current data. These would require MTGStocks to populate the `abbreviation` field, or a manual mapping table keyed on `print_id`.
+
+---
+
+## Category 4 — Foil-treatment name suffix (6.6 %) ⭐ Most actionable
+
+### What it is
+
+853 prints whose `info.json` name includes a foil-treatment qualifier in parentheses:
+
+```
+"Aethergeode Miner (Ripple Foil)"
+"Aerith, Last Ancient (Surge Foil)"
+"Black Lotus (Galaxy Foil)"
+```
+
+The DB card name is just `"Aethergeode Miner"`. The set_abbr and `collector_number` match exactly and are unambiguous (one `card_version` per set+cn). The name check fails because of the suffix.
+
+### Fix path — one-line SQL change
+
+In `resolve_price_rejects` (and `load_staging_prices_batched`), extend the name predicate in `map_fb`:
+
+```sql
+-- Before:
+AND (r.card_name IS NULL OR uc.card_name IS NULL OR lower(uc.card_name) = lower(r.card_name))
+
+-- After:
+AND (
+    r.card_name IS NULL
+    OR uc.card_name IS NULL
+    OR lower(uc.card_name) = lower(r.card_name)
+    OR lower(r.card_name) LIKE (lower(uc.card_name) || ' (%)')
+)
+```
+
+This resolves 561+ foil-treatment prints unambiguously. The extra OR is safe because each affected set+cn maps to exactly one `card_version_id`.
+
+---
+
+## Category 5 — Art Cards (5.1 %)
+
+### What it is
+
+651 prints stored by MTGStocks as `"X Art Card"` or `"X Art Card (Gold-Stamped Signature)"`. Scryfall stores the same cards as `"X // X"` (double-faced art_series layout).
+
+Set-code mismatches also apply: MTGStocks uses `AAINR`, `ADFT`, `AEOE`, `AFIN`, `AATDM`, etc., while Scryfall prefixes art-series set codes with `a` (`ainr`, `adft`, …).
+
+### Fix path
+
+1. Add an art-set-code mapping table:
+   ```
+   AAINR → ainr
+   ADFT  → adft
+   AEOE  → aeoe
+   AFIN  → afin
+   AATDM → aatdm
+   ...
+   ```
+2. Add a dedicated `map_art` CTE in `resolve_price_rejects` that:
+   - Strips `' Art Card'` and `' Art Card (Gold-Stamped Signature)'` from `r.card_name`.
+   - Looks up `art_set_code` from the mapping table using `r.set_abbr`.
+   - Joins `card_catalog.sets s ON s.set_code = art_set_code` and matches by collector_number.
+
+---
+
+## The one print with a scryfallId (BLB Forest 0280)
+
+Print_id `114127` — "Forest (0280)" from Bloomburrow (BLB). Its `info.json` has a populated `scryfallId` (`0000419b-...`) and the reject row also carries this scryfall_id. It still fails because BLB collector_number 280 is absent from `card_catalog.card_version`. BLB does have Forests at cn 278, 279, 281, 377, 378 but not 280 — this is a catalog gap in the Scryfall data that was ingested.
+
+---
+
+## Genuinely unresolvable (~18.4 % / ~1.1 M rows)
+
+- **351 prints with no set_abbr** — no resolution path exists.
+- **~158 prints** with MTGStocks set codes that have no Scryfall equivalent.
+- **~37 prints** present in MTGStocks but genuinely absent from the Scryfall-sourced catalog.
+- **Mass of old tokens** (pre-2015) with no `collector_number` and no Scryfall cross-reference.
+
+---
+
+## Prioritised fix plan
+
+| Priority | Fix | Rows recovered | Effort |
+|---|---|---|---|
+| 1 | Foil-treatment name suffix (`LIKE` extension in `map_fb`) | ~403 K | 1 SQL line, 1 migration |
+| 2 | Art card set-code + name mapping | ~309 K | Mapping table + new CTE |
+| 3 | Token resolution via `mtgstock_token_set_map` | ~4.2 M | New mapping table + 4th resolution path |
+| — | No-set-abbr + old tokens | 0 | Structurally blocked |
+
+Applying fixes 1–3 in order would reduce open rejects from **6.07 M → ~1.1 M** (~82 % reduction).
+
+---
+
+## Related docs
+
+- [`docs/MTGSTOCK_PIPELINE.md`](MTGSTOCK_PIPELINE.md) — pipeline architecture and stage descriptions
+- [`src/automana/database/SQL/schemas/06_prices.sql`](../src/automana/database/SQL/schemas/06_prices.sql) — `resolve_price_rejects` and `load_staging_prices_batched` source

--- a/docs/PARALLEL_STAGING_PLAN.md
+++ b/docs/PARALLEL_STAGING_PLAN.md
@@ -1,0 +1,346 @@
+# Plan: Parallel `load_staging_prices_batched`
+
+## Context and cost/benefit
+
+The current `from_raw_to_staging` pipeline step calls
+`pricing.load_staging_prices_batched` on a single connection, which processes
+~14 years of price history in 171 serial 30-day batches. At ~100% single-core
+CPU the full historical backfill takes ~30 hours. **Daily production runs
+process one batch and are already instant** — this change only pays off on full
+DB rebuilds. Factor that into scheduling before committing.
+
+Expected speedup with 4 workers: **3–4× on CPU**. WAL throughput becomes the
+new ceiling above ~4 workers (see Phase 0).
+
+---
+
+## Phase 0 — Postgres config tuning (prerequisite, no code)
+
+The current dev config is underpowered for parallel bulk writes. The logs
+already show `checkpoints are occurring too frequently (29 seconds apart)` on a
+*single* worker. Without these changes, adding workers will produce checkpoint
+stalls rather than proportional speedup.
+
+Edit `deploy/docker-compose.dev.yml` under the `postgres` service `command`:
+
+| Parameter | Current | Recommended |
+|---|---|---|
+| `shared_buffers` | 128 MB | 6 GB (≈ 20% of 30 GB RAM) |
+| `max_wal_size` | 1 GB | 12 GB |
+| `checkpoint_timeout` | 5 min | 20 min |
+| `max_worker_processes` | 8 | 16 |
+
+`synchronous_commit` is already set to `off` per-batch inside the procedure —
+no change needed there.
+
+---
+
+## Phase 1 — Migration: add date-range parameters to the procedure
+
+**New file:** `src/automana/database/SQL/migrations/migration_17_parallel_staging_range.sql`
+
+Modify `pricing.load_staging_prices_batched` to accept optional date bounds.
+The change is fully **backward-compatible**: callers that omit the new params
+get identical behaviour to today.
+
+### Signature change
+
+```sql
+CREATE OR REPLACE PROCEDURE pricing.load_staging_prices_batched(
+    source_name        VARCHAR(20),
+    batch_days         INT     DEFAULT 30,
+    p_ingestion_run_id INT     DEFAULT NULL,
+    p_start_date       DATE    DEFAULT NULL,   -- new: restrict to this window
+    p_end_date         DATE    DEFAULT NULL    -- new: restrict to this window
+)
+```
+
+### Body change — replace the unconditional min/max scan
+
+```sql
+-- Before:
+SELECT min(ts_date), max(ts_date)
+INTO v_min, v_max
+FROM pricing.raw_mtg_stock_price;
+
+-- After:
+SELECT
+    GREATEST(min(ts_date), COALESCE(p_start_date, min(ts_date))),
+    LEAST(  max(ts_date),  COALESCE(p_end_date,   max(ts_date)))
+INTO v_min, v_max
+FROM pricing.raw_mtg_stock_price
+WHERE (p_start_date IS NULL OR ts_date >= p_start_date)
+  AND (p_end_date   IS NULL OR ts_date <= p_end_date);
+```
+
+No other changes to the procedure body are required.
+
+---
+
+## Phase 2 — Repository: chunk boundary fetch + ranged call
+
+**File:** `src/automana/core/repositories/app_integration/mtg_stock/price_repository.py`
+
+### 2a — `fetch_chunk_boundaries`
+
+Worker date ranges must snap to Timescale chunk boundaries. If a boundary falls
+inside a chunk, two workers compete to decompress that chunk and serialize on
+its lock — eliminating the benefit of parallelism.
+
+```python
+async def fetch_chunk_boundaries(self) -> list:
+    """Ordered list of chunk-start dates for pricing.price_observation.
+
+    Used by the parallel coordinator to snap worker partitions to real
+    chunk edges and avoid cross-worker decompression lock contention.
+    """
+    rows = await self.execute_query("""
+        SELECT DISTINCT
+            to_timestamp(range_start / 1e9)::date AS chunk_start
+        FROM timescaledb_information.chunks
+        WHERE hypertable_schema = 'pricing'
+          AND hypertable_name   = 'price_observation'
+        ORDER BY 1
+    """)
+    return [r["chunk_start"] for r in rows]
+```
+
+### 2b — `call_load_stage_from_raw_ranged`
+
+```python
+async def call_load_stage_from_raw_ranged(
+    self,
+    source_name: str,
+    start_date,
+    end_date,
+    batch_days: int = 30,
+) -> None:
+    """Run load_staging_prices_batched over [start_date, end_date] only.
+
+    Passes p_ingestion_run_id=NULL so the procedure writes no per-batch
+    ops rows — the parallel coordinator writes a single summary row instead,
+    avoiding batch_seq collisions between workers.
+    """
+    await self.connection.execute(
+        "SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0"
+    )
+    try:
+        await self.connection.execute(
+            "CALL pricing.load_staging_prices_batched"
+            "($1::varchar, $2::int, NULL, $3::date, $4::date);",
+            source_name,
+            batch_days,
+            start_date,
+            end_date,
+        )
+    finally:
+        await self.connection.execute(
+            "RESET timescaledb.max_tuples_decompressed_per_dml_transaction"
+        )
+```
+
+---
+
+## Phase 3 — Service: parallel coordinator
+
+**File:** `src/automana/core/services/app_integration/mtg_stock/data_staging.py`
+
+Add a new registered service alongside the existing `from_raw_to_staging`.
+The existing service stays intact as a fallback.
+
+### Partition helper (module-level, not registered)
+
+```python
+def _snap_partitions(raw_min, raw_max, chunk_boundaries, n_workers):
+    """Divide [raw_min, raw_max] into n_workers non-overlapping date ranges,
+    snapping boundaries to the nearest chunk edge to avoid lock contention.
+
+    Returns a list of (start_date, end_date) tuples.
+    """
+    from datetime import timedelta
+
+    # Filter boundaries that fall inside [raw_min, raw_max]
+    edges = sorted(
+        b for b in chunk_boundaries
+        if raw_min <= b <= raw_max
+    )
+    # Always include endpoints
+    all_edges = sorted({raw_min} | set(edges) | {raw_max + timedelta(days=1)})
+
+    # Spread n_workers evenly across the edge list
+    step = max(1, len(all_edges) // n_workers)
+    split_points = all_edges[::step]
+
+    partitions = []
+    for i in range(len(split_points) - 1):
+        start = split_points[i]
+        end   = split_points[i + 1] - timedelta(days=1)
+        if start <= end:
+            partitions.append((start, end))
+
+    # Merge any remainder into the last partition
+    if partitions and partitions[-1][1] < raw_max:
+        partitions[-1] = (partitions[-1][0], raw_max)
+
+    return partitions
+```
+
+### Worker coroutine (module-level, not registered)
+
+```python
+async def _staging_worker(pool, source_name, start_date, end_date, batch_days, worker_id):
+    """Acquire a dedicated connection and run load_staging_prices_batched
+    over the assigned date window.
+
+    Uses a raw pool connection rather than the injected repository connection
+    so each worker has an independent session — required because
+    SET timescaledb.max_tuples_decompressed_per_dml_transaction is session-scoped
+    and the procedure issues internal COMMITs that would reset SET LOCAL.
+    """
+    async with pool.acquire() as conn:
+        repo = PriceRepository(conn)
+        logger.info(
+            "staging_worker: starting",
+            extra={"worker_id": worker_id, "start": str(start_date), "end": str(end_date)},
+        )
+        await repo.call_load_stage_from_raw_ranged(
+            source_name=source_name,
+            start_date=start_date,
+            end_date=end_date,
+            batch_days=batch_days,
+        )
+        logger.info(
+            "staging_worker: done",
+            extra={"worker_id": worker_id, "start": str(start_date), "end": str(end_date)},
+        )
+```
+
+The `pool` reference must be threaded in from the coordinator. The ServiceManager
+already holds the pool; expose it via a lightweight accessor or pass it explicitly.
+This is the **only** place in the codebase where a service touches the pool directly
+— document the exception and don't generalise it.
+
+### Registered service
+
+```python
+@ServiceRegistry.register(
+    path="mtg_stock.data_staging.from_raw_to_staging_parallel",
+    db_repositories=["price", "ops"],
+    runs_in_transaction=False,
+    command_timeout=86400,
+)
+async def from_raw_to_staging_parallel(
+    price_repository: PriceRepository,
+    ops_repository: OpsRepository,
+    ingestion_run_id: int = None,
+    source_name: str = "mtgstocks",
+    n_workers: int = 4,
+    batch_days: int = 30,
+):
+    """Parallel variant of from_raw_to_staging.
+
+    Divides the raw date range into n_workers non-overlapping windows snapped
+    to price_observation chunk boundaries, then runs one DB session per window
+    concurrently via asyncio.gather. Workers pass p_ingestion_run_id=NULL to
+    avoid batch_seq collisions; this coordinator writes a single summary ops
+    row on completion.
+    """
+    import asyncio
+    from datetime import date as date_type
+
+    async with track_step(ops_repository, ingestion_run_id, "raw_to_staging"):
+        # 1. Discover date range
+        rows = await price_repository.execute_query(
+            "SELECT min(ts_date) AS d_min, max(ts_date) AS d_max"
+            " FROM pricing.raw_mtg_stock_price"
+        )
+        if not rows or rows[0]["d_min"] is None:
+            logger.info("from_raw_to_staging_parallel: raw table is empty, nothing to do")
+            return {}
+
+        raw_min: date_type = rows[0]["d_min"]
+        raw_max: date_type = rows[0]["d_max"]
+
+        # 2. Snap partitions to chunk boundaries
+        chunk_bounds = await price_repository.fetch_chunk_boundaries()
+        partitions = _snap_partitions(raw_min, raw_max, chunk_bounds, n_workers)
+
+        logger.info(
+            "from_raw_to_staging_parallel: launching workers",
+            extra={"n_workers": len(partitions), "raw_min": str(raw_min), "raw_max": str(raw_max)},
+        )
+
+        # 3. Run workers concurrently — each acquires its own pool connection
+        pool = price_repository.connection._pool  # implementation detail; wrap if pool accessor added
+        await asyncio.gather(*[
+            _staging_worker(pool, source_name, start, end, batch_days, i)
+            for i, (start, end) in enumerate(partitions)
+        ])
+```
+
+> **Note on pool access:** `price_repository.connection._pool` reaches into asyncpg
+> internals. The cleaner approach is to add a `pool` property to `AbstractRepository`
+> (or `ServiceManager`) and expose it explicitly. Do that in the same PR.
+
+---
+
+## Phase 4 — Pipeline wiring
+
+**File:** `src/automana/worker/tasks/pipelines.py`
+
+Swap one line in `mtgStock_download_pipeline`. Keep the serial version registered.
+
+```python
+# Before:
+run_service.s("mtg_stock.data_staging.from_raw_to_staging",
+              source_name="mtgstocks"),
+
+# After:
+run_service.s("mtg_stock.data_staging.from_raw_to_staging_parallel",
+              source_name="mtgstocks",
+              n_workers=4),
+```
+
+`n_workers=4` is a conservative start. Tune upward after validation (Phase 5).
+
+---
+
+## Phase 5 — Validation before adopting in production
+
+Run this against a clean dev DB before merging:
+
+1. Load a narrow raw slice into `raw_mtg_stock_price`: `2018-01-01 → 2018-12-31`
+2. Run the **serial** version:
+   ```bash
+   automana-run mtg_stock.data_staging.from_raw_to_staging --source_name mtgstocks
+   ```
+3. Capture a fingerprint:
+   ```sql
+   SELECT COUNT(*),
+          MD5(string_agg(ts_date::text || source_product_id::text || sold_avg_cents::text,
+                         ',' ORDER BY ts_date, source_product_id))
+   FROM pricing.price_observation;
+   ```
+4. Truncate `price_observation`, reload the same raw slice.
+5. Run the **parallel** version:
+   ```bash
+   automana-run mtg_stock.data_staging.from_raw_to_staging_parallel \
+     --source_name mtgstocks --n_workers 4
+   ```
+6. Capture the same fingerprint. **Must match exactly.**
+
+---
+
+## Delivery order
+
+| # | Phase | Files touched | Blocking? |
+|---|-------|---------------|-----------|
+| 0 | Postgres tuning | `docker-compose.dev.yml` | Yes — do before any parallel run |
+| 1 | Migration | `migrations/migration_17_*.sql`, `schemas/06_prices.sql` | Yes — procedure must exist before repo methods |
+| 2 | Repository additions | `price_repository.py` | Yes |
+| 3 | Coordinator service | `data_staging.py` | Yes |
+| 4 | Pipeline swap | `pipelines.py` | After validation |
+| 5 | Validation | Manual | Gate for Phase 4 |
+
+Phases 1–3 can be written and unit-tested without a running DB. Phase 4 is a
+one-line change gated on Phase 5 passing.

--- a/src/automana/core/services/app_integration/mtg_stock/data_staging.py
+++ b/src/automana/core/services/app_integration/mtg_stock/data_staging.py
@@ -224,7 +224,8 @@ async def retry_rejects(price_repository: PriceRepository,
 )
 async def from_staging_to_prices(price_repository: PriceRepository
                                  , ops_repository: OpsRepository
-                                 , ingestion_run_id: int = None):
+                                 , ingestion_run_id: int = None
+                                 , **_kwargs):
     """Promote stg_price_observation rows into the pricing.price_observation
     hypertable via pricing.load_prices_from_staged_batched(). The previously
     separate `from_staging_to_dim` step has been removed — no

--- a/src/automana/database/SQL/migrations/migration_17_foil_finish_suffix.sql
+++ b/src/automana/database/SQL/migrations/migration_17_foil_finish_suffix.sql
@@ -1,0 +1,1003 @@
+-- Migration 17: Foil-treatment finish suffix mapping
+--
+-- Adds pricing.mtgstock_name_finish_suffix, new finish codes (SURGE_FOIL,
+-- RIPPLE_FOIL, RAINBOW_FOIL), and updates the three pricing procedures to:
+--   1. Accept "Base Name (Foil Treatment)" names in the set+collector fallback
+--      name check (resolves ~403 K foil-treatment reject rows).
+--   2. Assign the granular finish_id from the suffix table instead of the
+--      generic FOIL finish_id during promotion.
+-- Safe to re-run: all INSERTs use ON CONFLICT DO NOTHING.
+-- Applies to: load_staging_prices_batched, load_prices_from_staged_batched,
+--             resolve_price_rejects.
+
+BEGIN;
+
+-- -----------------------------------------------------------------------
+-- 1) New finish codes
+-- -----------------------------------------------------------------------
+INSERT INTO pricing.card_finished (code, description) VALUES
+  ('SURGE_FOIL',   'Surge Foil'),
+  ('RIPPLE_FOIL',  'Ripple Foil'),
+  ('RAINBOW_FOIL', 'Rainbow Foil')
+ON CONFLICT (code) DO NOTHING;
+
+-- -----------------------------------------------------------------------
+-- 2) Suffix mapping table
+-- -----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS pricing.mtgstock_name_finish_suffix (
+    suffix     TEXT PRIMARY KEY,
+    finish_id  SMALLINT NOT NULL REFERENCES pricing.card_finished(finish_id)
+);
+
+INSERT INTO pricing.mtgstock_name_finish_suffix (suffix, finish_id) VALUES
+  ('Surge Foil',    (SELECT finish_id FROM pricing.card_finished WHERE code = 'SURGE_FOIL')),
+  ('Ripple Foil',   (SELECT finish_id FROM pricing.card_finished WHERE code = 'RIPPLE_FOIL')),
+  ('Rainbow Foil',  (SELECT finish_id FROM pricing.card_finished WHERE code = 'RAINBOW_FOIL')),
+  ('Foil Etched',   (SELECT finish_id FROM pricing.card_finished WHERE code = 'ETCHED')),
+  ('Ripper Foil',   (SELECT finish_id FROM pricing.card_finished WHERE code = 'FOIL')),
+  ('Textured Foil', (SELECT finish_id FROM pricing.card_finished WHERE code = 'FOIL'))
+ON CONFLICT (suffix) DO NOTHING;
+
+-- -----------------------------------------------------------------------
+-- 3) load_staging_prices_batched — updated tmp_map_fallback name check
+--    and _prom_batch finish_id derivation.
+-- -----------------------------------------------------------------------
+CREATE OR REPLACE PROCEDURE pricing.load_staging_prices_batched(source_name VARCHAR(20), batch_days int DEFAULT 30, p_ingestion_run_id INT DEFAULT NULL)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_min date;
+  v_max date;
+  v_start date;
+  v_end   date;
+  v_source_id SMALLINT;
+  v_ok boolean;
+  v_mtg_game_id SMALLINT;
+  v_data_provider_id SMALLINT;
+  cur_rows bigint;
+  total_inserted bigint := 0;
+  v_batch_seq   INT := 0;
+  v_batch_start TIMESTAMPTZ;
+  v_total_days  INT;
+  -- Promotion dimension IDs — resolved once before the loop
+  v_price_type_id      int;
+  v_finish_foil_id     smallint;
+  v_finish_default_id  smallint;
+  v_condition_id       smallint;
+  v_language_id        smallint;
+  -- Per-batch promotion counters
+  v_prom_rows          bigint;
+  v_prom_deleted       bigint;
+  total_promoted       bigint := 0;
+  total_staged_drained bigint := 0;
+
+BEGIN
+  -- determine overall date range from raw data
+  SET LOCAL work_mem = '512MB';
+  SET LOCAL maintenance_work_mem = '1GB';
+  -- NOTE: temp_buffers cannot be changed after first temp-table access in a
+  -- session, so it is NOT set here.  The target value (256 MB = 32768 pages)
+  -- is pre-configured at pool-connection time via asyncpg server_settings in
+  -- core/database.py, which makes this SET LOCAL a no-op on pool-recycled
+  -- connections and avoids InvalidParameterValueError on second+ invocations.
+  SET LOCAL synchronous_commit = off;
+  SET LOCAL max_parallel_workers_per_gather = 4;
+
+  SELECT min(ts_date), max(ts_date) INTO v_min, v_max FROM pricing.raw_mtg_stock_price;
+  IF v_min IS NULL THEN
+    RAISE NOTICE 'load_staging_prices_batched: no rows in raw_mtg_stock_price';
+    RETURN;
+  END IF;
+  v_total_days := (v_max - v_min) + 1;
+
+  SELECT ps.source_id INTO v_source_id
+  FROM pricing.price_source ps
+  WHERE ps.code = source_name;
+
+  IF v_source_id IS NULL THEN
+    RAISE EXCEPTION 'Missing source_code=% in pricing.price_source', source_name;
+  END IF;
+
+  SELECT dp.data_provider_id INTO v_data_provider_id
+  FROM pricing.data_provider dp
+  WHERE dp.code = 'mtgstocks';
+
+  IF v_data_provider_id IS NULL THEN
+    RAISE EXCEPTION 'Missing pricing.data_provider row with code=mtgstocks';
+  END IF;
+
+  SELECT cg.game_id INTO v_mtg_game_id
+  FROM card_catalog.card_games_ref cg
+  WHERE lower(cg.code) IN ('mtg', 'magic', 'magic_the_gathering')
+  ORDER BY CASE lower(cg.code) WHEN 'mtg' THEN 1 ELSE 2 END
+  LIMIT 1;
+
+  v_start := v_min;
+
+  -- Resolve promotion dimension IDs once — stable across all batches.
+  v_finish_default_id := pricing.default_finish_id();
+  SELECT cf.finish_id INTO v_finish_foil_id
+  FROM pricing.card_finished cf
+  WHERE lower(cf.code) IN ('foil', 'foiled', 'premium')
+  ORDER BY cf.finish_id LIMIT 1;
+  IF v_finish_foil_id IS NULL THEN
+    v_finish_foil_id := v_finish_default_id;
+  END IF;
+  SELECT tt.transaction_type_id INTO v_price_type_id
+  FROM pricing.transaction_type tt
+  WHERE lower(tt.transaction_type_code) = 'sell'
+  ORDER BY tt.transaction_type_id LIMIT 1;
+  IF v_price_type_id IS NULL THEN
+    RAISE EXCEPTION 'No ''sell'' row in pricing.transaction_type';
+  END IF;
+  v_condition_id := pricing.default_condition_id();
+  v_language_id  := card_catalog.default_language_id();
+
+  WHILE v_start <= v_max LOOP
+    v_batch_seq   := v_batch_seq + 1;
+    v_batch_start := clock_timestamp();
+    v_end := LEAST(v_start + (batch_days - 1), v_max);
+    v_ok :=false;
+    BEGIN
+      SET LOCAL work_mem                    = '512MB';
+      SET LOCAL maintenance_work_mem        = '1GB';
+      SET LOCAL synchronous_commit          = off;
+      SET LOCAL max_parallel_workers_per_gather = 4;
+
+      RAISE NOTICE 'Loading raw -> staging for % to %', v_start, v_end;
+
+      DROP TABLE IF EXISTS tmp_raw_batch;
+      CREATE TEMP TABLE tmp_raw_batch ON COMMIT DROP AS
+      SELECT
+        s.ts_date,
+        s.game_code,
+        s.print_id,
+        s.price_low,
+        s.price_avg,
+        s.price_foil,
+        s.price_market,
+        s.price_market_foil,
+        s.source_code,
+        s.scraped_at,
+        s.card_name,
+        s.set_abbr,
+        s.collector_number,
+        s.scryfall_id,
+        s.tcg_id,
+        s.cardtrader_id,
+        v_data_provider_id AS data_provider_id
+      FROM pricing.raw_mtg_stock_price s
+      WHERE s.ts_date >= v_start
+        AND s.ts_date <= v_end;
+
+      DROP TABLE IF EXISTS tmp_batch_foil_split;
+      CREATE TEMP TABLE tmp_batch_foil_split ON COMMIT DROP AS
+      SELECT
+        r.ts_date,
+        r.game_code,
+        r.print_id,
+        r.source_code,
+        r.scraped_at,
+        r.card_name,
+        r.set_abbr,
+        r.collector_number,
+        r.scryfall_id,
+        r.tcg_id,
+        r.cardtrader_id,
+        (v.list_low_cents * 100)::int AS list_low_cents,
+        (v.list_avg_cents * 100)::int AS list_avg_cents,
+        (v.sold_avg_cents * 100)::int AS sold_avg_cents,
+        v.is_foil,
+        v.value,
+        r.data_provider_id
+      FROM tmp_raw_batch r
+      CROSS JOIN LATERAL (VALUES
+        (r.price_low, r.price_avg, r.price_market, false,
+         COALESCE(r.price_avg, r.price_market, r.price_low)),
+        (NULL::numeric, r.price_foil, r.price_market_foil, true,
+         COALESCE(r.price_foil, r.price_market_foil))
+      ) AS v(list_low_cents, list_avg_cents, sold_avg_cents, is_foil, value)
+      WHERE v.value IS NOT NULL;
+
+      DROP TABLE IF EXISTS tmp_map_print;
+      CREATE TEMP TABLE tmp_map_print ON COMMIT DROP AS
+      SELECT DISTINCT
+        u.print_id,
+        cei.card_version_id
+      FROM tmp_batch_foil_split u
+      JOIN card_catalog.card_identifier_ref cir
+        ON cir.identifier_name = 'mtgstock_id'
+      JOIN card_catalog.card_external_identifier cei
+        ON cei.card_identifier_ref_id = cir.card_identifier_ref_id
+       AND cei.value = u.print_id::text
+      WHERE u.print_id IS NOT NULL;
+
+      DROP TABLE IF EXISTS tmp_map_external;
+      CREATE TEMP TABLE tmp_map_external ON COMMIT DROP AS
+      WITH candidates AS (
+        SELECT u.print_id
+          , 'scryfall_id'::text   AS identifier_name
+          , COALESCE(m.new_scryfall_id::text, u.scryfall_id) AS identifier_value, 1 AS prio
+        FROM tmp_raw_batch u
+        LEFT JOIN card_catalog.scryfall_migration m
+          ON NULLIF(u.scryfall_id,'')::uuid = m.old_scryfall_id
+         AND m.migration_strategy IN ('merge','move')
+         AND m.new_scryfall_id IS NOT NULL
+        WHERE u.scryfall_id IS NOT NULL AND u.scryfall_id <> ''
+
+        UNION ALL
+        SELECT u.print_id, 'tcgplayer_id'::text, u.tcg_id, 2
+        FROM tmp_raw_batch u WHERE u.tcg_id IS NOT NULL
+
+        UNION ALL
+        SELECT u.print_id, 'cardtrader_id'::text, u.cardtrader_id, 3
+        FROM tmp_raw_batch u WHERE u.cardtrader_id IS NOT NULL
+      ),
+      joined AS (
+        SELECT c.print_id, c.prio, cei.card_version_id
+        FROM candidates c
+        JOIN card_catalog.card_identifier_ref cir
+          ON cir.identifier_name = c.identifier_name
+        JOIN card_catalog.card_external_identifier cei
+          ON cei.card_identifier_ref_id = cir.card_identifier_ref_id
+         AND cei.value = c.identifier_value
+      ),
+      ranked AS (
+        SELECT *, row_number() OVER (PARTITION BY print_id ORDER BY prio) rn
+        FROM joined
+      )
+      SELECT print_id, card_version_id
+      FROM ranked
+      WHERE rn = 1;
+
+      -- fallback by set + collector; relaxed name check allows "Name (Foil Suffix)"
+      DROP TABLE IF EXISTS tmp_map_fallback;
+      CREATE TEMP TABLE tmp_map_fallback ON COMMIT DROP AS
+      SELECT DISTINCT
+        u.set_abbr,
+        u.collector_number,
+        cv.card_version_id
+      FROM tmp_raw_batch u
+      JOIN card_catalog.sets sr
+        ON LOWER(sr.set_code) = LOWER(u.set_abbr)
+      JOIN card_catalog.card_version cv
+        ON cv.set_id = sr.set_id
+       AND cv.collector_number::text = u.collector_number
+      LEFT JOIN card_catalog.unique_cards_ref uc
+        ON uc.unique_card_id = cv.unique_card_id
+      WHERE u.set_abbr IS NOT NULL
+        AND u.collector_number IS NOT NULL
+        AND (
+            u.card_name IS NULL
+            OR uc.card_name IS NULL
+            OR lower(uc.card_name) = lower(u.card_name)
+            OR lower(u.card_name) LIKE (lower(uc.card_name) || ' (%')
+        );
+
+      DROP TABLE IF EXISTS tmp_resolved;
+      CREATE TEMP TABLE tmp_resolved ON COMMIT DROP AS
+      SELECT
+        u.*,
+        COALESCE(mp.card_version_id, me.card_version_id, mf.card_version_id) AS card_version_id,
+        CASE
+          WHEN mp.card_version_id IS NOT NULL THEN 'PRINT_ID'
+          WHEN me.card_version_id IS NOT NULL THEN 'EXTERNAL_ID'
+          WHEN mf.card_version_id IS NOT NULL THEN 'SET_COLLECTOR'
+          ELSE 'UNRESOLVED'
+        END AS resolution_method
+      FROM tmp_batch_foil_split u
+      LEFT JOIN tmp_map_print mp
+        ON mp.print_id = u.print_id
+      LEFT JOIN tmp_map_external me
+        ON me.print_id = u.print_id
+      LEFT JOIN tmp_map_fallback mf
+        ON mf.set_abbr = u.set_abbr
+       AND mf.collector_number = u.collector_number;
+
+      WITH resolved_prints AS (
+        SELECT DISTINCT r.print_id, r.card_version_id
+        FROM tmp_resolved r
+        WHERE r.print_id IS NOT NULL AND r.card_version_id IS NOT NULL
+      ),
+      unambiguous_print AS (
+        SELECT rp.print_id, rp.card_version_id
+        FROM resolved_prints rp
+        JOIN (
+          SELECT print_id
+          FROM resolved_prints
+          GROUP BY print_id
+          HAVING count(DISTINCT card_version_id) = 1
+        ) ok USING (print_id)
+      ),
+      pick_one_per_cv AS (
+        SELECT DISTINCT ON (card_version_id)
+          card_version_id,
+          print_id::text AS print_value
+        FROM unambiguous_print
+        ORDER BY card_version_id, print_id
+      ),
+      mtgstock_ref AS (
+        SELECT card_identifier_ref_id
+        FROM card_catalog.card_identifier_ref
+        WHERE identifier_name = 'mtgstock_id'
+        LIMIT 1
+      )
+      INSERT INTO card_catalog.card_external_identifier (card_identifier_ref_id, card_version_id, value)
+      SELECT r.card_identifier_ref_id, p.card_version_id, p.print_value
+      FROM pick_one_per_cv p
+      CROSS JOIN mtgstock_ref r
+      LEFT JOIN card_catalog.card_external_identifier existing_pk
+        ON existing_pk.card_version_id = p.card_version_id
+       AND existing_pk.card_identifier_ref_id = r.card_identifier_ref_id
+      WHERE existing_pk.card_version_id IS NULL
+      ON CONFLICT (card_version_id, card_identifier_ref_id) DO NOTHING;
+
+      INSERT INTO pricing.stg_price_observation_reject (
+        ts_date, game_code, print_id, source_code, data_provider_id, scraped_at,
+        list_low_cents, list_avg_cents, sold_avg_cents, is_foil, value,
+        card_name, set_abbr, collector_number, scryfall_id, tcg_id, cardtrader_id,
+        reject_reason
+      )
+      SELECT
+        r.ts_date, r.game_code, r.print_id, r.source_code, r.data_provider_id, r.scraped_at,
+        r.list_low_cents, r.list_avg_cents, r.sold_avg_cents, r.is_foil, r.value,
+        r.card_name, r.set_abbr, r.collector_number, r.scryfall_id, r.tcg_id, r.cardtrader_id,
+        'Could not resolve card_version_id via print_id/external_id/set+collector'
+      FROM tmp_resolved r
+      WHERE r.card_version_id IS NULL;
+
+      WITH need AS (
+        SELECT DISTINCT r.card_version_id
+        FROM tmp_resolved r
+        LEFT JOIN pricing.mtg_card_products mcp ON mcp.card_version_id = r.card_version_id
+        WHERE r.card_version_id IS NOT NULL AND mcp.product_id IS NULL
+      ),
+      gen AS (
+        SELECT card_version_id, uuid_generate_v4() AS product_id FROM need
+      ),
+      ins_prod AS (
+        INSERT INTO pricing.product_ref (product_id, game_id)
+        SELECT product_id, v_mtg_game_id FROM gen
+        ON CONFLICT (product_id) DO NOTHING
+      )
+      INSERT INTO pricing.mtg_card_products (product_id, card_version_id)
+      SELECT product_id, card_version_id FROM gen
+      ON CONFLICT (card_version_id) DO NOTHING;
+
+      DROP TABLE IF EXISTS tmp_product_lookup;
+      CREATE TEMP TABLE tmp_product_lookup ON COMMIT DROP AS
+      SELECT mcp.card_version_id, mcp.product_id
+      FROM pricing.mtg_card_products mcp
+      WHERE mcp.card_version_id IN (
+        SELECT DISTINCT card_version_id FROM tmp_resolved WHERE card_version_id IS NOT NULL
+      );
+
+      INSERT INTO pricing.source_product (product_id, source_id)
+      SELECT DISTINCT pl.product_id, v_source_id
+      FROM tmp_product_lookup pl
+      LEFT JOIN pricing.source_product sp
+        ON sp.product_id = pl.product_id AND sp.source_id = v_source_id
+      WHERE sp.source_product_id IS NULL
+      ON CONFLICT (product_id, source_id) DO NOTHING;
+
+      DROP TABLE IF EXISTS tmp_sp_lookup;
+      CREATE TEMP TABLE tmp_sp_lookup ON COMMIT DROP AS
+      SELECT pl.card_version_id, pl.product_id, sp.source_product_id
+      FROM tmp_product_lookup pl
+      JOIN pricing.source_product sp
+        ON sp.product_id = pl.product_id AND sp.source_id = v_source_id;
+
+      INSERT INTO pricing.stg_price_observation (
+        ts_date, game_code, print_id, list_low_cents, list_avg_cents, sold_avg_cents,
+        is_foil, source_code, data_provider_id, value,
+        product_id, card_version_id, source_product_id,
+        set_abbr, collector_number, card_name, scryfall_id, tcg_id, scraped_at
+      )
+      SELECT
+        r.ts_date, r.game_code, r.print_id,
+        r.list_low_cents, r.list_avg_cents, r.sold_avg_cents,
+        r.is_foil, r.source_code, r.data_provider_id, r.value,
+        l.product_id, r.card_version_id, l.source_product_id,
+        r.set_abbr, r.collector_number, r.card_name, r.scryfall_id, r.tcg_id, r.scraped_at
+      FROM tmp_resolved r
+      JOIN tmp_sp_lookup l ON l.card_version_id = r.card_version_id
+      WHERE r.card_version_id IS NOT NULL;
+
+      GET DIAGNOSTICS cur_rows = ROW_COUNT;
+      total_inserted := total_inserted + cur_rows;
+
+      -- Inline promotion: drain staging rows for this date window immediately.
+      -- finish_id uses suffix table for named foil treatments, falls back to
+      -- the is_foil flag otherwise.
+      DROP TABLE IF EXISTS _prom_batch;
+      CREATE TEMP TABLE _prom_batch ON COMMIT DROP AS
+      SELECT
+        s.stg_id,
+        s.ts_date,
+        s.source_product_id,
+        s.data_provider_id,
+        v_price_type_id::int                              AS price_type_id,
+        COALESCE(
+            fsm.finish_id,
+            CASE WHEN s.is_foil THEN v_finish_foil_id
+                 ELSE v_finish_default_id END
+        )                                                 AS finish_id,
+        v_condition_id                                    AS condition_id,
+        v_language_id                                     AS language_id,
+        s.list_low_cents,
+        s.list_avg_cents,
+        s.sold_avg_cents,
+        s.scraped_at
+      FROM pricing.stg_price_observation s
+      LEFT JOIN pricing.mtgstock_name_finish_suffix fsm
+          ON s.card_name ~ '\([^)]+\)$'
+         AND fsm.suffix = regexp_replace(s.card_name, '^.+\s+\(([^)]+)\)$', '\1')
+      WHERE s.ts_date >= v_start
+        AND s.ts_date <= v_end
+        AND NOT (s.list_low_cents IS NULL
+             AND s.list_avg_cents IS NULL
+             AND s.sold_avg_cents IS NULL);
+
+      DROP TABLE IF EXISTS _prom_dedup;
+      CREATE TEMP TABLE _prom_dedup ON COMMIT DROP AS
+      SELECT *
+      FROM (
+        SELECT b.*,
+               row_number() OVER (
+                 PARTITION BY
+                   b.ts_date, b.source_product_id, b.price_type_id,
+                   b.finish_id, b.condition_id, b.language_id, b.data_provider_id
+                 ORDER BY b.scraped_at DESC, b.stg_id DESC
+               ) AS rn
+        FROM _prom_batch b
+      ) x
+      WHERE rn = 1;
+
+      INSERT INTO pricing.price_observation (
+        ts_date, source_product_id, price_type_id,
+        finish_id, condition_id, language_id, data_provider_id,
+        list_low_cents, list_avg_cents, sold_avg_cents, scraped_at
+      )
+      SELECT
+        ts_date, source_product_id, price_type_id,
+        finish_id, condition_id, language_id, data_provider_id,
+        list_low_cents, list_avg_cents, sold_avg_cents, scraped_at
+      FROM _prom_dedup
+      ORDER BY ts_date
+      ON CONFLICT (ts_date, source_product_id, price_type_id,
+                   finish_id, condition_id, language_id, data_provider_id)
+      DO UPDATE SET
+        list_low_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.list_low_cents IS NOT NULL
+            THEN EXCLUDED.list_low_cents
+          ELSE pricing.price_observation.list_low_cents
+        END,
+        list_avg_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.list_avg_cents IS NOT NULL
+            THEN EXCLUDED.list_avg_cents
+          ELSE pricing.price_observation.list_avg_cents
+        END,
+        sold_avg_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.sold_avg_cents IS NOT NULL
+            THEN EXCLUDED.sold_avg_cents
+          ELSE pricing.price_observation.sold_avg_cents
+        END,
+        scraped_at = GREATEST(pricing.price_observation.scraped_at, EXCLUDED.scraped_at),
+        updated_at = now();
+
+      GET DIAGNOSTICS v_prom_rows = ROW_COUNT;
+      total_promoted := total_promoted + v_prom_rows;
+
+      DELETE FROM pricing.stg_price_observation s
+      USING _prom_batch b
+      WHERE s.stg_id = b.stg_id;
+
+      GET DIAGNOSTICS v_prom_deleted = ROW_COUNT;
+      total_staged_drained := total_staged_drained + v_prom_deleted;
+
+      RAISE NOTICE 'Batch % to %: staged %, promoted %, drained %',
+                   v_start, v_end, cur_rows, v_prom_rows, v_prom_deleted;
+      v_ok := true;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'Error processing batch % to %: %', v_start, v_end, SQLERRM;
+      v_ok := false;
+    END;
+
+    if v_ok THEN
+      COMMIT;
+    ELSE
+      ROLLBACK;
+    END IF;
+    IF p_ingestion_run_id IS NOT NULL THEN
+      INSERT INTO ops.ingestion_step_batches (
+        ingestion_run_step_id, batch_seq, range_start, range_end,
+        status, items_ok, items_failed, duration_ms, error_details
+      )
+      SELECT
+        st.id,
+        v_batch_seq,
+        EXTRACT(EPOCH FROM v_start)::bigint,
+        EXTRACT(EPOCH FROM v_end)::bigint,
+        CASE WHEN v_ok THEN 'success' ELSE 'failed' END,
+        CASE WHEN v_ok THEN cur_rows ELSE 0 END,
+        0,
+        ROUND(EXTRACT(EPOCH FROM (clock_timestamp() - v_batch_start)) * 1000)::int,
+        jsonb_build_object('date_start', v_start::text, 'date_end', v_end::text,
+                           'total_inserted', total_inserted,
+                           'promoted', v_prom_rows)
+      FROM ops.ingestion_run_steps st
+      WHERE st.ingestion_run_id = p_ingestion_run_id
+        AND st.step_name = 'raw_to_staging'
+      LIMIT 1
+      ON CONFLICT (ingestion_run_step_id, batch_seq) DO NOTHING;
+      UPDATE ops.ingestion_run_steps
+      SET progress = ROUND(100.0 * (v_end - v_min + 1) / NULLIF(v_total_days, 0), 2)
+      WHERE ingestion_run_id = p_ingestion_run_id AND step_name = 'raw_to_staging';
+      COMMIT;
+    END IF;
+    v_start := v_end + 1;
+  END LOOP;
+  RAISE NOTICE 'load_staging_prices_batched: total staged %, promoted %, drained %',
+               total_inserted, total_promoted, total_staged_drained;
+END;
+$$;
+
+-- -----------------------------------------------------------------------
+-- 4) load_prices_from_staged_batched — updated _batch finish_id derivation.
+--    Safety-net path for reject rows re-fed via resolve_price_rejects.
+-- -----------------------------------------------------------------------
+CREATE OR REPLACE PROCEDURE pricing.load_prices_from_staged_batched(batch_days int DEFAULT 30)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_min date;
+  v_max date;
+  v_start date;
+  v_end date;
+  v_price_type_id      int;
+  v_finish_foil_id     smallint;
+  v_finish_default_id  smallint;
+  v_condition_id       smallint;
+  v_language_id        smallint;
+  v_ok boolean;
+  cur_rows      bigint;
+  deleted_rows  bigint;
+  inserted_rows bigint := 0;
+  total_deleted bigint := 0;
+BEGIN
+  v_finish_default_id := pricing.default_finish_id();
+
+  SELECT cf.finish_id
+  INTO   v_finish_foil_id
+  FROM   pricing.card_finished cf
+  WHERE  lower(cf.code) IN ('foil', 'foiled', 'premium')
+  ORDER  BY cf.finish_id
+  LIMIT  1;
+
+  IF v_finish_foil_id IS NULL THEN
+    v_finish_foil_id := v_finish_default_id;
+  END IF;
+
+  SELECT tt.transaction_type_id
+  INTO   v_price_type_id
+  FROM   pricing.transaction_type tt
+  WHERE  lower(tt.transaction_type_code) = 'sell'
+  ORDER  BY tt.transaction_type_id
+  LIMIT  1;
+
+  IF v_price_type_id IS NULL THEN
+    RAISE EXCEPTION 'No ''sell'' row in pricing.transaction_type; cannot load price_observation';
+  END IF;
+
+  v_condition_id := pricing.default_condition_id();
+  v_language_id  := card_catalog.default_language_id();
+
+  SELECT min(ts_date), max(ts_date)
+  INTO   v_min, v_max
+  FROM   pricing.stg_price_observation;
+
+  IF v_min IS NULL THEN
+    RAISE NOTICE 'load_prices_from_staged_batched: staging is empty, nothing to do';
+    RETURN;
+  END IF;
+
+  RAISE NOTICE 'Loading price_observation from staging for % to %', v_min, v_max;
+
+  v_start := v_min;
+  WHILE v_start <= v_max LOOP
+    v_end := LEAST(v_start + (batch_days - 1), v_max);
+    v_ok  := false;
+
+    BEGIN
+      SET LOCAL work_mem          = '512MB';
+      SET LOCAL maintenance_work_mem = '1GB';
+      SET LOCAL synchronous_commit   = off;
+
+      RAISE NOTICE 'Batch % to %', v_start, v_end;
+
+      DROP TABLE IF EXISTS _batch;
+      CREATE TEMP TABLE _batch ON COMMIT DROP AS
+      SELECT
+        s.stg_id,
+        s.ts_date,
+        s.source_product_id,
+        s.data_provider_id,
+        v_price_type_id::int                          AS price_type_id,
+        COALESCE(
+            fsm.finish_id,
+            CASE WHEN s.is_foil THEN v_finish_foil_id
+                 ELSE v_finish_default_id END
+        )                                             AS finish_id,
+        v_condition_id                                AS condition_id,
+        v_language_id                                 AS language_id,
+        s.list_low_cents,
+        s.list_avg_cents,
+        s.sold_avg_cents,
+        s.scraped_at
+      FROM pricing.stg_price_observation s
+      LEFT JOIN pricing.mtgstock_name_finish_suffix fsm
+          ON s.card_name ~ '\([^)]+\)$'
+         AND fsm.suffix = regexp_replace(s.card_name, '^.+\s+\(([^)]+)\)$', '\1')
+      WHERE s.ts_date >= v_start
+        AND s.ts_date <= v_end
+        AND NOT (s.list_low_cents IS NULL
+             AND s.list_avg_cents IS NULL
+             AND s.sold_avg_cents IS NULL);
+
+      DROP TABLE IF EXISTS _dedup;
+      CREATE TEMP TABLE _dedup ON COMMIT DROP AS
+      SELECT *
+      FROM (
+        SELECT b.*,
+               row_number() OVER (
+                 PARTITION BY
+                   b.ts_date, b.source_product_id, b.price_type_id,
+                   b.finish_id, b.condition_id, b.language_id, b.data_provider_id
+                 ORDER BY b.scraped_at DESC, b.stg_id DESC
+               ) AS rn
+        FROM _batch b
+      ) x
+      WHERE rn = 1;
+
+      INSERT INTO pricing.price_observation (
+        ts_date, source_product_id, price_type_id,
+        finish_id, condition_id, language_id, data_provider_id,
+        list_low_cents, list_avg_cents, sold_avg_cents, scraped_at
+      )
+      SELECT
+        ts_date, source_product_id, price_type_id,
+        finish_id, condition_id, language_id, data_provider_id,
+        list_low_cents, list_avg_cents, sold_avg_cents, scraped_at
+      FROM _dedup
+      ORDER BY ts_date
+      ON CONFLICT (ts_date, source_product_id, price_type_id,
+                   finish_id, condition_id, language_id, data_provider_id)
+      DO UPDATE SET
+        list_low_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.list_low_cents IS NOT NULL
+            THEN EXCLUDED.list_low_cents
+          ELSE pricing.price_observation.list_low_cents
+        END,
+        list_avg_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.list_avg_cents IS NOT NULL
+            THEN EXCLUDED.list_avg_cents
+          ELSE pricing.price_observation.list_avg_cents
+        END,
+        sold_avg_cents = CASE
+          WHEN EXCLUDED.scraped_at >= pricing.price_observation.scraped_at
+               AND EXCLUDED.sold_avg_cents IS NOT NULL
+            THEN EXCLUDED.sold_avg_cents
+          ELSE pricing.price_observation.sold_avg_cents
+        END,
+        scraped_at = GREATEST(pricing.price_observation.scraped_at, EXCLUDED.scraped_at),
+        updated_at = now();
+
+      GET DIAGNOSTICS cur_rows = ROW_COUNT;
+      inserted_rows := inserted_rows + cur_rows;
+
+      DELETE FROM pricing.stg_price_observation s
+      USING _batch b
+      WHERE s.stg_id = b.stg_id;
+
+      GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+      total_deleted := total_deleted + deleted_rows;
+
+      RAISE NOTICE 'Batch % to %: inserted/updated %, deleted % staging rows',
+                   v_start, v_end, cur_rows, deleted_rows;
+
+      v_ok := true;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'Error processing batch % to %: % (SQLSTATE %)',
+                    v_start, v_end, SQLERRM, SQLSTATE;
+      v_ok := false;
+    END;
+
+    IF v_ok THEN
+      COMMIT;
+    ELSE
+      ROLLBACK;
+    END IF;
+    v_start := v_end + 1;
+  END LOOP;
+
+  RAISE NOTICE 'load_prices_from_staged_batched: total inserted/updated %, total deleted from staging %',
+               inserted_rows, total_deleted;
+END;
+$$;
+
+-- -----------------------------------------------------------------------
+-- 5) resolve_price_rejects — updated map_fb name check.
+-- -----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pricing.resolve_price_rejects(
+    p_limit int DEFAULT 50000,
+    p_only_unresolved boolean DEFAULT true
+)
+RETURNS bigint
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_source_id       smallint;
+  v_mtg_game_id     smallint;
+  v_inserted        bigint := 0;
+  v_selected        bigint := 0;
+  v_print_id        bigint := 0;
+  v_external_id     bigint := 0;
+  v_set_collector   bigint := 0;
+  v_unresolved      bigint := 0;
+  v_terminal_scry   bigint := 0;
+BEGIN
+  SELECT ps.source_id INTO v_source_id
+  FROM pricing.price_source ps
+  WHERE ps.code = 'mtgstocks';
+
+  IF v_source_id IS NULL THEN
+    RAISE EXCEPTION 'Missing source_code=mtgstocks in pricing.price_source';
+  END IF;
+
+  SELECT cg.game_id INTO v_mtg_game_id
+  FROM card_catalog.card_games_ref cg
+  WHERE lower(cg.code) IN ('mtg', 'magic', 'magic_the_gathering')
+  ORDER BY CASE lower(cg.code) WHEN 'mtg' THEN 1 ELSE 2 END
+  LIMIT 1;
+
+  IF v_mtg_game_id IS NULL THEN
+    RAISE EXCEPTION 'Could not resolve MTG game_id';
+  END IF;
+
+  DROP TABLE IF EXISTS tmp_rejects;
+  CREATE TEMP TABLE tmp_rejects ON COMMIT DROP AS
+  SELECT *
+  FROM pricing.stg_price_observation_reject r
+  WHERE (NOT p_only_unresolved) OR (r.resolved_at IS NULL AND is_terminal IS FALSE)
+  ORDER BY r.resolution_attempted_at
+  LIMIT p_limit;
+
+  SELECT COUNT(*) INTO v_selected FROM tmp_rejects;
+  RAISE NOTICE 'resolve_price_rejects: selected % candidates (only_unresolved=%)', v_selected, p_only_unresolved;
+
+  DROP TABLE IF EXISTS tmp_resolved;
+  CREATE TEMP TABLE tmp_resolved ON COMMIT DROP AS
+  WITH map_print AS (
+    SELECT DISTINCT r.print_id, cei.card_version_id
+    FROM tmp_rejects r
+    JOIN card_catalog.card_identifier_ref cir
+      ON cir.identifier_name = 'mtgstock_id'
+    JOIN card_catalog.card_external_identifier cei
+      ON cei.card_identifier_ref_id = cir.card_identifier_ref_id
+     AND cei.value = r.print_id::text
+  ),
+  map_ext AS (
+    WITH candidates AS (
+      SELECT r.print_id
+      , 'scryfall_id'::text AS identifier_name
+      , COALESCE(m.new_scryfall_id::text, r.scryfall_id) AS identifier_value
+      , 1 AS prio
+      FROM tmp_rejects r
+      LEFT JOIN card_catalog.scryfall_migration m
+        ON NULLIF(r.scryfall_id,'')::uuid = m.old_scryfall_id
+        AND m.migration_strategy IN ('merge', 'move')
+        AND m.new_scryfall_id IS NOT NULL
+      WHERE r.scryfall_id IS NOT NULL AND r.scryfall_id <> ''
+      UNION ALL
+      SELECT r.print_id, 'tcgplayer_id', r.tcg_id, 2
+      FROM tmp_rejects r WHERE r.tcg_id IS NOT NULL AND r.tcg_id <> ''
+      UNION ALL
+      SELECT r.print_id, 'cardtrader_id', r.cardtrader_id, 3
+      FROM tmp_rejects r WHERE r.cardtrader_id IS NOT NULL AND r.cardtrader_id <> ''
+    ),
+    joined AS (
+      SELECT c.print_id, c.prio, cei.card_version_id
+      FROM candidates c
+      JOIN card_catalog.card_identifier_ref cir
+        ON cir.identifier_name = c.identifier_name
+      JOIN card_catalog.card_external_identifier cei
+        ON cei.card_identifier_ref_id = cir.card_identifier_ref_id
+       AND cei.value = c.identifier_value
+    ),
+    ranked AS (
+      SELECT *, row_number() OVER (PARTITION BY print_id ORDER BY prio) rn
+      FROM joined
+    )
+    SELECT print_id, card_version_id
+    FROM ranked
+    WHERE rn = 1
+  ),
+  map_fb AS (
+    SELECT DISTINCT r.set_abbr, r.collector_number, cv.card_version_id
+    FROM tmp_rejects r
+    JOIN card_catalog.sets s
+      ON LOWER(s.set_code) = LOWER(r.set_abbr)
+    JOIN card_catalog.card_version cv
+      ON cv.set_id = s.set_id
+     AND cv.collector_number::text = r.collector_number
+    LEFT JOIN card_catalog.unique_cards_ref uc
+      ON uc.unique_card_id = cv.unique_card_id
+    WHERE r.set_abbr IS NOT NULL
+      AND r.collector_number IS NOT NULL
+      AND (
+          r.card_name IS NULL
+          OR uc.card_name IS NULL
+          OR lower(uc.card_name) = lower(r.card_name)
+          OR lower(r.card_name) LIKE (lower(uc.card_name) || ' (%')
+      )
+  )
+  SELECT
+    r.*,
+    COALESCE(mp.card_version_id, me.card_version_id, mf.card_version_id) AS card_version_id,
+    CASE
+      WHEN mp.card_version_id IS NOT NULL THEN 'PRINT_ID'
+      WHEN me.card_version_id IS NOT NULL THEN 'EXTERNAL_ID'
+      WHEN mf.card_version_id IS NOT NULL THEN 'SET_COLLECTOR'
+      ELSE 'UNRESOLVED'
+    END AS resolution_method
+  FROM tmp_rejects r
+  LEFT JOIN map_print mp ON mp.print_id = r.print_id
+  LEFT JOIN map_ext   me ON me.print_id = r.print_id
+  LEFT JOIN map_fb    mf ON mf.set_abbr = r.set_abbr AND mf.collector_number = r.collector_number;
+
+  SELECT
+    COUNT(*) FILTER (WHERE resolution_method = 'PRINT_ID'),
+    COUNT(*) FILTER (WHERE resolution_method = 'EXTERNAL_ID'),
+    COUNT(*) FILTER (WHERE resolution_method = 'SET_COLLECTOR'),
+    COUNT(*) FILTER (WHERE resolution_method = 'UNRESOLVED')
+  INTO v_print_id, v_external_id, v_set_collector, v_unresolved
+  FROM tmp_resolved;
+  RAISE NOTICE 'resolve_price_rejects: PRINT_ID=% EXTERNAL_ID=% SET_COLLECTOR=% UNRESOLVED=%',
+    v_print_id, v_external_id, v_set_collector, v_unresolved;
+
+  WITH resolved_prints AS (
+    SELECT DISTINCT r.print_id, r.card_version_id
+    FROM tmp_resolved r
+    WHERE r.card_version_id IS NOT NULL AND r.resolution_method <> 'PRINT_ID'
+  ),
+  unambiguous_print AS (
+    SELECT rp.print_id, rp.card_version_id
+    FROM resolved_prints rp
+    JOIN (
+      SELECT print_id FROM resolved_prints
+      GROUP BY print_id HAVING count(DISTINCT card_version_id) = 1
+    ) ok USING (print_id)
+  ),
+  pick_one_per_cv AS (
+    SELECT DISTINCT ON (card_version_id)
+      card_version_id,
+      print_id::text AS print_value
+    FROM unambiguous_print
+    ORDER BY card_version_id, print_id
+  ),
+  mtgstock_ref AS (
+    SELECT card_identifier_ref_id
+    FROM card_catalog.card_identifier_ref
+    WHERE identifier_name = 'mtgstock_id'
+    LIMIT 1
+  )
+  INSERT INTO card_catalog.card_external_identifier (card_identifier_ref_id, card_version_id, value)
+  SELECT r.card_identifier_ref_id, p.card_version_id, p.print_value
+  FROM pick_one_per_cv p
+  CROSS JOIN mtgstock_ref r
+  LEFT JOIN card_catalog.card_external_identifier existing_pk
+    ON existing_pk.card_version_id = p.card_version_id
+   AND existing_pk.card_identifier_ref_id = r.card_identifier_ref_id
+  WHERE existing_pk.card_version_id IS NULL
+  ON CONFLICT (card_version_id, card_identifier_ref_id) DO NOTHING;
+
+  WITH need AS (
+    SELECT DISTINCT card_version_id FROM tmp_resolved
+    WHERE card_version_id IS NOT NULL
+    EXCEPT SELECT card_version_id FROM pricing.mtg_card_products
+  ),
+  gen AS (
+    SELECT card_version_id, uuid_generate_v4() AS product_id FROM need
+  ),
+  ins_prod AS (
+    INSERT INTO pricing.product_ref (product_id, game_id)
+    SELECT product_id, v_mtg_game_id FROM gen
+    ON CONFLICT (product_id) DO NOTHING
+  )
+  INSERT INTO pricing.mtg_card_products (product_id, card_version_id)
+  SELECT product_id, card_version_id FROM gen
+  ON CONFLICT (card_version_id) DO NOTHING;
+
+  INSERT INTO pricing.source_product (product_id, source_id)
+  SELECT DISTINCT mcp.product_id, v_source_id
+  FROM tmp_resolved r
+  JOIN pricing.mtg_card_products mcp ON mcp.card_version_id = r.card_version_id
+  LEFT JOIN pricing.source_product sp
+    ON sp.product_id = mcp.product_id AND sp.source_id = v_source_id
+  WHERE r.card_version_id IS NOT NULL AND sp.source_product_id IS NULL
+  ON CONFLICT (product_id, source_id) DO NOTHING;
+
+  INSERT INTO pricing.stg_price_observation (
+    ts_date, game_code, print_id,
+    list_low_cents, list_avg_cents, sold_avg_cents,
+    is_foil, source_code, data_provider_id, value,
+    product_id, card_version_id, source_product_id,
+    set_abbr, collector_number, card_name, scryfall_id, tcg_id,
+    scraped_at
+  )
+  SELECT
+    r.ts_date, r.game_code, r.print_id,
+    r.list_low_cents, r.list_avg_cents, r.sold_avg_cents,
+    r.is_foil, r.source_code, r.data_provider_id, r.value,
+    mcp.product_id, r.card_version_id, sp.source_product_id,
+    r.set_abbr, r.collector_number, r.card_name, r.scryfall_id, r.tcg_id,
+    r.scraped_at
+  FROM tmp_resolved r
+  JOIN pricing.mtg_card_products mcp ON mcp.card_version_id = r.card_version_id
+  JOIN pricing.source_product sp
+    ON sp.product_id = mcp.product_id AND sp.source_id = v_source_id
+  WHERE r.card_version_id IS NOT NULL
+    AND NOT (r.list_low_cents IS NULL
+         AND r.list_avg_cents IS NULL
+         AND r.sold_avg_cents IS NULL);
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+  RAISE NOTICE 'resolve_price_rejects: re-fed % rows into stg_price_observation', v_inserted;
+
+  UPDATE pricing.stg_price_observation_reject rej
+  SET
+    resolved_at                = now(),
+    resolved_card_version_id   = r.card_version_id,
+    resolved_method            = r.resolution_method,
+    resolved_product_id        = mcp.product_id,
+    resolved_source_product_id = sp.source_product_id,
+    is_terminal                = TRUE,
+    terminal_reason            = 'Resolved via ' || r.resolution_method || ' mapping'
+  FROM tmp_resolved r
+  JOIN pricing.mtg_card_products mcp ON mcp.card_version_id = r.card_version_id
+  JOIN pricing.source_product sp
+    ON sp.product_id = mcp.product_id AND sp.source_id = v_source_id
+  WHERE rej.ts_date          = r.ts_date
+    AND rej.print_id         = r.print_id
+    AND rej.is_foil          = r.is_foil
+    AND rej.source_code      = r.source_code
+    AND rej.data_provider_id = r.data_provider_id
+    AND rej.scraped_at       = r.scraped_at
+    AND r.card_version_id IS NOT NULL;
+
+  UPDATE pricing.stg_price_observation_reject r
+  SET
+    resolved_at = now(),
+    is_terminal = TRUE,
+    terminal_reason = 'Scryfall migration delete and no alternative identifiers'
+  FROM card_catalog.scryfall_migration m
+  WHERE m.migration_strategy = 'delete'
+    AND m.old_scryfall_id::text = r.scryfall_id;
+
+  GET DIAGNOSTICS v_terminal_scry = ROW_COUNT;
+  RAISE NOTICE 'resolve_price_rejects: marked % rows terminal (scryfall delete)', v_terminal_scry;
+
+  RETURN v_inserted;
+END;
+$$;
+
+-- Grant SELECT on new table to read roles
+GRANT SELECT ON pricing.mtgstock_name_finish_suffix TO app_readonly;
+GRANT SELECT, INSERT, UPDATE ON pricing.mtgstock_name_finish_suffix TO app_celery;
+
+COMMIT;

--- a/src/automana/database/SQL/schemas/06_prices.sql
+++ b/src/automana/database/SQL/schemas/06_prices.sql
@@ -716,7 +716,7 @@ BEGIN
     cv.card_version_id
   FROM tmp_raw_batch u
   JOIN card_catalog.sets sr
-    ON sr.set_code = u.set_abbr
+    ON LOWER(sr.set_code) = LOWER(u.set_abbr)
   JOIN card_catalog.card_version cv
     ON cv.set_id = sr.set_id
   AND cv.collector_number::text = u.collector_number
@@ -1390,7 +1390,7 @@ BEGIN
     SELECT DISTINCT r.set_abbr, r.collector_number, cv.card_version_id
     FROM tmp_rejects r
     JOIN card_catalog.sets s
-      ON s.set_code = r.set_abbr
+      ON LOWER(s.set_code) = LOWER(r.set_abbr)
     JOIN card_catalog.card_version cv
       ON cv.set_id = s.set_id
      AND cv.collector_number::text = r.collector_number

--- a/src/automana/database/SQL/schemas/06_prices.sql
+++ b/src/automana/database/SQL/schemas/06_prices.sql
@@ -65,6 +65,14 @@ CREATE TABLE IF NOT EXISTS pricing.card_finished(
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+-- Maps MTGStocks name suffixes (e.g. "Surge Foil") to their finish_id.
+-- Used by load_staging_prices_batched, load_prices_from_staged_batched, and
+-- resolve_price_rejects to assign granular finishes instead of generic FOIL.
+CREATE TABLE IF NOT EXISTS pricing.mtgstock_name_finish_suffix (
+    suffix     TEXT PRIMARY KEY,
+    finish_id  SMALLINT NOT NULL REFERENCES pricing.card_finished(finish_id)
+);
+
 CREATE TABLE IF NOT EXISTS pricing.card_game (
   game_id     SMALLSERIAL PRIMARY KEY,
   code        TEXT UNIQUE NOT NULL,   -- 'mtg','yugioh','pokemon', etc.
@@ -115,10 +123,22 @@ ON CONFLICT (code) DO NOTHING;
 
 -- Finishes
 INSERT INTO pricing.card_finished (code, description) VALUES
-  ('NONFOIL', 'Nonfoil'),
-  ('FOIL',    'Foil'),
-  ('ETCHED',  'Etched')
+  ('NONFOIL',      'Nonfoil'),
+  ('FOIL',         'Foil'),
+  ('ETCHED',       'Etched'),
+  ('SURGE_FOIL',   'Surge Foil'),
+  ('RIPPLE_FOIL',  'Ripple Foil'),
+  ('RAINBOW_FOIL', 'Rainbow Foil')
 ON CONFLICT (code) DO NOTHING;
+
+INSERT INTO pricing.mtgstock_name_finish_suffix (suffix, finish_id) VALUES
+  ('Surge Foil',    (SELECT finish_id FROM pricing.card_finished WHERE code = 'SURGE_FOIL')),
+  ('Ripple Foil',   (SELECT finish_id FROM pricing.card_finished WHERE code = 'RIPPLE_FOIL')),
+  ('Rainbow Foil',  (SELECT finish_id FROM pricing.card_finished WHERE code = 'RAINBOW_FOIL')),
+  ('Foil Etched',   (SELECT finish_id FROM pricing.card_finished WHERE code = 'ETCHED')),
+  ('Ripper Foil',   (SELECT finish_id FROM pricing.card_finished WHERE code = 'FOIL')),
+  ('Textured Foil', (SELECT finish_id FROM pricing.card_finished WHERE code = 'FOIL'))
+ON CONFLICT (suffix) DO NOTHING;
 
 INSERT INTO pricing.price_source (code, name, currency_code) VALUES
   ('tcg', 'tcgplayer', 'USD'),
@@ -724,7 +744,12 @@ BEGIN
     ON uc.unique_card_id = cv.unique_card_id
   WHERE u.set_abbr IS NOT NULL
     AND u.collector_number IS NOT NULL
-    AND (u.card_name IS NULL OR uc.card_name IS NULL OR lower(uc.card_name) = lower(u.card_name));
+    AND (
+        u.card_name IS NULL
+        OR uc.card_name IS NULL
+        OR lower(uc.card_name) = lower(u.card_name)
+        OR lower(u.card_name) LIKE (lower(uc.card_name) || ' (%')
+    );
 
   -- 3d) Final resolved rows — built from tmp_batch_foil_split so that each row
   --     already carries the foil-split price columns (list_low_cents, list_avg_cents,
@@ -928,8 +953,11 @@ BEGIN
         s.source_product_id,
         s.data_provider_id,
         v_price_type_id::int                              AS price_type_id,
-        CASE WHEN s.is_foil THEN v_finish_foil_id
-             ELSE v_finish_default_id END                 AS finish_id,
+        COALESCE(
+            fsm.finish_id,
+            CASE WHEN s.is_foil THEN v_finish_foil_id
+                 ELSE v_finish_default_id END
+        )                                                 AS finish_id,
         v_condition_id                                    AS condition_id,
         v_language_id                                     AS language_id,
         s.list_low_cents,
@@ -937,6 +965,9 @@ BEGIN
         s.sold_avg_cents,
         s.scraped_at
       FROM pricing.stg_price_observation s
+      LEFT JOIN pricing.mtgstock_name_finish_suffix fsm
+          ON s.card_name ~ '\([^)]+\)$'
+         AND fsm.suffix = regexp_replace(s.card_name, '^.+\s+\(([^)]+)\)$', '\1')
       WHERE s.ts_date >= v_start
         AND s.ts_date <= v_end
         AND NOT (s.list_low_cents IS NULL
@@ -1160,8 +1191,11 @@ BEGIN
         s.source_product_id,
         s.data_provider_id,
         v_price_type_id::int                          AS price_type_id,
-        CASE WHEN s.is_foil THEN v_finish_foil_id
-             ELSE v_finish_default_id END             AS finish_id,
+        COALESCE(
+            fsm.finish_id,
+            CASE WHEN s.is_foil THEN v_finish_foil_id
+                 ELSE v_finish_default_id END
+        )                                             AS finish_id,
         v_condition_id                                AS condition_id,
         v_language_id                                 AS language_id,
         s.list_low_cents,
@@ -1169,6 +1203,9 @@ BEGIN
         s.sold_avg_cents,
         s.scraped_at
       FROM pricing.stg_price_observation s
+      LEFT JOIN pricing.mtgstock_name_finish_suffix fsm
+          ON s.card_name ~ '\([^)]+\)$'
+         AND fsm.suffix = regexp_replace(s.card_name, '^.+\s+\(([^)]+)\)$', '\1')
       WHERE s.ts_date >= v_start
         AND s.ts_date <= v_end
         AND NOT (s.list_low_cents IS NULL
@@ -1398,7 +1435,12 @@ BEGIN
       ON uc.unique_card_id = cv.unique_card_id
     WHERE r.set_abbr IS NOT NULL
       AND r.collector_number IS NOT NULL
-      AND (r.card_name IS NULL OR uc.card_name IS NULL OR lower(uc.card_name) = lower(r.card_name))
+      AND (
+          r.card_name IS NULL
+          OR uc.card_name IS NULL
+          OR lower(uc.card_name) = lower(r.card_name)
+          OR lower(r.card_name) LIKE (lower(uc.card_name) || ' (%')
+      )
   )
   SELECT
     r.*,


### PR DESCRIPTION
## Summary

- Adds granular finish types `SURGE_FOIL`, `RIPPLE_FOIL`, `RAINBOW_FOIL` to `pricing.card_finished`
- Creates `pricing.mtgstock_name_finish_suffix` mapping table (suffix text → finish_id) seeded with 6 known foil-treatment suffixes
- Relaxes the `map_fb` / `tmp_map_fallback` name check in all three pricing procedures to accept `"Base Name (Foil Treatment)"` patterns via `LIKE` — empirically safe: 0 ambiguous set+cn combinations across all 187 paren-suffix patterns in the reject data
- `_prom_batch` (inline promotion) and `_batch` (safety-net promotion) now derive `finish_id` from the suffix table via `COALESCE`, falling back to the `is_foil` flag for unmapped names

## Result (applied to dev DB)

| Metric | Before | After |
|---|---|---|
| Open reject rows | 6,073,613 | 5,801,810 |
| Distinct open print_ids | 5,978 | 5,301 |
| Rows resolved | — | 271,803 |
| SURGE_FOIL observations in price_observation | 0 | 65,867 |
| RIPPLE_FOIL observations | 0 | 171,523 |
| RAINBOW_FOIL observations | 0 | 22,181 |

## Files changed

- `src/automana/database/SQL/schemas/06_prices.sql` — source of truth updated
- `src/automana/database/SQL/migrations/migration_17_foil_finish_suffix.sql` — new migration (safe to re-run, all INSERTs use `ON CONFLICT DO NOTHING`)
- `docs/MTGSTOCK_REJECT_ANALYSIS.md` — updated progress log, new breakdown, remaining fix plan
- `docs/MTGSTOCK_PIPELINE.md` — inline promotion clarification, observed performance table
- `docs/PARALLEL_STAGING_PLAN.md` — parallel staging design doc (future work)

## Remaining reject backlog (documented in MTGSTOCK_REJECT_ANALYSIS.md)

| Fix | Rows recoverable | Status |
|---|---|---|
| Fix 2 — Art card set-code + name mapping | ~680 K | Pending |
| Fix 3 — Token resolution via token-set map | ~3.8 M | Pending |
| No-set-abbr / old tokens / catalog gaps | ~1.3 M | Structurally blocked |

## Test plan

- [ ] Run `automana-run mtg_stock.data_staging.retry_rejects --limit 300000` on a fresh DB after applying migration — confirm `rows_resolved > 0` for foil-suffix prints
- [ ] Verify `pricing.card_finished` has codes `SURGE_FOIL`, `RIPPLE_FOIL`, `RAINBOW_FOIL`
- [ ] Verify `pricing.price_observation` has rows with `finish_id IN (16, 17, 18)` after promotion
- [ ] Full rebuild: `rebuild_dev_db.sh` — schema should apply cleanly including new table and seed data

🤖 Generated with [Claude Code](https://claude.com/claude-code)