### PR TITLE
feat(dev): flower proxy wiring, ngrok container, tunnel security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,4 @@ plans/
 # rebuild_dev_db.sh per-stage logs
 logs/
 
+config/nginx/htpasswd

--- a/config/nginx/htpasswd.example
+++ b/config/nginx/htpasswd.example
@@ -1,0 +1,8 @@
+# htpasswd file for the nginx tunnel (port 8080) basic auth.
+# Copy this file to htpasswd and replace the hash with a real one.
+#
+# Generate a new entry:
+#   python3 -c "from passlib.hash import apr_md5_crypt; print('dev:' + apr_md5_crypt.hash('yourpassword'))"
+#
+# Add multiple users by adding one line per user.
+dev:$apr1$XXXXXXXX$XXXXXXXXXXXXXXXXXXXXXXXX

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -227,7 +227,7 @@ services:
     restart: unless-stopped
     environment:
       NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN}
-    command: http --domain=trolling-linseed-giddy.ngrok-free.dev proxy:8080
+    command: http --url=trolling-linseed-giddy.ngrok-free.dev --pooling-enabled proxy:8080
     networks:
       - backend-network
     depends_on:

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -88,6 +88,7 @@ services:
       - "8080:8080"
     volumes:
       - ../config/nginx/certs:/etc/nginx/certs:ro
+      - ../config/nginx/htpasswd:/etc/nginx/htpasswd:ro
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- --no-check-certificate https://localhost/health > /dev/null || exit 1"]
       interval: 10s
@@ -220,6 +221,19 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+  ngrok:
+    image: ngrok/ngrok:latest
+    container_name: automana-ngrok-dev
+    restart: unless-stopped
+    environment:
+      NGROK_AUTHTOKEN: ${NGROK_AUTHTOKEN}
+    command: http --domain=trolling-linseed-giddy.ngrok-free.dev proxy:8080
+    networks:
+      - backend-network
+    depends_on:
+      proxy:
+        condition: service_healthy
+
   schema-spy:
     build:
       context: ..

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -216,7 +216,7 @@ services:
       --db=/home/appuser/flower/flower.db
       --logging=${CELERY_LOGLEVEL:-info}"
     healthcheck:
-      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5555/healthcheck')\" || exit 1"]
+      test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:5555/flower/healthcheck')\" || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/deploy/docker/nginx/nginx.local.conf
+++ b/deploy/docker/nginx/nginx.local.conf
@@ -21,6 +21,7 @@ http {
     error_log  /var/log/nginx/error.log warn;
 
     limit_req_zone $binary_remote_addr zone=perip:10m rate=10r/s;
+    limit_req_zone $binary_remote_addr zone=flower:10m rate=5r/m;
 
     sendfile        on;
     tcp_nopush      on;
@@ -61,11 +62,9 @@ http {
         }
     }
 
-    # Tunnel listener — plain HTTP, no TLS redirect.
-    # Used by ngrok/cloudflared to receive eBay OAuth callbacks without
-    # self-signed-cert negotiation. Rate limiting and proxy headers are
-    # kept identical to the HTTPS server so the request path is production-like.
-    # Bind ngrok to this port: ngrok http --domain=<domain> 8080
+    # Tunnel listener — plain HTTP, receives ngrok-forwarded traffic.
+    # All external access goes through basic auth before reaching the app.
+    # Credentials: dev / automana-dev (regenerate htpasswd for real sharing).
     server {
         listen 8080;
         server_name localhost;
@@ -80,7 +79,16 @@ http {
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Request-ID      $request_id;
 
+        add_header X-Frame-Options         "SAMEORIGIN" always;
+        add_header X-Content-Type-Options  "nosniff" always;
+        add_header Referrer-Policy         "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';" always;
+
+        auth_basic           "AutoMana Dev";
+        auth_basic_user_file /etc/nginx/htpasswd;
+
         location /health {
+            auth_basic off;
             proxy_pass            http://fastapi_backend;
             proxy_http_version    1.1;
             proxy_connect_timeout 2s;
@@ -100,6 +108,7 @@ http {
         }
 
         location /flower/ {
+            limit_req zone=flower burst=3 nodelay;
             proxy_pass http://flower;
             proxy_http_version 1.1;
             proxy_set_header Upgrade    $http_upgrade;
@@ -158,6 +167,7 @@ http {
         }
 
         location /flower/ {
+            limit_req zone=flower burst=3 nodelay;
             proxy_pass http://flower;
             proxy_http_version 1.1;
             proxy_set_header Upgrade    $http_upgrade;

--- a/deploy/docker/nginx/nginx.local.conf
+++ b/deploy/docker/nginx/nginx.local.conf
@@ -99,6 +99,16 @@ http {
             proxy_read_timeout    60s;
         }
 
+        location /flower/ {
+            proxy_pass http://flower;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade    $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_connect_timeout 60s;
+            proxy_send_timeout    60s;
+            proxy_read_timeout    60s;
+        }
+
         location / {
             proxy_pass         http://fastapi_backend;
             proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

- **Flower proxy**: add `/flower/` location to the 8080 tunnel block (was only on 443); fix healthcheck path from `/healthcheck` → `/flower/healthcheck` (required by `--url_prefix=flower`)
- **ngrok container**: add `ngrok/ngrok` service to docker-compose; reads `NGROK_AUTHTOKEN` from `.env.dev`; connects to `proxy:8080` using the fixed free-tier domain; `--pooling-enabled` lets the container join gracefully if a terminal session already holds the domain
- **Tunnel security (port 8080)**: HTTP basic auth gate — all requests require `dev:automana-dev`; `/health` exempted for Docker healthchecks; security headers added (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, CSP)
- **Flower rate limiting**: dedicated `limit_req_zone` (5r/m, burst 3) on `/flower/` in both 443 and 8080 blocks, separate from the global `perip` zone
- **`config/nginx/htpasswd`** added to `.gitignore`; `htpasswd.example` committed with generation instructions

## Test plan

- [ ] `dcdev-automana up -d` — all containers healthy including flower and ngrok
- [ ] `curl https://trolling-linseed-giddy.ngrok-free.dev/health` → `{"status":"healthy"}` (no auth)
- [ ] `curl https://trolling-linseed-giddy.ngrok-free.dev/api/...` without credentials → 401
- [ ] Same request with `-u dev:automana-dev` → passes nginx, hits app
- [ ] `/flower/` accessible through both 8080 and 443, shows basic auth prompt
- [ ] Flower container shows `healthy` (fixed healthcheck path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)