### PR TITLE
docs: update architecture, deployment, and API for eBay CQS split, nginx tunnel, ngrok

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -179,10 +179,14 @@ eBay (`/api/integrations/ebay`)
 - `GET /api/integrations/ebay/auth/callback` — OAuth callback
 - `POST /api/integrations/ebay/auth/exange_token` — exchange refresh token, sets `ebay_access_{app_code}` cookie
 - `GET /api/integrations/ebay/search/` — search listings (requires `app_code` and `q`)
-- `POST /api/integrations/ebay/listing/` — create listing (requires user session)
-- `GET /api/integrations/ebay/listing/active` — active listings (requires user session)
-- `GET /api/integrations/ebay/listing/history` — listing history (requires user session)
-- `PUT /api/integrations/ebay/listing/{item_id}` — update listing (requires user session)
+
+Listing endpoints (all require a user session and an `app_code` query parameter):
+
+- `POST /api/integrations/ebay/listing/` — create listing; requires `Idempotency-Key` header (400 if absent); uses Redis SETNX to short-circuit duplicate creates
+- `GET /api/integrations/ebay/listing/active` — paginated active listings (`limit`, `offset`); returns `PaginatedResponse`
+- `GET /api/integrations/ebay/listing/history` — paginated order fulfillment history (`limit`, `offset`); returns `PaginatedResponse`
+- `PUT /api/integrations/ebay/listing/{item_id}` — update an existing listing; body `ItemID` must match the URL `item_id`
+- `DELETE /api/integrations/ebay/listing/{item_id}` — end a listing; optional `ending_reason` query param (default `NotAvailable`)
 
 Shopify (`/api/integrations/shopify`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -35,6 +35,31 @@ FastAPI backend (internal network only)
 
 Reference compose file: `deploy/docker-compose.prod.yml`.
 
+### Dev topology (Docker)
+
+In development, nginx publishes three ports and ngrok provides a public tunnel:
+
+```
+Internet
+	|
+	v
+ngrok (fixed free-tier domain, --pooling-enabled)
+	|
+	v (HTTP)
+nginx proxy
+	|-- port 80  → redirects to 443
+	|-- port 443 → TLS termination (self-signed cert)
+	|-- port 8080 → plain-HTTP tunnel endpoint; HTTP basic auth; X-Forwarded-Proto: https
+	|
+	v
+FastAPI backend (internal network only, port 8000)
+	|
+	+--> Postgres (published to host as localhost:5433)
+	+--> Redis (published to host as localhost:6379)
+```
+
+Port 8080 is the entry point for ngrok traffic. All requests require HTTP basic auth (credentials in `config/nginx/htpasswd`, gitignored) except `GET /health`. See [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) for setup details.
+
 ## Backend runtime
 
 ### Entry point and lifespan
@@ -175,7 +200,11 @@ Integrations are exposed under `/api/integrations/...` and implemented via servi
 
 Current integration areas include:
 
-- **eBay** (OAuth + listing/search/selling)
+- **eBay** (OAuth + listing/search/selling) — the selling side is split along CQS lines into three registered service modules:
+  - `listings_read_service` — `integrations.ebay.selling.listings.get`, `integrations.ebay.selling.listings.active`
+  - `listings_write_service` — `integrations.ebay.selling.listings.create`, `integrations.ebay.selling.listings.update`, `integrations.ebay.selling.listings.end`
+  - `fulfillment_service` — `integrations.ebay.selling.fulfillment.history`
+  - `selling_services` is kept as an unregistered import-time shim that emits `DeprecationWarning` and delegates to the typed modules above; it will be removed in a follow-up PR.
 - **Shopify** (metadata ingestion, market/collection/theme)
 - **MTGStock** (staging/loading/pricing)
 - **Scryfall** (daily ETL pipeline — see [`docs/SCRYFALL_PIPELINE.md`](SCRYFALL_PIPELINE.md))

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -56,8 +56,9 @@ What it does:
 - `backend` publishes `8000:8000`
 - `postgres` publishes `5433:5432` (convenience for local tools)
 - `redis` publishes `6379:6379`
-- `proxy` publishes `80:80` and `443:443`
+- `proxy` publishes `80:80`, `443:443`, and `8080:8080`
 - `flower` is not directly exposed (only via nginx proxy)
+- `ngrok` tunnels external traffic to `proxy:8080` (see [ngrok tunnel setup](#ngrok-tunnel-setup) below)
 
 Run:
 
@@ -78,9 +79,10 @@ Service access:
 |---------|-----|-------|
 | Backend API | `http://localhost:8000` | Direct; also exposed through proxy |
 | Backend API (proxy) | `https://localhost/api/` | Through nginx reverse proxy (HTTPS) |
+| Backend API (tunnel) | `http://localhost:8080/api/` | Through nginx port 8080 — HTTP basic auth required |
 | OpenAPI docs | `https://localhost/docs` | Through nginx reverse proxy |
-| Health check | `https://localhost/health` | Through nginx reverse proxy |
-| Flower | `https://localhost/flower/` | Through nginx proxy; auth: `admin:changeme_dev` (from `FLOWER_BASIC_AUTH`) |
+| Health check | `https://localhost/health` | Through nginx reverse proxy; `/health` on port 8080 is auth-exempt |
+| Flower | `https://localhost/flower/` | Through nginx proxy (443 and 8080); auth: `admin:changeme_dev` (from `FLOWER_BASIC_AUTH`) |
 | Postgres | `localhost:5433` | Host-side access (`.env.dev` default); containers use `postgres:5432` |
 | Redis | `localhost:6379` | Host-side access; containers use `redis:6379` |
 
@@ -101,6 +103,30 @@ Stop:
 ```bash
 docker compose -f deploy/docker-compose.dev.yml down
 ```
+
+### ngrok tunnel setup
+
+The dev stack includes an `ngrok` container that exposes the app to the internet through nginx port 8080 for eBay OAuth callbacks and external testing.
+
+**How it works:**
+
+- nginx port 8080 listens as a plain-HTTP tunnel endpoint; it sets `X-Forwarded-Proto: https` so the app sees HTTPS even though the upstream connection is plain HTTP.
+- HTTP basic auth is enforced on all requests to port 8080 (except `/health`). Credentials are stored in `config/nginx/htpasswd` (gitignored).
+- Flower gets a dedicated `limit_req_zone` on both 443 and 8080 (5 r/m, burst 3), separate from the general per-IP zone.
+- Security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, CSP) are present on the 8080 block. HSTS is intentionally absent (port 8080 is plain HTTP).
+
+**Prerequisites:**
+
+1. Set `NGROK_AUTHTOKEN` in `config/env/.env.dev`.
+2. Create `config/nginx/htpasswd` from the example:
+   ```bash
+   # see config/nginx/htpasswd.example for the generation command
+   cp config/nginx/htpasswd.example config/nginx/htpasswd
+   # edit htpasswd and replace the placeholder hash with a real one
+   ```
+3. `config/nginx/htpasswd` is gitignored — never commit it.
+
+The `ngrok` service in `deploy/docker-compose.dev.yml` connects to `proxy:8080` using a fixed free-tier domain (`--pooling-enabled` lets it rejoin if a terminal session already holds the domain).
 
 ## Production (Docker Compose)
 
@@ -242,6 +268,8 @@ All responses on HTTPS (port 443) include:
 - `Referrer-Policy: strict-origin-when-cross-origin`
 - `Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'`
 
+Responses on the plain-HTTP tunnel (port 8080) include the same headers except HSTS (omitted deliberately — HSTS on a plain-HTTP port has no effect and can cause browser confusion).
+
 ## Flower (Celery monitoring)
 
 Flower provides a real-time web UI for inspecting Celery workers and tasks.
@@ -252,7 +280,8 @@ Flower is only exposed through the nginx reverse proxy (not directly on port 555
 
 | Environment | URL | Auth |
 |-------------|-----|------|
-| Dev (proxy) | https://localhost/flower/ | `admin:changeme_dev` (from `FLOWER_BASIC_AUTH` in `.env.dev`) |
+| Dev (proxy HTTPS) | https://localhost/flower/ | `admin:changeme_dev` (from `FLOWER_BASIC_AUTH` in `.env.dev`) |
+| Dev (tunnel HTTP) | http://localhost:8080/flower/ | HTTP basic auth (htpasswd) + `FLOWER_BASIC_AUTH` |
 | Prod (proxy) | https://your-domain/flower/ | Configure via `FLOWER_BASIC_AUTH` in `.env.prod` |
 
 ### Persistence


### PR DESCRIPTION
## Summary

Follow-up doc update for PRs #166 and #167.

- **ARCHITECTURE.md**: dev topology diagram (ngrok → nginx 80/443/8080 → backend); eBay CQS-split service paths documented under integrations
- **DEPLOYMENT.md**: port 8080 in dev stack table; full ngrok tunnel setup section (NGROK_AUTHTOKEN, htpasswd bootstrap, `--pooling-enabled` rationale); flower access table; security header note
- **API.md**: all 5 typed eBay listing endpoints with Idempotency-Key and pagination notes; DELETE endpoint added

No code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)