### PR TITLE
feat(db): migration 19 — widen app_info.redirect_uri to VARCHAR(255)

### DIFF
--- a/src/automana/database/SQL/migrations/migration_19_widen_redirect_uri.sql
+++ b/src/automana/database/SQL/migrations/migration_19_widen_redirect_uri.sql
@@ -1,0 +1,5 @@
+-- migration_19_widen_redirect_uri.sql
+-- Widens app_info.redirect_uri from VARCHAR(50) to VARCHAR(255)
+-- so full ngrok/production URLs fit without truncation.
+ALTER TABLE app_integration.app_info
+    ALTER COLUMN redirect_uri TYPE VARCHAR(255);

--- a/src/automana/database/SQL/migrations/migration_19_widen_redirect_uri.sql
+++ b/src/automana/database/SQL/migrations/migration_19_widen_redirect_uri.sql
@@ -1,5 +1,9 @@
 -- migration_19_widen_redirect_uri.sql
 -- Widens app_info.redirect_uri from VARCHAR(50) to VARCHAR(255)
 -- so full ngrok/production URLs fit without truncation.
+BEGIN;
+
 ALTER TABLE app_integration.app_info
     ALTER COLUMN redirect_uri TYPE VARCHAR(255);
+
+COMMIT;

--- a/src/automana/database/SQL/schemas/05_ebay.sql
+++ b/src/automana/database/SQL/schemas/05_ebay.sql
@@ -7,7 +7,7 @@ CREATE TABLE IF NOT EXISTS app_integration.app_info(
     --needs to be updated, maybe add cient id??
     app_id TEXT PRIMARY KEY,
     app_name VARCHAR(100) NOT NULL,
-    redirect_uri VARCHAR(50) NOT NULL,
+    redirect_uri VARCHAR(255) NOT NULL,
     response_type VARCHAR(20) NOT NULL,
     client_secret_encrypted TEXT NOT NULL,
     environment TEXT NOT NULL DEFAULT 'SANDBOX',


### PR DESCRIPTION
## Summary

- Adds `migration_19_widen_redirect_uri.sql` to widen `app_integration.app_info.redirect_uri` from `VARCHAR(50)` to `VARCHAR(255)` — the full ngrok callback URL is 72 chars, exceeding the old limit
- Updates `05_ebay.sql` schema definition to match, keeping fresh DB rebuilds consistent with the migration

## Context

Part of the eBay OAuth ngrok wiring work. Remaining tasks (nginx auth bypass, PATCH endpoint for updating redirect URI, service + repository layer) will follow in subsequent commits on this branch.

## Test plan

- [ ] Apply migration: `psql -U app_admin -d automana_dev < migration_19_widen_redirect_uri.sql` → expect `ALTER TABLE`
- [ ] Verify column width: `\d app_integration.app_info` → `redirect_uri | character varying(255)`
- [ ] Fresh DB rebuild still succeeds with updated schema file

🤖 Generated with [Claude Code](https://claude.com/claude-code)