### PR TITLE
feat(ebay): wire OAuth callback through VPS tunnel

### DIFF
--- a/src/automana/api/routers/integrations/ebay/ebay_auth.py
+++ b/src/automana/api/routers/integrations/ebay/ebay_auth.py
@@ -5,6 +5,11 @@ from automana.api.dependancies.service_deps import ServiceManagerDep
 from automana.api.dependancies.auth.users import CurrentUserDep
 from automana.core.models.ebay.auth import AppRegistrationRequest, CreateAppRequest
 from automana.api.schemas.StandardisedQueryResponse import ApiResponse
+from pydantic import BaseModel
+
+
+class UpdateRedirectUriRequest(BaseModel):
+    redirect_uri: str
 import logging
 
 logger = logging.getLogger(__name__)
@@ -103,6 +108,33 @@ async def handle_ebay_callback(request: Request,
         raise
     except Exception:
         raise
+@ebay_auth_router.patch(
+    '/admin/apps/{app_code}/redirect-uri',
+    description='Update the redirect URI for a registered eBay app',
+    status_code=status.HTTP_200_OK,
+)
+async def update_redirect_uri(
+    app_code: str,
+    body: UpdateRedirectUriRequest,
+    user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    try:
+        await service_manager.execute_service(
+            "integrations.ebay.update_app_redirect_uri",
+            app_code=app_code,
+            redirect_uri=body.redirect_uri,
+        )
+        return ApiResponse(
+            message="Redirect URI updated successfully",
+            data={
+                "app_code": app_code,
+                "redirect_uri": body.redirect_uri,
+            },
+        )
+    except Exception:
+        raise
+
 from automana.api.schemas.auth.cookie import AccessTokenCookie, RefreshTokenResponse
 @ebay_auth_router.post('/exange_token')
 async def do_exange_refresh_token( response: Response

--- a/src/automana/core/repositories/app_integration/ebay/app_queries.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_queries.py
@@ -38,3 +38,11 @@ assign_scope_query = """
                             FROM scopes
                             WHERE scope_url = $2
                             ON CONFLICT (scope_id, app_id) DO NOTHING; """
+
+update_redirect_uri_query = """
+UPDATE app_integration.app_info
+SET redirect_uri = $1,
+    updated_at   = now()
+WHERE app_code = $2
+RETURNING app_code;
+"""

--- a/src/automana/core/repositories/app_integration/ebay/app_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_repository.py
@@ -57,7 +57,14 @@ class EbayAppRepository(AbstractRepository):
     def create(self, values):
         raise NotImplementedError("Method 'create' is not implemented in EbayAccountRepository")    
     def update(self, values):
-        raise NotImplementedError("Method 'update' is not implemented in EbayAccountRepository")    
+        raise NotImplementedError("Method 'update' is not implemented in EbayAccountRepository")
+
+    async def update_redirect_uri(self, app_code: str, redirect_uri: str) -> bool:
+        result = await self.execute_query(
+            app_queries.update_redirect_uri_query,
+            (redirect_uri, app_code)
+        )
+        return bool(result)
     def delete(self, values):
         raise NotImplementedError("Method 'delete' is not implemented in EbayAccountRepository")
 

--- a/src/automana/core/services/app_integration/ebay/auth_services.py
+++ b/src/automana/core/services/app_integration/ebay/auth_services.py
@@ -199,6 +199,23 @@ async def get_environment(auth_repository: EbayAuthRepository
     except app_exception.EbayEnvironmentException as e:
         raise app_exception.EbayEnvironmentException(f"Failed to get environment: {str(e)}")
 
+@ServiceRegistry.register(
+    'integrations.ebay.update_app_redirect_uri',
+    db_repositories=['app']
+)
+async def update_app_redirect_uri(
+    app_repository: EbayAppRepository,
+    app_code: str,
+    redirect_uri: str,
+) -> bool:
+    """Update the redirect_uri stored for an eBay app."""
+    updated = await app_repository.update_redirect_uri(app_code, redirect_uri)
+    if not updated:
+        raise app_exception.EbayAppNotFoundException(
+            f"eBay app with code {app_code!r} not found"
+        )
+    return updated
+
 """
     async def assign_scope(self, newScope: AssignScope) -> bool | None:
      

--- a/tests/unit/core/repositories/app_integration/ebay/test_app_repository.py
+++ b/tests/unit/core/repositories/app_integration/ebay/test_app_repository.py
@@ -1,0 +1,36 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from automana.core.repositories.app_integration.ebay.app_repository import EbayAppRepository
+
+
+@pytest.fixture
+def repo():
+    conn = MagicMock()
+    executor = MagicMock()
+    r = EbayAppRepository(connection=conn, executor=executor)
+    r.execute_query = AsyncMock()
+    return r
+
+
+@pytest.mark.asyncio
+async def test_update_redirect_uri_returns_true_on_success(repo):
+    repo.execute_query.return_value = [{"app_code": "my-app"}]
+    result = await repo.update_redirect_uri("my-app", "https://automana.duckdns.org/api/integrations/ebay/auth/callback")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_update_redirect_uri_returns_false_when_app_not_found(repo):
+    repo.execute_query.return_value = []
+    result = await repo.update_redirect_uri("unknown-app", "https://automana.duckdns.org/api/integrations/ebay/auth/callback")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_update_redirect_uri_passes_correct_args(repo):
+    repo.execute_query.return_value = [{"app_code": "my-app"}]
+    url = "https://automana.duckdns.org/api/integrations/ebay/auth/callback"
+    await repo.update_redirect_uri("my-app", url)
+    repo.execute_query.assert_called_once()
+    call_args = repo.execute_query.call_args
+    assert call_args[0][1] == (url, "my-app")


### PR DESCRIPTION
## Summary
- **nginx**: exact-match location block on port 8080 disables `auth_basic` for `/api/integrations/ebay/auth/callback` so eBay's redirect lands without a 401
- **DB**: migration 19 widens `app_integration.app_info.redirect_uri` VARCHAR(50 → 255) to fit full tunnel URLs; schema file updated to match
- **Repository/Service**: `update_redirect_uri` query + method + `integrations.ebay.update_app_redirect_uri` ServiceRegistry entry
- **Router**: `PATCH /api/integrations/ebay/auth/admin/apps/{app_code}/redirect-uri` lets admins update the stored redirect URI without re-registering the app

## Test Plan
- [ ] `pytest tests/unit/` — 375 passed (3 new tests cover `update_redirect_uri` true/false/args)
- [ ] Start stack → `nginx -t` passes, reload succeeds
- [ ] `curl http://localhost:8080/api/integrations/ebay/auth/callback` returns 400 (FastAPI rejects missing params), not 401
- [ ] PATCH endpoint returns 200 with updated `redirect_uri` in response
- [ ] Full OAuth flow: login → eBay consent page → callback lands → tokens saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)