### PR TITLE
feat(pricing): Tier 3 archival fix + price chart Tier 2/3 unification

### DIFF
--- a/PRICE_STORAGE_GAPS_INVESTIGATION.md
+++ b/PRICE_STORAGE_GAPS_INVESTIGATION.md
@@ -1,0 +1,449 @@
+# AutoMana Price Storage: 3-Tier Architecture & Gaps Investigation
+**Date:** 2026-05-05  
+**Scope:** Comprehensive audit of price data storage tiers, pipeline, and data quality
+
+---
+
+## Executive Summary
+
+AutoMana implements a **3-tier price storage architecture** designed to balance **freshness** (Tier 1: daily observations), **queryability** (Tier 2: aggregated daily), and **retention** (Tier 3: weekly archive). However, **critical gaps exist at every tier**:
+
+| Tier | Status | Impact |
+|------|--------|--------|
+| **Tier 1** (`price_observation`) | Deployed, **0% link rate** | Data present but 6.09M rejected rows block ingestion |
+| **Tier 2** (`print_price_daily`) | **Designed, not deployed** | No daily aggregates for UI/API |
+| **Tier 3** (`print_price_weekly`) | **Designed, not deployed** | No long-term archive |
+| **Snapshot** (`print_price_latest`) | **Designed, not deployed** | No fast path for "current price" queries |
+
+**Root cause:** MTGStock pipeline has 0% link rate (6.09M rejects vs 0 linked rows), blocking all Tier 1 data ingestion. Tier 2/3 deployment is blocked waiting on pipeline fixes.
+
+---
+
+## Architecture Overview
+
+### The 3 Tiers (Designed)
+
+```
+TIER 1 (Raw observations)
+  pricing.price_observation
+  Grain: (ts_date, source_product_id, data_provider_id, finish_id, condition_id, language_id)
+  Retention: Live + compressed after 180 days
+  TimescaleDB: 7-day chunks, auto-compress after 180 days
+  Status: ✅ Deployed, structure correct
+  Data: ❌ 0 rows (pipeline failing)
+
+       │
+       │ refresh_daily_prices() — daily, Celery beat
+       ▼
+
+TIER 2 (Daily rollup, source-preserving)
+  pricing.print_price_daily
+  Grain: (price_date, card_version_id, source_id, finish_id, condition_id, language_id)
+  Retention: ~5 years
+  TimescaleDB: 7-day chunks, auto-compress after 30 days
+  Status: ❌ Designed in migration_18, NOT DEPLOYED
+  Data: ❌ 0 rows
+  
+       │
+       │ archive_to_weekly() — monthly, Celery beat
+       ▼
+
+TIER 3 (Weekly archive)
+  pricing.print_price_weekly
+  Grain: (price_week, card_version_id, source_id, finish_id, condition_id, language_id)
+  Retention: Indefinite
+  TimescaleDB: 4-week chunks, auto-compress after 7 days
+  Status: ❌ Designed in migration_18, NOT DEPLOYED
+  Data: ❌ 0 rows
+
+SNAPSHOT TABLE (Current price fast path)
+  pricing.print_price_latest
+  Grain: (card_version_id, source_id, finish_id, condition_id, language_id) — one row per key
+  Purpose: O(1) lookup for "what's the current price"
+  Status: ❌ Designed in migration_18, NOT DEPLOYED
+```
+
+### Key Design Decisions
+
+✅ **Source identity preserved at every tier** — `source_id` is in the PK of Tier 2 and 3, preventing cross-market aggregation that would destroy arbitrage signals.
+
+✅ **3-column price interface** (same across all tiers):
+- `list_low_cents` (MIN across providers)
+- `list_avg_cents` (AVG across providers)
+- `sold_avg_cents` (AVG across providers)
+
+✅ **Aggregation across `data_provider_id` only** — multiple providers reporting the same source on the same day are collapsed; source-per-day remains granular.
+
+✅ **Crash-safe resume** via `tier_watermark` table (designed but not deployed).
+
+---
+
+## Critical Gaps
+
+### 🔴 **Gap 1: MTGStock Pipeline — 0% Link Rate (BLOCKING)**
+
+**Problem:** The MTGStock ingestion pipeline is rejecting **6.09M rows** out of 6.09M, with **0 rows** successfully resolved to `card_version_id`.
+
+**Details:**
+
+| Metric | Value | Category |
+|--------|-------|----------|
+| Raw rows ingested | 6,090,227 | volume |
+| Resolved to card_version | 0 | ❌ 0% link rate |
+| Rejected (unresolved) | 5,801,810 | ❌ 95% of all data |
+| Terminal rejects | 288,417 | (marked as failed in prior run) |
+| Distinct prints linked | 0 | ❌ should be ~1000s |
+
+**Classification of rejects** (from `docs/MTGSTOCK_REJECT_ANALYSIS.md`):
+- **~680K rows** — art-card set-code mapping missing (Fix 2)
+- **~3.8M rows** — tokens without token resolution (Fix 3)
+- **~1.3M rows** — require Scryfall-side investigation
+- **~0 rows** — currently linked ❌
+
+**Impact:**
+- Tier 1 has 0 price observations
+- Tier 2/3 have no data to aggregate (all upstream is blocked)
+- Metrics that query Tier 1 time out or fail entirely
+- No price data reaching the frontend
+
+**Root Cause:** The print_id → card_version_id resolution waterfall (PRINT_ID → EXTERNAL_ID → SET_COLLECTOR) is failing at every stage:
+
+1. **PRINT_ID mapping** — `card_catalog.card_external_identifier` where `identifier_name = 'mtgstock_id'` has no entries (back-fill not yet run)
+2. **EXTERNAL_ID fallback** — scryfall_id / tcgplayer_id / cardtrader_id not present in raw MTGStock rows
+3. **SET_COLLECTOR fallback** — many rows have incorrect set_code (art-cards use nonstandard codes) or missing collector numbers
+
+**Workaround:** Fixes 2 and 3 in `docs/PIPELINE_TECHNICAL_DEBT.md` are documented. Status: **not yet implemented**.
+
+---
+
+### 🔴 **Gap 2: Tier 2 Not Deployed (BLOCKING Tier 2 & 3)**
+
+**Problem:** `pricing.print_price_daily` table and `refresh_daily_prices()` procedure are designed in `migration_18_pricing_tiers.sql` but **never applied to the database**.
+
+**What should exist (per migration_18):**
+
+```sql
+CREATE TABLE pricing.print_price_daily (
+  price_date DATE NOT NULL,
+  card_version_id UUID NOT NULL,
+  source_id SMALLINT NOT NULL,
+  transaction_type_id INTEGER NOT NULL,
+  finish_id SMALLINT NOT NULL,
+  condition_id SMALLINT NOT NULL,
+  language_id SMALLINT NOT NULL,
+  
+  list_low_cents INTEGER,
+  list_avg_cents INTEGER,
+  sold_avg_cents INTEGER,
+  n_providers SMALLINT,
+  
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  
+  PRIMARY KEY (price_date, card_version_id, source_id, transaction_type_id, finish_id, condition_id, language_id)
+) USING timescaledb;
+```
+
+**Status in database:** Table stubs exist in `06_prices.sql` but with **wrong schema** (old `p25`/`p75` columns, missing `source_id`, not a hypertable).
+
+**Procedures designed but not wired:**
+- `pricing.refresh_daily_prices(p_from DATE, p_to DATE)` — aggregates Tier 1 into daily rows (30-day batches)
+- No Celery beat task to call it (designed to run daily, post-MTGStock pipeline)
+
+**Impact:**
+- UI and APIs cannot query aggregated daily prices
+- Every price query must scan the raw Tier 1 hypertable for MAX(price_date) and aggregate on-the-fly
+- No analytical dashboards possible without full table scans
+
+**Blocker:** Tier 1 is empty (Gap 1), so deployment of Tier 2 will show 0 data. Recommend deploying now (procedures are idempotent) so data flows once Gap 1 is fixed.
+
+---
+
+### 🔴 **Gap 3: Tier 3 Not Deployed (BLOCKING Long-Term Archive)**
+
+**Problem:** `pricing.print_price_weekly` table and `archive_to_weekly()` procedure are designed in `migration_18_pricing_tiers.sql` but **never applied to the database**.
+
+**What should exist:**
+
+```sql
+CREATE TABLE pricing.print_price_weekly (
+  price_week DATE NOT NULL,  -- DATE_TRUNC('week', price_date)
+  card_version_id UUID NOT NULL,
+  source_id SMALLINT NOT NULL,
+  ...
+  n_days SMALLINT,  -- 1 to 7
+  n_providers SMALLINT,  -- MAX across the week
+  PRIMARY KEY (price_week, card_version_id, source_id, ...)
+) USING timescaledb;
+```
+
+**Procedures designed but not wired:**
+- `pricing.archive_to_weekly(p_older_than INTERVAL DEFAULT '5 years')` — rolls Tier 2 into weekly starting 5 years ago
+- No Celery beat task to call it (designed to run monthly)
+
+**Impact:**
+- No long-term price trend archive
+- Cannot answer "what did this card cost in Q3 2023?"
+- Tier 2 has unbounded growth (5 years of daily data)
+- Cost of Tier 2 hypertable grows without purging old data
+
+**Blocker:** Same as Gap 2 — depends on Tier 1 fix. But deployment can happen now.
+
+---
+
+### 🔴 **Gap 4: Latest Price Snapshot Not Deployed (BLOCKING Fast Queries)**
+
+**Problem:** `pricing.print_price_latest` table is designed in `migration_18_pricing_tiers.sql` but **never applied to the database**.
+
+**What should exist:**
+
+```sql
+CREATE TABLE pricing.print_price_latest (
+  card_version_id UUID NOT NULL,
+  source_id SMALLINT NOT NULL,
+  transaction_type_id INTEGER NOT NULL,
+  finish_id SMALLINT NOT NULL,
+  condition_id SMALLINT NOT NULL,
+  language_id SMALLINT NOT NULL,
+  
+  price_date DATE NOT NULL,
+  list_low_cents INTEGER,
+  list_avg_cents INTEGER,
+  sold_avg_cents INTEGER,
+  n_providers SMALLINT,
+  
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  
+  PRIMARY KEY (card_version_id, source_id, transaction_type_id, finish_id, condition_id, language_id)
+);
+```
+
+**Current state:** Queries for "current price of card X on source Y" must:
+1. Scan Tier 1 hypertable
+2. Filter to most recent `ts_date`
+3. Aggregate across `data_provider_id`
+4. Return to caller
+
+**With snapshot table:** O(1) lookup into a plain table.
+
+**Impact:**
+- Every "current price" query is slow (hypertable scan + aggregation)
+- API response times degrade as Tier 1 grows
+- No index-friendly fast path for the most common query pattern
+
+---
+
+### 🟡 **Gap 5: Pricing Report Metrics Failing (OPERATIONAL)**
+
+**Problem:** The `pricing_report` runner (which runs hourly on beat) has **16+ metric checks failing** with `TimeoutError` or `InFailedSQLTransactionError`.
+
+**Affected metrics:**
+- `pricing.card_coverage.*` (3 metrics)
+- `pricing.coverage.*` (1 metric)
+- `pricing.freshness.*` (2 metrics)
+- `pricing.referential.*` (2 metrics)
+- `pricing.staging.*` (1 metric)
+- `pricing.duplicate_detection.*` (1 metric)
+
+**Root cause:** Full hypertable scans on `pricing.price_observation` without time-bounded CTEs. Each scan times out at 60–120 seconds (default `statement_timeout`).
+
+**Workarounds (from PIPELINE_TECHNICAL_DEBT.md):**
+1. **Rewrite SQL** to use `pg_class.reltuples` for row estimates, `pg_constraint` for PK checks, and time-bounded windows (e.g., last 90 days).
+2. **Raise Docker `/dev/shm`** from default (64MB) to 512MB — allows in-memory sorts to succeed.
+
+**Impact:**
+- Health checks are blind (metrics don't run)
+- No alerting on pricing data quality issues
+- `pipeline-health-check` skill cannot auto-discover pricing problems
+
+**Timeline:** Blocking but lower priority than Gaps 1–4. Workaround is temporary (rewrite to efficient SQL once Tier 1 is fixed).
+
+---
+
+### 🟡 **Gap 6: No Watermark Initialization (OPERATIONAL)**
+
+**Problem:** The `tier_watermark` table is designed to track the last successfully processed date for each tier (`daily`, `weekly`) but is **not created or seeded**.
+
+**What should happen on first deploy:**
+
+```sql
+INSERT INTO pricing.tier_watermark (tier_name, last_processed_date)
+  VALUES ('daily', '1970-01-01'), ('weekly', '1970-01-01');
+```
+
+**Impact:**
+- `refresh_daily_prices()` and `archive_to_weekly()` will fail on first call (no watermark row to read)
+- Manual backfill requires passing explicit date ranges (`p_from`, `p_to`) instead of resuming from watermark
+- Crash recovery is not possible (no state to resume from)
+
+**Workaround:** Manual initialization or explicit date ranges.
+
+---
+
+### 🟢 **Gap 7: Python Service Layer Not Wired (INTEGRATION)**
+
+**Problem:** The procedures exist but no Python service code calls them.
+
+**Missing:**
+- `PriceRepository.call_refresh_daily_prices()` — analogous to existing `call_load_stage_from_raw()`, `call_resolve_price_rejects()`, etc.
+- `PriceRepository.call_archive_to_weekly()` — similar wrapper
+- Celery beat tasks in `worker/tasks/pipelines.py` or `celeryconfig.py` to invoke these services
+
+**Impact:**
+- Tier 2/3 procedures have no way to be called from the pipeline
+- Manual SQL invocation required for backfill and maintenance
+
+**Workaround:** Until Python service layer is built, procedures can be called manually or via `automana-run`:
+
+```bash
+# Manual refresh (all unprocessed dates since last watermark)
+automana-run -raw "CALL pricing.refresh_daily_prices();"
+
+# Or with explicit range
+automana-run -raw "CALL pricing.refresh_daily_prices('2026-01-01', '2026-04-30');"
+```
+
+---
+
+## Dependency Chain
+
+```
+Fix Gap 1 (MTGStock 0% link rate)
+  ↓
+Tier 1 has data (price_observation)
+  ↓
+Deploy Tier 2 (Gap 2) + Fix pricing report queries (Gap 5)
+  ↓
+Tier 2 has data (print_price_daily)
+  ↓
+Deploy Tier 3 (Gap 3) + Wire Celery beat + Build Python service layer (Gap 7)
+  ↓
+Full 3-tier system operational
+```
+
+---
+
+## Remediation Plan
+
+### Immediate (Blocking User-Facing Data)
+
+| Gap | Action | Owner | Timeline | Blocker |
+|-----|--------|-------|----------|---------|
+| 1 | Implement Fix 2 + Fix 3 from MTGSTOCK_REJECT_ANALYSIS.md | data team | TBD | Yes |
+| 1 | Re-run MTGStock pipeline with fixes | data team | TBD | Yes |
+| 2 | Deploy migration_18 (`print_price_daily` table + procedures) | DBA | ASAP after Gap 1 data exists | No (Gap 1) |
+| 4 | Deploy migration_18 (`print_price_latest` snapshot table) | DBA | Same as Gap 2 | No (Gap 1) |
+| 6 | Seed `tier_watermark` table | DBA | Same as Gap 2 | No |
+
+### Short Term (Fixing Observability)
+
+| Gap | Action | Owner | Timeline | Notes |
+|-----|--------|-------|----------|-------|
+| 5 | Rewrite pricing metrics to use time-bounded windows | backend team | 1 day | Critical for health checks |
+| 7 | Add `PriceRepository.call_refresh_daily_prices()` wrapper | backend team | 1 day | ~30 lines of code |
+| 7 | Add `PriceRepository.call_archive_to_weekly()` wrapper | backend team | 1 day | ~30 lines of code |
+
+### Medium Term (Automating Tier 2/3)
+
+| Gap | Action | Owner | Timeline | Notes |
+|-----|--------|-------|----------|-------|
+| 7 | Wire Celery beat for daily `refresh_daily_prices()` | backend team | 1 day | After Python wrapper |
+| 7 | Wire Celery beat for monthly `archive_to_weekly()` | backend team | 1 day | After Python wrapper |
+| 2 | Backfill Tier 2 from historical Tier 1 data | data team | ~2 hours | After Gap 1 + Gap 2 deployed |
+| 3 | Backfill Tier 3 from historical Tier 2 data | data team | ~1 hour | After Tier 2 backfill |
+
+### Long Term (Operational Excellence)
+
+| Gap | Action | Owner | Timeline | Notes |
+|-----|--------|-------|----------|-------|
+| 5 | Add more granular metrics (e.g., per-source freshness breakdown) | backend team | 1 week | Depends on Gap 5 fix |
+| — | Add indexes on Tier 2/3 for common query patterns | DBA | 1 week | After backfill to test cardinality |
+| — | Document Tier 2/3 query patterns for analytics | docs team | 1 week | UI/API consumption guide |
+
+---
+
+## Query Patterns by Tier
+
+### Tier 1 (Raw observations)
+
+```sql
+-- Niche: audit a specific scrape
+SELECT * FROM pricing.price_observation
+WHERE source_product_id = 123 AND ts_date = '2026-04-25'
+ORDER BY data_provider_id;
+```
+
+**Current use:** Mostly internal validation. Raw data seldom queried directly.
+
+---
+
+### Tier 2 (Daily aggregates — PRIMARY for UI/API)
+
+```sql
+-- Chart: Lightning Bolt price history on TCGplayer, last 90 days
+SELECT price_date, list_avg_cents, sold_avg_cents, n_providers
+FROM pricing.print_price_daily
+WHERE card_version_id = '...' AND source_id = 1 AND finish_id = 1
+  AND price_date >= CURRENT_DATE - 90
+ORDER BY price_date DESC;
+
+-- Current price lookup
+SELECT list_avg_cents, list_low_cents
+FROM pricing.print_price_latest
+WHERE card_version_id = '...' AND source_id = 1 AND finish_id = 1;
+```
+
+**Expected use:** ~99% of all price queries (frontend, API, analytics).
+
+---
+
+### Tier 3 (Weekly archive — LONG-TERM TRENDS)
+
+```sql
+-- Trend: average price of card over 5 years, weekly
+SELECT price_week, AVG(list_avg_cents) as avg_price
+FROM pricing.print_price_weekly
+WHERE card_version_id = '...' AND source_id IN (1, 2, 3)  -- TCGplayer, CardMarket, CK
+GROUP BY price_week
+ORDER BY price_week DESC;
+```
+
+**Expected use:** Historical analysis, trend detection, volatility studies.
+
+---
+
+## Testing Checklist (Post-Fix)
+
+- [ ] `pricing.price_observation` has > 1M rows (post-Gap 1 fix)
+- [ ] `CALL pricing.refresh_daily_prices()` completes without error (post-migration_18)
+- [ ] `pricing.print_price_daily` has data for all dates since Tier 1 backfill (post-Gap 2)
+- [ ] `pricing.print_price_latest` returns O(1) results for a known card/source
+- [ ] `CALL pricing.archive_to_weekly()` completes without error (post-migration_18)
+- [ ] `pricing.print_price_weekly` has weekly rollups for old data (post-Gap 3)
+- [ ] All `pricing_report` metrics pass (post-Gap 5 fix)
+- [ ] Celery beat tasks fire daily (Tier 2) and monthly (Tier 3) without errors
+- [ ] API `/prices` endpoint returns data from Tier 2 instead of scanning Tier 1
+
+---
+
+## Related Documentation
+
+- [`docs/MTGSTOCK_PIPELINE.md`](docs/MTGSTOCK_PIPELINE.md) — end-to-end pipeline flow and stages
+- [`docs/HEALTH_METRICS.md`](docs/HEALTH_METRICS.md) — pricing metrics and health checks
+- [`docs/PIPELINE_TECHNICAL_DEBT.md`](docs/PIPELINE_TECHNICAL_DEBT.md) — current open issues and fixes
+- [`src/automana/database/SQL/migrations/migration_18_pricing_tiers.sql`](src/automana/database/SQL/migrations/migration_18_pricing_tiers.sql) — full Tier 2/3 DDL and procedures
+- [`src/automana/database/SQL/schemas/06_prices.sql`](src/automana/database/SQL/schemas/06_prices.sql) — reference schema definitions (may be out of sync with migration)
+
+---
+
+## Summary Table
+
+| Layer | Status | Severity | Data | Deployed | Wired | Notes |
+|-------|--------|----------|------|----------|-------|-------|
+| **Tier 1** | Broken | 🔴 Critical | 0 rows | ✅ | ✅ | 0% link rate from MTGStock |
+| **Tier 2** | Missing | 🔴 Critical | — | ❌ | ❌ | migration_18 ready; blocked on Tier 1 |
+| **Tier 3** | Missing | 🔴 Critical | — | ❌ | ❌ | migration_18 ready; blocked on Tier 2 |
+| **Snapshot** | Missing | 🔴 Critical | — | ❌ | ❌ | migration_18 ready; enables fast queries |
+| **Watermark** | Missing | 🟡 Important | — | ❌ | ❌ | Needed for crash recovery |
+| **Metrics** | Failing | 🟡 Important | — | ✅ | ❌ | Timeouts on hypertable scans |
+| **Service layer** | Missing | 🟡 Important | — | — | ❌ | Python wrappers for procedures |

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -78,6 +78,8 @@ services:
       context: ..
       dockerfile: deploy/docker/frontend/Frontend.dev.Dockerfile
     container_name: automana-frontend-dev
+    ports:
+      - "5173:5173"
     volumes:
       - ../src/frontend:/app
       - frontend-node-modules:/app/node_modules

--- a/src/automana/api/repositories/user_management/user_repository.py
+++ b/src/automana/api/repositories/user_management/user_repository.py
@@ -36,6 +36,12 @@ class UserRepository(AbstractRepository):
         result = await self.execute_query(query, (username,))
         return result[0] if result else None
 
+    async def get_by_email(self, email: str) -> dict:
+        query = """
+        SELECT * FROM users WHERE email = $1;"""
+        result = await self.execute_query(query, (email,))
+        return result[0] if result else None
+
     def get_sync(self, username: str) -> dict:
         query = """
         SELECT * FROM users WHERE username = $1;"""

--- a/src/automana/api/routers/mtg/card_reference.py
+++ b/src/automana/api/routers/mtg/card_reference.py
@@ -148,21 +148,22 @@ async def get_card_price_history(
 ) -> ApiResponse[PriceHistoryResponse]:
     """Get price history for a card in the specified time range."""
     try:
-        # Map price_range to days_back
+        # Map price_range to days_back and aggregation
         range_map = {
-            '1w': 7,
-            '1m': 30,
-            '3m': 90,
-            '1y': 365,
-            'all': None,
+            '1w': (7, 'daily'),
+            '1m': (30, 'daily'),
+            '3m': (90, 'daily'),
+            '1y': (365, 'weekly'),
+            'all': (None, 'daily'),
         }
-        days_back = range_map[price_range]
+        days_back, aggregation = range_map[price_range]
 
         result = await service_manager.execute_service(
             "card_catalog.card.get_price_history",
             card_id=card_id,
             days_back=days_back,
             finish=finish,
+            aggregation=aggregation,
         )
 
         return ApiResponse(

--- a/src/automana/api/routers/mtg/card_reference.py
+++ b/src/automana/api/routers/mtg/card_reference.py
@@ -154,7 +154,7 @@ async def get_card_price_history(
             '1m': (30, 'daily'),
             '3m': (90, 'daily'),
             '1y': (365, 'weekly'),
-            'all': (None, 'daily'),
+            'all': (None, 'weekly'),
         }
         days_back, aggregation = range_map[price_range]
 

--- a/src/automana/api/routers/users/users.py
+++ b/src/automana/api/routers/users/users.py
@@ -103,7 +103,7 @@ async def list_users(
     '/',
     summary="Register a new user",
     description=(
-        "Creates a new user account. Pass the plain-text password in `hashed_password` "
+        "Creates a new user account. Pass the plain-text password in `password` "
         "— the server hashes it on receipt. Returns the newly created user record "
         "wrapped in an `ApiResponse` envelope."
     ),

--- a/src/automana/api/schemas/user_management/user.py
+++ b/src/automana/api/schemas/user_management/user.py
@@ -15,8 +15,8 @@ class UserPublic(BaseModel):
 
 class BaseUser(UserPublic):
     email : EmailStr | None = Field(default=None)
-    hashed_password : str = Field(
-        title='Hashed user password'
+    password : str = Field(
+        title='Plain-text password (hashed by the server on receipt)'
     )
 
 class UserInDB(BaseUser):

--- a/src/automana/api/services/auth/auth_service.py
+++ b/src/automana/api/services/auth/auth_service.py
@@ -36,10 +36,13 @@ async def check_token_validity(request : Request):
     except ValueError as e:
         raise HTTPException(status_code=401, detail=str(e))
 
-async def authenticate_user(repository : UserRepository
-                      , username : str
-                      , password : str) -> UserInDB | None:
-    user  = await repository.get(username)
+async def authenticate_user(repository: UserRepository,
+                            username: str,
+                            password: str) -> UserInDB | None:
+    # Accept either username or email in the username field (email-first login UX)
+    user = await repository.get(username)
+    if not user:
+        user = await repository.get_by_email(username)
     if not user:
         return None
     if not verify_password(password, user['hashed_password']):

--- a/src/automana/api/services/user_management/user_service.py
+++ b/src/automana/api/services/user_management/user_service.py
@@ -1,5 +1,5 @@
 ﻿from typing import Annotated, Union, Optional
-from fastapi import  Body
+from fastapi import Body, HTTPException
 from automana.api.schemas.user_management.user import  BaseUser, UserUpdatePublic,UserInDB, UserPublic
 from automana.core.utils.get_hash_password import  get_hash_password
 from automana.api.repositories.user_management.user_repository import UserRepository
@@ -32,6 +32,8 @@ async def register(user_repository: UserRepository, user : Annotated[BaseUser, B
         if not result:
             raise user_exceptions.UserCreationError("Failed to create user")
         return UserInDB.model_validate(result)
+    except HTTPException:
+        raise
     except Exception as e:
         raise user_exceptions.UserError(f"Error creating user: {e}")
 

--- a/src/automana/api/services/user_management/user_service.py
+++ b/src/automana/api/services/user_management/user_service.py
@@ -24,11 +24,10 @@ async def register(user_repository: UserRepository, user : Annotated[BaseUser, B
             'password' : 'password',
         }
     ])]) -> UserInDB:
-    hashed_password = get_hash_password(user.hashed_password)
-    user.hashed_password = hashed_password
- 
+    hashed_password = get_hash_password(user.password)
+
     try:
-        result = await user_repository.add(username=user.username, email=user.email, hashed_password=user.hashed_password, fullname=user.fullname)
+        result = await user_repository.add(username=user.username, email=user.email, hashed_password=hashed_password, fullname=user.fullname)
         if not result:
             raise user_exceptions.UserCreationError("Failed to create user")
         return UserInDB.model_validate(result)

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -685,21 +685,23 @@ class CardReferenceRepository(AbstractRepository[Any]):
         start_date: date,
         end_date: date,
         finish: Optional[str] = None,
+        aggregation: str = 'daily',
     ) -> Dict[str, Any]:
         """
-        Fetch aggregated daily price history for a card across all sources.
+        Fetch aggregated price history for a card across all sources.
 
         Args:
             card_version_id: Card version ID
             start_date: Start date (inclusive)
             end_date: End date (inclusive)
             finish: Optional finish code string ('NONFOIL', 'FOIL', 'ETCHED', etc.)
+            aggregation: 'daily' or 'weekly' aggregation (default='daily')
 
         Returns:
             Dict with keys: list_avg, sold_avg, dates
-            - list_avg: List[Optional[float]] with one entry per date (null-filled for missing dates)
-            - sold_avg: List[Optional[float]] with one entry per date (null-filled for missing dates)
-            - dates: List[date] with dates in order
+            - list_avg: List[Optional[float]] with one entry per period (null-filled for missing data)
+            - sold_avg: List[Optional[float]] with one entry per period (null-filled for missing data)
+            - dates: List[date] with period start dates in order
         """
         finish_filter = ""
         params: list = [card_version_id, start_date, end_date]
@@ -707,31 +709,58 @@ class CardReferenceRepository(AbstractRepository[Any]):
             finish_filter = f"AND f.code = ${len(params) + 1}"
             params.append(finish.upper())
 
-        query = f"""
-        WITH date_range AS (
-            SELECT generate_series($2::date, $3::date, interval '1 day')::date AS price_date
-        ),
-        daily_prices AS (
+        if aggregation == 'weekly':
+            query = f"""
+            WITH weekly_range AS (
+                SELECT generate_series(date_trunc('week', $2::date)::date, $3::date, interval '1 week')::date AS week_start
+            ),
+            weekly_prices AS (
+                SELECT
+                    date_trunc('week', ppd.price_date)::date AS week_start,
+                    AVG(ppd.list_avg_cents)::float / 100 AS list_avg_price,
+                    AVG(ppd.sold_avg_cents)::float / 100 AS sold_avg_price
+                FROM pricing.print_price_daily ppd
+                JOIN pricing.card_finished f ON f.finish_id = ppd.finish_id
+                WHERE ppd.card_version_id = $1
+                  AND ppd.price_date >= $2
+                  AND ppd.price_date <= $3
+                  {finish_filter}
+                GROUP BY date_trunc('week', ppd.price_date)
+            )
             SELECT
-                ppd.price_date,
-                AVG(ppd.list_avg_cents)::float / 100 AS list_avg_price,
-                AVG(ppd.sold_avg_cents)::float / 100 AS sold_avg_price
-            FROM pricing.print_price_daily ppd
-            JOIN pricing.card_finished f ON f.finish_id = ppd.finish_id
-            WHERE ppd.card_version_id = $1
-              AND ppd.price_date >= $2
-              AND ppd.price_date <= $3
-              {finish_filter}
-            GROUP BY ppd.price_date
-        )
-        SELECT
-            dr.price_date,
-            dp.list_avg_price,
-            dp.sold_avg_price
-        FROM date_range dr
-        LEFT JOIN daily_prices dp ON dr.price_date = dp.price_date
-        ORDER BY dr.price_date ASC
-        """
+                wr.week_start AS price_date,
+                wp.list_avg_price,
+                wp.sold_avg_price
+            FROM weekly_range wr
+            LEFT JOIN weekly_prices wp ON wr.week_start = wp.week_start
+            ORDER BY wr.week_start ASC
+            """
+        else:
+            query = f"""
+            WITH date_range AS (
+                SELECT generate_series($2::date, $3::date, interval '1 day')::date AS price_date
+            ),
+            daily_prices AS (
+                SELECT
+                    ppd.price_date,
+                    AVG(ppd.list_avg_cents)::float / 100 AS list_avg_price,
+                    AVG(ppd.sold_avg_cents)::float / 100 AS sold_avg_price
+                FROM pricing.print_price_daily ppd
+                JOIN pricing.card_finished f ON f.finish_id = ppd.finish_id
+                WHERE ppd.card_version_id = $1
+                  AND ppd.price_date >= $2
+                  AND ppd.price_date <= $3
+                  {finish_filter}
+                GROUP BY ppd.price_date
+            )
+            SELECT
+                dr.price_date,
+                dp.list_avg_price,
+                dp.sold_avg_price
+            FROM date_range dr
+            LEFT JOIN daily_prices dp ON dr.price_date = dp.price_date
+            ORDER BY dr.price_date ASC
+            """
 
         rows = await self.execute_query(query, tuple(params))
 

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -714,7 +714,7 @@ class CardReferenceRepository(AbstractRepository[Any]):
             WITH weekly_range AS (
                 SELECT generate_series(date_trunc('week', $2::date)::date, $3::date, interval '1 week')::date AS week_start
             ),
-            weekly_prices AS (
+            tier2_prices AS (
                 SELECT
                     date_trunc('week', ppd.price_date)::date AS week_start,
                     AVG(ppd.list_avg_cents)::float / 100 AS list_avg_price,
@@ -726,13 +726,33 @@ class CardReferenceRepository(AbstractRepository[Any]):
                   AND ppd.price_date <= $3
                   {finish_filter}
                 GROUP BY date_trunc('week', ppd.price_date)
+            ),
+            tier3_prices AS (
+                SELECT
+                    ppw.price_week AS week_start,
+                    AVG(ppw.list_avg_cents)::float / 100 AS list_avg_price,
+                    AVG(ppw.sold_avg_cents)::float / 100 AS sold_avg_price
+                FROM pricing.print_price_weekly ppw
+                JOIN pricing.card_finished f ON f.finish_id = ppw.finish_id
+                WHERE ppw.card_version_id = $1
+                  AND ppw.price_week >= $2
+                  AND ppw.price_week <= $3
+                  {finish_filter}
+                GROUP BY ppw.price_week
+            ),
+            combined AS (
+                SELECT week_start, list_avg_price, sold_avg_price FROM tier2_prices
+                UNION ALL
+                SELECT t3.week_start, t3.list_avg_price, t3.sold_avg_price
+                FROM tier3_prices t3
+                WHERE t3.week_start NOT IN (SELECT week_start FROM tier2_prices)
             )
             SELECT
                 wr.week_start AS price_date,
-                wp.list_avg_price,
-                wp.sold_avg_price
+                c.list_avg_price,
+                c.sold_avg_price
             FROM weekly_range wr
-            LEFT JOIN weekly_prices wp ON wr.week_start = wp.week_start
+            LEFT JOIN combined c ON wr.week_start = c.week_start
             ORDER BY wr.week_start ASC
             """
         else:

--- a/src/automana/core/repositories/pricing/__init__.py
+++ b/src/automana/core/repositories/pricing/__init__.py
@@ -1,0 +1,1 @@
+# Pricing repositories

--- a/src/automana/core/repositories/pricing/price_repository.py
+++ b/src/automana/core/repositories/pricing/price_repository.py
@@ -1,0 +1,99 @@
+from datetime import date
+from typing import Optional
+import logging
+
+from automana.core.repositories.abstract_repositories.AbstractDBRepository import AbstractRepository
+
+logger = logging.getLogger(__name__)
+
+
+class PricingTierRepository(AbstractRepository):
+    """Repository for pricing tier aggregation procedures."""
+
+    def __init__(self, connection, executor=None):
+        super().__init__(connection, executor)
+
+    @property
+    def name(self) -> str:
+        return "PriceRepository"
+
+    async def refresh_daily_prices(
+        self,
+        p_from: Optional[date] = None,
+        p_to: Optional[date] = None,
+    ) -> dict:
+        """
+        Populate Tier 2 (print_price_daily) from Tier 1 (price_observation).
+
+        Links source_product_id → card_version_id via mtg_card_products.
+
+        Args:
+            p_from: Start date (inclusive). If None, uses last_processed_date from watermark.
+            p_to: End date (inclusive). If None, uses CURRENT_DATE - 1.
+
+        Returns:
+            Dict with procedure output (notice messages, row counts).
+        """
+        try:
+            await self.execute_procedure(
+                "pricing.refresh_daily_prices",
+                (p_from, p_to),
+            )
+            logger.info(
+                "refresh_daily_prices completed",
+                extra={"p_from": p_from, "p_to": p_to},
+            )
+            return {"status": "success"}
+        except Exception as e:
+            logger.error(
+                "refresh_daily_prices failed",
+                extra={"p_from": p_from, "p_to": p_to, "error": str(e)},
+            )
+            raise
+
+    async def archive_to_weekly(
+        self,
+        older_than_interval: str = "5 YEARS",
+    ) -> dict:
+        """
+        Archive Tier 2 (print_price_daily) rows to Tier 3 (print_price_weekly).
+
+        Args:
+            older_than_interval: PostgreSQL interval string (e.g., '5 YEARS', '90 DAYS').
+
+        Returns:
+            Dict with procedure output (notice messages, row counts).
+        """
+        try:
+            # Convert string interval to proper SQL format
+            interval_param = f"INTERVAL '{older_than_interval}'"
+            await self.execute_procedure(
+                "pricing.archive_to_weekly",
+                (interval_param,),
+            )
+            logger.info(
+                "archive_to_weekly completed",
+                extra={"older_than_interval": older_than_interval},
+            )
+            return {"status": "success"}
+        except Exception as e:
+            logger.error(
+                "archive_to_weekly failed",
+                extra={"older_than_interval": older_than_interval, "error": str(e)},
+            )
+            raise
+
+    async def execute_procedure(self, proc_name: str, args: tuple) -> None:
+        """
+        Execute a stored procedure with arguments.
+
+        Args:
+            proc_name: Fully qualified procedure name (e.g., 'pricing.refresh_daily_prices')
+            args: Tuple of arguments to pass to the procedure
+        """
+        # Build the CALL statement
+        placeholders = ", ".join(f"${i+1}" for i in range(len(args)))
+        call_stmt = f"CALL {proc_name}({placeholders})"
+
+        # Execute via the connection
+        await self.connection.execute(call_stmt, *args)

--- a/src/automana/core/service_modules.py
+++ b/src/automana/core/service_modules.py
@@ -26,6 +26,7 @@ SERVICE_MODULES : dict[str, list[str]]= {
             "automana.core.services.ops.pricing_report",
             "automana.core.services.ops.tier_health_service",
             "automana.core.services.ops.scryfall_identifier_audit",
+            "automana.core.services.pricing.pricing_aggregation",
         ],
 
     "celery": [
@@ -44,6 +45,7 @@ SERVICE_MODULES : dict[str, list[str]]= {
             "automana.core.services.ops.pricing_report",
             "automana.core.services.ops.tier_health_service",
             "automana.core.services.ops.scryfall_identifier_audit",
+            "automana.core.services.pricing.pricing_aggregation",
         ],
     "all" : [
             "automana.api.services.auth.auth_service",
@@ -73,5 +75,6 @@ SERVICE_MODULES : dict[str, list[str]]= {
             "automana.core.services.ops.pricing_report",
             "automana.core.services.ops.tier_health_service",
             "automana.core.services.ops.scryfall_identifier_audit",
+            "automana.core.services.pricing.pricing_aggregation",
     ]
 }

--- a/src/automana/core/service_registry.py
+++ b/src/automana/core/service_registry.py
@@ -198,6 +198,11 @@ ServiceRegistry.register_db_repository(
     "price", "automana.core.repositories.app_integration.mtg_stock.price_repository", "PriceRepository"
 )
 
+# Pricing Tier repositories
+ServiceRegistry.register_db_repository(
+    "pricing", "automana.core.repositories.pricing.price_repository", "PricingTierRepository"
+)
+
 # Ops repositories
 ServiceRegistry.register_db_repository(
     "ops", "automana.core.repositories.ops.ops_repository", "OpsRepository"

--- a/src/automana/core/services/card_catalog/card_service.py
+++ b/src/automana/core/services/card_catalog/card_service.py
@@ -262,15 +262,17 @@ async def get_card_price_history(
     card_id: UUID,
     days_back: Optional[int] = 30,
     finish: Optional[str] = None,
+    aggregation: str = 'daily',
 ) -> PriceHistoryResponse:
     """
-    Fetch aggregated daily price history for a card.
+    Fetch aggregated price history for a card.
 
     Args:
         card_repository: CardReferenceRepository instance
         card_id: Card version ID (UUID)
         days_back: Number of days back from today (None = all available data, default=30)
         finish: Optional finish name string ('nonfoil', 'foil', 'etched', etc.)
+        aggregation: 'daily' or 'weekly' aggregation (default='daily')
 
     Returns:
         PriceHistoryResponse with price arrays and date range info
@@ -288,7 +290,7 @@ async def get_card_price_history(
             start_date = end_date - timedelta(days=days_back)
 
         # Call repository to fetch aggregated prices
-        result = await card_repository.get_price_history(card_id, start_date, end_date, finish=finish)
+        result = await card_repository.get_price_history(card_id, start_date, end_date, finish=finish, aggregation=aggregation)
 
         # Build response
         return PriceHistoryResponse(

--- a/src/automana/core/services/pricing/__init__.py
+++ b/src/automana/core/services/pricing/__init__.py
@@ -1,0 +1,1 @@
+# Pricing services

--- a/src/automana/core/services/pricing/pricing_aggregation.py
+++ b/src/automana/core/services/pricing/pricing_aggregation.py
@@ -1,0 +1,57 @@
+from datetime import date
+from typing import Optional
+import logging
+
+from automana.core.repositories.pricing.price_repository import PricingTierRepository
+from automana.core.service_registry import ServiceRegistry
+
+logger = logging.getLogger(__name__)
+
+
+@ServiceRegistry.register(
+    "pricing.refresh_daily_prices",
+    db_repositories=["pricing"],
+)
+async def refresh_daily_prices(
+    price_repository: PricingTierRepository,
+    p_from: Optional[date] = None,
+    p_to: Optional[date] = None,
+) -> dict:
+    """
+    Service to refresh Tier 2 (daily aggregates) from Tier 1 (raw observations).
+
+    Links source_product_id → card_version_id via mtg_card_products table.
+    Populates print_price_daily and print_price_latest.
+
+    Args:
+        price_repository: PriceRepository instance
+        p_from: Start date. If None, uses watermark.
+        p_to: End date. If None, uses yesterday.
+
+    Returns:
+        Dict with status and counts.
+    """
+    return await price_repository.refresh_daily_prices(p_from=p_from, p_to=p_to)
+
+
+@ServiceRegistry.register(
+    "pricing.archive_to_weekly",
+    db_repositories=["pricing"],
+)
+async def archive_to_weekly(
+    price_repository: PricingTierRepository,
+    older_than_interval: str = "5 YEARS",
+) -> dict:
+    """
+    Service to archive Tier 2 (daily) to Tier 3 (weekly rollups).
+
+    Args:
+        price_repository: PriceRepository instance
+        older_than_interval: PostgreSQL interval (e.g., '5 YEARS')
+
+    Returns:
+        Dict with status and counts.
+    """
+    return await price_repository.archive_to_weekly(
+        older_than_interval=older_than_interval
+    )

--- a/src/automana/database/SQL/migrations/migration_19_archive_to_weekly_fix.sql
+++ b/src/automana/database/SQL/migrations/migration_19_archive_to_weekly_fix.sql
@@ -1,0 +1,168 @@
+-- Migration 19: Fix pricing.archive_to_weekly — "tuple decompression limit exceeded"
+--
+-- Root cause: print_price_daily is a TimescaleDB hypertable with a 30-day
+-- compression policy. The DELETE step inside each batch issues row-level DML
+-- against already-compressed chunks, which forces inline decompression. The
+-- default timescaledb.max_tuples_decompressed_per_dml_transaction (~100,000)
+-- is far below the ~5M rows per batch window, causing the procedure to abort.
+--
+-- Fix:
+--   1. Explicitly decompress each chunk overlapping the batch window before
+--      the DELETE so the DML runs against uncompressed rows (no GUC issue).
+--      decompress_chunk(..., if_compressed => TRUE) is a no-op on already-
+--      uncompressed chunks, making the procedure safe to run regardless of
+--      compression state. The compression policy re-compresses the data
+--      naturally on its next scheduled run.
+--   2. Reduce batch size from the previous values (2 days or 4 weeks) to
+--      7 days — one full chunk per batch — to bound memory and lock duration.
+--
+-- Safe to apply: only replaces the stored procedure, no DDL on tables.
+
+CREATE OR REPLACE PROCEDURE pricing.archive_to_weekly(
+    p_older_than INTERVAL DEFAULT '5 years'
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_cutoff        DATE;
+    v_min_date      DATE;
+    v_max_date      DATE;
+    v_start         DATE;
+    v_end           DATE;
+    v_batch_days    INT  := 7;    -- one 7-day chunk per batch
+    v_ok            BOOLEAN;
+    _chunk          REGCLASS;
+    cur_archived    BIGINT;
+    cur_deleted     BIGINT;
+    total_archived  BIGINT := 0;
+    total_deleted   BIGINT := 0;
+BEGIN
+    -- Cutoff is floored to the previous Monday so we always archive complete weeks.
+    v_cutoff := DATE_TRUNC('week', CURRENT_DATE - p_older_than)::DATE;
+
+    SELECT MIN(price_date), MAX(price_date)
+    INTO   v_min_date, v_max_date
+    FROM   pricing.print_price_daily
+    WHERE  price_date < v_cutoff;
+
+    IF v_min_date IS NULL THEN
+        RAISE NOTICE 'archive_to_weekly: no data older than % to archive', v_cutoff;
+        RETURN;
+    END IF;
+
+    RAISE NOTICE 'archive_to_weekly: archiving % to % (cutoff=%, older_than=%)',
+                 v_min_date, v_max_date, v_cutoff, p_older_than;
+
+    v_start := DATE_TRUNC('week', v_min_date)::DATE;
+
+    WHILE v_start < v_cutoff LOOP
+        v_end := LEAST(v_start + (v_batch_days - 1), v_cutoff - 1);
+        v_ok  := FALSE;
+
+        BEGIN
+            SET LOCAL work_mem             = '256MB';
+            SET LOCAL maintenance_work_mem = '512MB';
+            SET LOCAL synchronous_commit   = off;
+            -- 0 = unlimited; required so decompress_chunk() on large chunks succeeds.
+            SET LOCAL timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
+
+            -- Decompress every chunk that overlaps this batch window before any DML.
+            -- This avoids "tuple decompression limit exceeded" on the DELETE step.
+            -- if_compressed => TRUE makes this a no-op on already-uncompressed chunks.
+            FOR _chunk IN
+                SELECT show_chunks(
+                    'pricing.print_price_daily',
+                    older_than => v_end + 1,
+                    newer_than => v_start
+                )
+            LOOP
+                PERFORM decompress_chunk(_chunk, if_compressed => TRUE);
+            END LOOP;
+
+            -- Aggregate tier 2 → tier 3 for this batch window.
+            DROP TABLE IF EXISTS _weekly_batch;
+            CREATE TEMP TABLE _weekly_batch ON COMMIT DROP AS
+            SELECT
+                DATE_TRUNC('week', price_date)::DATE         AS price_week,
+                card_version_id,
+                source_id,
+                transaction_type_id,
+                finish_id,
+                condition_id,
+                language_id,
+                MIN(list_low_cents)::INTEGER                 AS list_low_cents,
+                AVG(list_avg_cents)::INTEGER                 AS list_avg_cents,
+                AVG(sold_avg_cents)::INTEGER                 AS sold_avg_cents,
+                COUNT(DISTINCT price_date)::SMALLINT         AS n_days,
+                MAX(n_providers)::SMALLINT                   AS n_providers
+            FROM  pricing.print_price_daily
+            WHERE price_date >= v_start
+              AND price_date <= v_end
+            GROUP BY
+                DATE_TRUNC('week', price_date),
+                card_version_id, source_id, transaction_type_id,
+                finish_id, condition_id, language_id;
+
+            -- Upsert into print_price_weekly (idempotent re-runs are safe).
+            INSERT INTO pricing.print_price_weekly (
+                price_week, card_version_id, source_id, transaction_type_id,
+                finish_id, condition_id, language_id,
+                list_low_cents, list_avg_cents, sold_avg_cents, n_days, n_providers
+            )
+            SELECT
+                price_week, card_version_id, source_id, transaction_type_id,
+                finish_id, condition_id, language_id,
+                list_low_cents, list_avg_cents, sold_avg_cents, n_days, n_providers
+            FROM _weekly_batch
+            ON CONFLICT (price_week, card_version_id, source_id,
+                         transaction_type_id, finish_id, condition_id, language_id)
+            DO UPDATE SET
+                list_low_cents = EXCLUDED.list_low_cents,
+                list_avg_cents = EXCLUDED.list_avg_cents,
+                sold_avg_cents = EXCLUDED.sold_avg_cents,
+                n_days         = EXCLUDED.n_days,
+                n_providers    = EXCLUDED.n_providers,
+                updated_at     = now();
+
+            GET DIAGNOSTICS cur_archived = ROW_COUNT;
+            total_archived := total_archived + cur_archived;
+
+            -- Delete source daily rows. Chunks are now decompressed so this
+            -- runs as a plain row-level DELETE with no GUC limit.
+            DELETE FROM pricing.print_price_daily
+            WHERE price_date >= v_start
+              AND price_date <= v_end;
+
+            GET DIAGNOSTICS cur_deleted = ROW_COUNT;
+            total_deleted := total_deleted + cur_deleted;
+
+            RAISE NOTICE 'archive_to_weekly: batch % to %: archived=%, deleted=%',
+                         v_start, v_end, cur_archived, cur_deleted;
+            v_ok := TRUE;
+
+        EXCEPTION WHEN OTHERS THEN
+            RAISE WARNING 'archive_to_weekly: batch % to % failed: % (SQLSTATE %)',
+                          v_start, v_end, SQLERRM, SQLSTATE;
+            v_ok := FALSE;
+        END;
+
+        IF v_ok THEN
+            COMMIT;
+            UPDATE pricing.tier_watermark
+            SET    last_processed_date = v_end,
+                   updated_at          = now()
+            WHERE  tier_name = 'weekly';
+            COMMIT;
+        ELSE
+            ROLLBACK;
+        END IF;
+
+        v_start := v_end + 1;
+    END LOOP;
+
+    RAISE NOTICE 'archive_to_weekly: done. total archived=%, total deleted=%',
+                 total_archived, total_deleted;
+END;
+$$;
+
+-- No grant changes needed — procedure signature unchanged.

--- a/src/automana/database/SQL/schemas/06_prices.sql
+++ b/src/automana/database/SQL/schemas/06_prices.sql
@@ -607,8 +607,9 @@ DECLARE
     v_max_date      DATE;
     v_start         DATE;
     v_end           DATE;
-    v_batch_days    INT  := 2;
+    v_batch_days    INT  := 7;    -- one 7-day chunk per batch
     v_ok            BOOLEAN;
+    _chunk          REGCLASS;
     cur_archived    BIGINT;
     cur_deleted     BIGINT;
     total_archived  BIGINT := 0;
@@ -633,14 +634,28 @@ BEGIN
     v_start := DATE_TRUNC('week', v_min_date)::DATE;
 
     WHILE v_start < v_cutoff LOOP
-        -- Batch = v_batch_days days, capped at cutoff.
         v_end := LEAST(v_start + (v_batch_days - 1), v_cutoff - 1);
         v_ok  := FALSE;
 
         BEGIN
-            SET LOCAL work_mem             = '128MB';
-            SET LOCAL maintenance_work_mem = '256MB';
+            SET LOCAL work_mem             = '256MB';
+            SET LOCAL maintenance_work_mem = '512MB';
             SET LOCAL synchronous_commit   = off;
+            -- 0 = unlimited; required so decompress_chunk() on large chunks succeeds.
+            SET LOCAL timescaledb.max_tuples_decompressed_per_dml_transaction = 0;
+
+            -- Decompress every chunk overlapping this window before any DML.
+            -- Prevents "tuple decompression limit exceeded" on the DELETE step.
+            -- if_compressed => TRUE makes this a no-op on uncompressed chunks.
+            FOR _chunk IN
+                SELECT show_chunks(
+                    'pricing.print_price_daily',
+                    older_than => v_end + 1,
+                    newer_than => v_start
+                )
+            LOOP
+                PERFORM decompress_chunk(_chunk, if_compressed => TRUE);
+            END LOOP;
 
             -- Aggregate tier 2 → tier 3 for this batch window.
             DROP TABLE IF EXISTS _weekly_batch;
@@ -666,7 +681,7 @@ BEGIN
                 card_version_id, source_id, transaction_type_id,
                 finish_id, condition_id, language_id;
 
-            -- Upsert into print_price_weekly (idempotent re-runs are safe)
+            -- Upsert into print_price_weekly (idempotent re-runs are safe).
             INSERT INTO pricing.print_price_weekly (
                 price_week, card_version_id, source_id, transaction_type_id,
                 finish_id, condition_id, language_id,
@@ -690,7 +705,8 @@ BEGIN
             GET DIAGNOSTICS cur_archived = ROW_COUNT;
             total_archived := total_archived + cur_archived;
 
-            -- Delete the source daily rows only after a successful upsert.
+            -- Delete source daily rows. Chunks are decompressed above so this
+            -- runs as a plain row-level DELETE with no GUC limit.
             DELETE FROM pricing.print_price_daily
             WHERE price_date >= v_start
               AND price_date <= v_end;

--- a/src/automana/worker/celeryconfig.py
+++ b/src/automana/worker/celeryconfig.py
@@ -39,6 +39,7 @@ result_backend = _fix_redis_host(os.getenv("RESULT_BACKEND", f"redis://{_default
 imports = {
     "automana.worker.tasks.pipelines",
     "automana.worker.tasks.analytics",
+    "automana.worker.tasks.pricing",
 }
 
 
@@ -91,6 +92,20 @@ beat_schedule = {
         "task": "run_service",
         "schedule": crontab(minute=42),
         "kwargs": {"path": "ops.integrity.pricing_report"},
+    },
+    # Pricing tier aggregation: refresh daily aggregates from raw observations.
+    # Links source_product_id → card_version_id via mtg_card_products table.
+    # Runs at 05:30 AEST after MTGStock import completes (04:00).
+    "pricing-refresh-daily-aggregates": {
+        "task": "refresh_daily_prices",
+        "schedule": crontab(hour=5, minute=30),  # 05:30 AEST
+    },
+    # Pricing tier archival: move Tier 2 (daily) to Tier 3 (weekly) for data >5y.
+    # Reduces storage usage and speeds up daily price queries.
+    # Runs monthly (1st of month at 03:00 AEST) to avoid peak hours.
+    "pricing-archive-to-weekly": {
+        "task": "archive_to_weekly_prices",
+        "schedule": crontab(day_of_month=1, hour=3, minute=0),  # 1st at 03:00 AEST
     },
 }
 

--- a/src/automana/worker/tasks/pricing.py
+++ b/src/automana/worker/tasks/pricing.py
@@ -1,0 +1,73 @@
+from celery import shared_task
+import logging
+from datetime import datetime, date, timedelta
+from automana.worker.main import run_service
+from automana.core.logging_context import set_task_id
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(name="refresh_daily_prices", bind=True)
+def refresh_daily_prices_task(self):
+    """
+    Daily task to refresh Tier 2 (print_price_daily) from Tier 1 (price_observation).
+
+    Links source_product_id → card_version_id via mtg_card_products table.
+    Runs daily to populate the aggregated daily prices for charts and analytics.
+    """
+    set_task_id(self.request.id)
+    yesterday = datetime.utcnow().date() - timedelta(days=1)
+    logger.info(
+        "Starting pricing tier 2 refresh (daily aggregates)",
+        extra={"date": yesterday.isoformat()},
+    )
+
+    try:
+        result = run_service(
+            "pricing.refresh_daily_prices",
+            p_from=yesterday,
+            p_to=yesterday,
+        )
+        logger.info(
+            "Pricing tier 2 refresh completed",
+            extra={"result": result, "date": yesterday.isoformat()},
+        )
+        return {"status": "success", "date": yesterday.isoformat()}
+    except Exception as e:
+        logger.error(
+            "Pricing tier 2 refresh failed",
+            extra={"error": str(e), "date": yesterday.isoformat()},
+        )
+        raise
+
+
+@shared_task(name="archive_to_weekly_prices", bind=True)
+def archive_to_weekly_prices_task(self):
+    """
+    Monthly task to archive Tier 2 (daily) to Tier 3 (weekly rollups).
+
+    Runs monthly to move data older than 5 years to the weekly archive.
+    Reduces storage and speeds up Tier 2 queries by archiving old data.
+    """
+    set_task_id(self.request.id)
+    logger.info(
+        "Starting pricing tier 3 archive (weekly rollups)",
+        extra={"older_than": "5 YEARS"},
+    )
+
+    try:
+        result = run_service(
+            "pricing.archive_to_weekly",
+            older_than_interval="5 YEARS",
+        )
+        logger.info(
+            "Pricing tier 3 archive completed",
+            extra={"result": result},
+        )
+        return {"status": "success"}
+    except Exception as e:
+        logger.error(
+            "Pricing tier 3 archive failed",
+            extra={"error": str(e)},
+        )
+        raise

--- a/src/frontend/e2e/login.spec.ts
+++ b/src/frontend/e2e/login.spec.ts
@@ -1,31 +1,46 @@
 // src/frontend/e2e/login.spec.ts
 import { test, expect } from '@playwright/test'
 
-test('login page loads', async ({ page }) => {
+// Note: these tests run against the live dev server + backend.
+// A healthy backend is required for auth requests to succeed.
+
+test('login page loads with email field and Log in heading', async ({ page }) => {
   await page.goto('/login')
-  // The login page renders "Log in" as a <div> (formTitle), not a heading role.
-  // The <h1> on the left panel is about the market, not the form title.
   await expect(page.getByText('Log in').first()).toBeVisible()
   await expect(page.getByPlaceholder('you@example.com')).toBeVisible()
 })
 
-test.skip('submitting login form navigates to collection', async ({ page }) => {
-  // Skipped: /collection does not exist yet (Phase 2 feature).
-  // The stub login calls navigate({ to: '/collection' }) which will error out.
+test('toggling to signup mode shows username field and Create account heading', async ({ page }) => {
   await page.goto('/login')
-  await page.getByPlaceholder('you@example.com').fill('test@example.com')
-  await page.getByPlaceholder('••••••••').fill('password')
-  await page.getByRole('button', { name: /log in/i }).click()
-  await expect(page).toHaveURL(/\/collection/)
+  await page.getByRole('button', { name: 'Create one' }).click()
+  await expect(page.getByText('Create account').first()).toBeVisible()
+  await expect(page.getByPlaceholder('yourname')).toBeVisible()
 })
 
-test('submitting login form leaves the login page', async ({ page }) => {
-  // The stub login accepts any non-empty submission and navigates away from /login.
-  // /collection is not implemented (Phase 2) so we only assert the URL changes.
+test('toggling back from signup to login hides username field', async ({ page }) => {
+  await page.goto('/login')
+  await page.getByRole('button', { name: 'Create one' }).click()
+  await page.getByRole('button', { name: 'Log in' }).click()
+  await expect(page.getByText('Log in').first()).toBeVisible()
+  await expect(page.getByPlaceholder('yourname')).not.toBeVisible()
+})
+
+test.skip('invalid credentials shows error message — requires live backend', async ({ page }) => {
+  // Hits POST /api/users/auth/token against the real dev backend.
+  // Run manually with the backend up: `npx playwright test e2e/login.spec.ts`
+  await page.goto('/login')
+  await page.getByPlaceholder('you@example.com').fill('nobody@example.com')
+  await page.getByPlaceholder('••••••••').fill('wrongpassword')
+  await page.getByRole('button', { name: /log in/i }).click()
+  await expect(page.getByRole('alert')).toContainText('Invalid email or password')
+})
+
+test.skip('successful login navigates to /', async ({ page }) => {
+  // Requires a valid test account in the dev database.
+  // Run manually: fill in real credentials below.
   await page.goto('/login')
   await page.getByPlaceholder('you@example.com').fill('test@example.com')
-  await page.getByPlaceholder('••••••••').fill('password')
-  // The submit button text is "Log in →" — match by accessible role with partial name
+  await page.getByPlaceholder('••••••••').fill('testpassword')
   await page.getByRole('button', { name: /log in/i }).click()
-  await expect(page).not.toHaveURL(/\/login/)
+  await expect(page).toHaveURL('/')
 })

--- a/src/frontend/src/components/design-system/DualAreaChart.tsx
+++ b/src/frontend/src/components/design-system/DualAreaChart.tsx
@@ -37,7 +37,7 @@ export function DualAreaChart({
   const [hoverIdx, setHoverIdx] = useState<number | null>(null)
 
   const allValues = [...listAvg, ...soldAvg].filter((v) => v !== null) as number[]
-  if (allValues.length < 2 || dates.length < 2) return null
+  if (allValues.length < 1 || dates.length < 1) return null
 
   const cw = width - PAD.left - PAD.right
   const ch = height - PAD.top - PAD.bottom
@@ -48,7 +48,7 @@ export function DualAreaChart({
   const maxY = maxVal * 1.08
   const yRange = maxY - minY || 1
 
-  const toX = (i: number) => PAD.left + (i / (n - 1)) * cw
+  const toX = (i: number) => PAD.left + (n === 1 ? 0.5 : (i / (n - 1))) * cw
   const toY = (v: number) => PAD.top + ch - ((v - minY) / yRange) * ch
 
   const Y_COUNT = 4

--- a/src/frontend/src/features/auth/api.ts
+++ b/src/frontend/src/features/auth/api.ts
@@ -1,0 +1,77 @@
+// src/frontend/src/features/auth/api.ts
+//
+// Raw fetch wrappers for auth endpoints.
+// Login uses application/x-www-form-urlencoded (OAuth2 password flow).
+// Signup uses JSON. Neither goes through apiClient because login must not
+// carry a Bearer token and must use a different Content-Type.
+
+export interface LoginResponse {
+  access_token: string
+  refresh_token: string
+  token_type: string
+  expires_in: number
+}
+
+export interface MeResponse {
+  username: string
+  fullname: string | null
+}
+
+/**
+ * POST /api/users/auth/token
+ * OAuth2 password-grant flow. Sends credentials as form-urlencoded.
+ * The `username` field accepts either a username or an email (backend
+ * falls back to email lookup when username lookup returns no match).
+ */
+export async function postLogin(email: string, password: string): Promise<LoginResponse> {
+  const body = new URLSearchParams({ username: email, password })
+  const res = await fetch('/api/users/auth/token', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  })
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({})) as { detail?: string }
+    throw Object.assign(new Error(detail.detail ?? 'Login failed'), { status: res.status })
+  }
+  return res.json() as Promise<LoginResponse>
+}
+
+/**
+ * POST /api/users/
+ * Registers a new account. The backend hashes `hashed_password` on receipt.
+ */
+export async function postSignup(opts: {
+  username: string
+  email: string
+  password: string
+}): Promise<void> {
+  const res = await fetch('/api/users/', {
+    method: 'POST',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      username: opts.username,
+      email: opts.email,
+      hashed_password: opts.password,
+    }),
+  })
+  if (!res.ok) {
+    const detail = await res.json().catch(() => ({})) as { detail?: string }
+    throw Object.assign(new Error(detail.detail ?? 'Signup failed'), { status: res.status })
+  }
+}
+
+/**
+ * GET /api/users/me
+ * Returns the authenticated user's profile. Requires a Bearer token.
+ */
+export async function getMe(token: string): Promise<MeResponse> {
+  const res = await fetch('/api/users/me', {
+    credentials: 'include',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw Object.assign(new Error('Failed to fetch profile'), { status: res.status })
+  return res.json() as Promise<MeResponse>
+}

--- a/src/frontend/src/features/auth/api.ts
+++ b/src/frontend/src/features/auth/api.ts
@@ -40,7 +40,7 @@ export async function postLogin(email: string, password: string): Promise<LoginR
 
 /**
  * POST /api/users/
- * Registers a new account. The backend hashes `hashed_password` on receipt.
+ * Registers a new account. The backend hashes the password on receipt.
  */
 export async function postSignup(opts: {
   username: string
@@ -54,7 +54,7 @@ export async function postSignup(opts: {
     body: JSON.stringify({
       username: opts.username,
       email: opts.email,
-      hashed_password: opts.password,
+      password: opts.password,
     }),
   })
   if (!res.ok) {

--- a/src/frontend/src/features/cards/components/PriceCharts.tsx
+++ b/src/frontend/src/features/cards/components/PriceCharts.tsx
@@ -56,7 +56,7 @@ export function PriceCharts({ card }: PriceChartsProps) {
     : []
 
   const { list: listAvg, sold: soldAvg, dates } = trimNulls(rawList, rawSold, rawDates)
-  const hasData = [...listAvg, ...soldAvg].filter((v) => v !== null).length >= 2
+  const hasData = [...listAvg, ...soldAvg].filter((v) => v !== null).length >= 1
 
   return (
     <div className={styles.chartSection}>

--- a/src/frontend/src/lib/apiClient.ts
+++ b/src/frontend/src/lib/apiClient.ts
@@ -18,6 +18,7 @@ export async function apiClient<T>(
 
   const res = await fetch(`/api${path}`, {
     ...options,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
       ...(token ? { Authorization: `Bearer ${token}` } : {}),

--- a/src/frontend/src/routes/Login.module.css
+++ b/src/frontend/src/routes/Login.module.css
@@ -64,7 +64,10 @@
 
 .formTitle { font-family: var(--font-serif); font-size: 36px; font-weight: 500; letter-spacing: -0.6px; margin-bottom: 8px; }
 .formSub { font-size: 14px; color: var(--hd-muted); margin-bottom: 32px; }
-.formSubLink { color: var(--hd-accent); text-decoration: underline; text-underline-offset: 4px; cursor: pointer; }
+.formSubLink {
+  color: var(--hd-accent); text-decoration: underline; text-underline-offset: 4px; cursor: pointer;
+  background: none; border: none; padding: 0; font-size: inherit; font-family: inherit;
+}
 
 .socialButtons { display: flex; flex-direction: column; gap: 10px; margin-bottom: 28px; }
 .socialBtn {
@@ -95,12 +98,23 @@
 }
 .input:focus { outline: none; border-color: var(--hd-accent); }
 
+.errorBanner {
+  padding: 12px 16px;
+  background: rgba(220, 53, 69, 0.12);
+  border: 1px solid rgba(220, 53, 69, 0.35);
+  border-radius: 8px;
+  font-size: 13px;
+  color: #ff6b7a;
+  line-height: 1.45;
+}
+
 .submitBtn {
   margin-top: 14px; padding: 14px; width: 100%;
   background: var(--hd-accent); border: none; border-radius: 10px;
   color: var(--hd-bg); font-weight: 600; font-size: 14px; font-family: var(--font-sans);
   cursor: pointer;
 }
-.submitBtn:hover { opacity: 0.9; }
+.submitBtn:hover:not(:disabled) { opacity: 0.9; }
+.submitBtn:disabled { opacity: 0.55; cursor: not-allowed; }
 
 .terms { margin-top: 28px; font-size: 11px; color: var(--hd-sub); font-family: var(--font-mono); letter-spacing: 1.2px; }

--- a/src/frontend/src/routes/__root.tsx
+++ b/src/frontend/src/routes/__root.tsx
@@ -1,5 +1,6 @@
 // src/frontend/src/routes/__root.tsx
-import { createRootRouteWithContext, Outlet, redirect } from '@tanstack/react-router'
+import { createRootRouteWithContext, Outlet, redirect, useNavigate } from '@tanstack/react-router'
+import { useEffect, useRef } from 'react'
 import type { QueryClient } from '@tanstack/react-query'
 import { useAuthStore } from '../store/auth'
 
@@ -7,14 +8,38 @@ interface RouterContext {
   queryClient: QueryClient
 }
 
-const PUBLIC_PATHS = ['/', '/login']
+// Paths accessible without a token
+const PUBLIC_PATHS = ['/login', '/search']
+
+function RootComponent() {
+  const navigate = useNavigate()
+  const token = useAuthStore((s) => s.token)
+  const prevTokenRef = useRef(token)
+
+  useEffect(() => {
+    const wasAuthenticated = prevTokenRef.current !== null
+    const isNowUnauthenticated = token === null
+    if (wasAuthenticated && isNowUnauthenticated) {
+      // Token was cleared (logout or 401) — send the user to the public search page
+      navigate({ to: '/search' })
+    }
+    prevTokenRef.current = token
+  }, [token, navigate])
+
+  return <Outlet />
+}
 
 export const Route = createRootRouteWithContext<RouterContext>()({
   beforeLoad: ({ location }) => {
     const token = useAuthStore.getState().token
-    if (!token && !PUBLIC_PATHS.includes(location.pathname)) {
+    const { pathname } = location
+
+    // Unauthenticated: public paths are always allowed; / redirects to /search (marketing page is for guests, app shell is not)
+    if (!token) {
+      if (PUBLIC_PATHS.includes(pathname)) return
+      if (pathname === '/') throw redirect({ to: '/search' })
       throw redirect({ to: '/login' })
     }
   },
-  component: () => <Outlet />,
+  component: RootComponent,
 })

--- a/src/frontend/src/routes/__root.tsx
+++ b/src/frontend/src/routes/__root.tsx
@@ -36,7 +36,8 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
     // Unauthenticated: public paths are always allowed; / redirects to /search (marketing page is for guests, app shell is not)
     if (!token) {
-      if (PUBLIC_PATHS.includes(pathname)) return
+      const isPublicPath = PUBLIC_PATHS.includes(pathname) || pathname.startsWith('/cards/')
+      if (isPublicPath) return
       if (pathname === '/') throw redirect({ to: '/search' })
       throw redirect({ to: '/login' })
     }

--- a/src/frontend/src/routes/login.tsx
+++ b/src/frontend/src/routes/login.tsx
@@ -50,7 +50,6 @@ function LoginPage() {
       // Hydrate username from /me (UserPublic does not expose email; we already have it from the form)
       const me = await getMe(tokens.access_token)
       login(tokens.access_token, {
-        id: me.username,
         username: me.username,
         email,
       })

--- a/src/frontend/src/routes/login.tsx
+++ b/src/frontend/src/routes/login.tsx
@@ -1,117 +1,243 @@
 // src/frontend/src/routes/login.tsx
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
-import { useState } from 'react'
+import { useState, useId } from 'react'
 import { CardArt } from '../components/design-system/CardArt'
-import { Icon } from '../components/design-system/Icon'
 import { useAuthStore } from '../store/auth'
+import { postLogin, postSignup, getMe } from '../features/auth/api'
 import styles from './Login.module.css'
 
 export const Route = createFileRoute('/login')({
   component: LoginPage,
 })
 
-const SOCIAL = [
-  { icon: 'G', label: 'Continue with Google' },
-  { icon: '⌘', label: 'Continue with Apple'  },
-  { icon: '◐', label: 'Continue with Discord' },
-]
-
 const CARD_NAMES = ['Ragavan', 'Mox Diamond', 'Sheoldred', 'One Ring']
 
+type Mode = 'login' | 'signup'
+
 function LoginPage() {
+  const [mode, setMode] = useState<Mode>('login')
   const [email, setEmail] = useState('')
+  const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
   const navigate = useNavigate()
   const login = useAuthStore((s) => s.login)
+  const formId = useId()
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    // Stubbed: accepts any non-empty email+password
-    login('dev-stub-token', { id: 'dev', email: email || 'dev@automana.local' })
-    navigate({ to: '/collection' } as any)
+  function switchMode(next: Mode) {
+    setMode(next)
+    setError(null)
+    setEmail('')
+    setUsername('')
+    setPassword('')
   }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+
+    try {
+      if (mode === 'signup') {
+        await postSignup({ username, email, password })
+      }
+
+      // Login (both for login mode and auto-login after signup)
+      const tokens = await postLogin(email, password)
+
+      // Hydrate username from /me (UserPublic does not expose email; we already have it from the form)
+      const me = await getMe(tokens.access_token)
+      login(tokens.access_token, {
+        id: me.username,
+        username: me.username,
+        email,
+      })
+
+      navigate({ to: '/' })
+    } catch (err: unknown) {
+      const e = err as { status?: number; message?: string }
+      if (mode === 'signup' && e.status === 409) {
+        setError('An account with that email or username already exists.')
+      } else if (mode === 'signup' && e.status === 422) {
+        setError('Please fill in all required fields correctly.')
+      } else if (e.status === 401) {
+        setError('Invalid email or password.')
+      } else {
+        setError(e.message ?? 'Something went wrong. Please try again.')
+      }
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const isLogin = mode === 'login'
 
   return (
     <div className={styles.page}>
+      {/* ── Left panel ── */}
       <div className={styles.left}>
         <div className={styles.leftGlow} />
         <div className={styles.leftLogo}>
           <div className={styles.logoMark}>a</div>
-          <span className={styles.logoText}>auto<span className={styles.logoAccent}>mana</span></span>
+          <span className={styles.logoText}>
+            auto<span className={styles.logoAccent}>mana</span>
+          </span>
         </div>
         <div className={styles.leftContent}>
-          <div className={styles.leftEyebrow}>● welcome back</div>
+          <div className={styles.leftEyebrow}>
+            {isLogin ? '● welcome back' : '● get started'}
+          </div>
           <h1 className={styles.leftHeadline}>
-            The market<br />
-            <span className={styles.leftHeadlineAccent}>moves while you sleep.</span>
+            {isLogin ? (
+              <>
+                The market<br />
+                <span className={styles.leftHeadlineAccent}>moves while you sleep.</span>
+              </>
+            ) : (
+              <>
+                Track every card,<br />
+                <span className={styles.leftHeadlineAccent}>every price move.</span>
+              </>
+            )}
           </h1>
           <p className={styles.leftSub}>
-            Sign in to see what your collection did overnight, manage active eBay listings,
-            and catch every price swing.
+            {isLogin
+              ? 'Sign in to see what your collection did overnight, manage active eBay listings, and catch every price swing.'
+              : 'Create your account and start tracking your MTG collection with real-time pricing and eBay integration.'}
           </p>
         </div>
         <div className={styles.cardStack}>
           {CARD_NAMES.map((name, i) => (
-            <div key={name} style={{ marginLeft: i === 0 ? 0 : -28, transform: `rotate(${(i - 1.5) * 4}deg)` }}>
+            <div
+              key={name}
+              style={{
+                marginLeft: i === 0 ? 0 : -28,
+                transform: `rotate(${(i - 1.5) * 4}deg)`,
+              }}
+            >
               <CardArt name={name} w={100} h={140} hue={180 + i * 18} label={false} />
             </div>
           ))}
         </div>
       </div>
 
+      {/* ── Right panel ── */}
       <div className={styles.right}>
-        <div className={styles.formTitle}>Log in</div>
+        <div className={styles.formTitle}>{isLogin ? 'Log in' : 'Create account'}</div>
         <div className={styles.formSub}>
-          Don't have an account?{' '}
-          <span className={styles.formSubLink}>Create one</span>
+          {isLogin ? (
+            <>
+              Don't have an account?{' '}
+              <button
+                type="button"
+                className={styles.formSubLink}
+                onClick={() => switchMode('signup')}
+              >
+                Create one
+              </button>
+            </>
+          ) : (
+            <>
+              Already have an account?{' '}
+              <button
+                type="button"
+                className={styles.formSubLink}
+                onClick={() => switchMode('login')}
+              >
+                Log in
+              </button>
+            </>
+          )}
         </div>
 
-        <div className={styles.socialButtons}>
-          {SOCIAL.map((s) => (
-            <button key={s.label} className={styles.socialBtn}>
-              <span className={styles.socialIcon}>{s.icon}</span>
-              <span className={styles.socialLabel}>{s.label}</span>
-              <Icon kind="arrowRight" size={14} color="var(--hd-sub)" />
-            </button>
-          ))}
-        </div>
+        <form
+          id={formId}
+          onSubmit={handleSubmit}
+          className={styles.fields}
+          noValidate
+        >
+          {/* Username — signup only */}
+          {!isLogin && (
+            <div>
+              <label htmlFor={`${formId}-username`} className={styles.fieldLabel}>
+                Username
+              </label>
+              <input
+                id={`${formId}-username`}
+                className={styles.input}
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="yourname"
+                autoComplete="username"
+                required
+                minLength={3}
+                maxLength={50}
+              />
+            </div>
+          )}
 
-        <div className={styles.divider}>
-          <div className={styles.dividerLine} />
-          <span className={styles.dividerText}>or with email</span>
-          <div className={styles.dividerLine} />
-        </div>
-
-        <form onSubmit={handleSubmit} className={styles.fields}>
           <div>
-            <div className={styles.fieldLabel}>Email</div>
+            <label htmlFor={`${formId}-email`} className={styles.fieldLabel}>
+              Email
+            </label>
             <input
+              id={`${formId}-email`}
               className={styles.input}
               type="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="you@example.com"
               autoComplete="email"
+              required
             />
           </div>
+
           <div>
             <div className={styles.fieldHeader}>
-              <div className={styles.fieldLabel}>Password</div>
-              <span className={styles.forgotLink}>Forgot?</span>
+              <label htmlFor={`${formId}-password`} className={styles.fieldLabel}>
+                Password
+              </label>
+              {isLogin && (
+                <span className={styles.forgotLink}>Forgot?</span>
+              )}
             </div>
             <input
+              id={`${formId}-password`}
               className={styles.input}
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               placeholder="••••••••"
-              autoComplete="current-password"
+              autoComplete={isLogin ? 'current-password' : 'new-password'}
+              required
+              minLength={8}
             />
           </div>
-          <button type="submit" className={styles.submitBtn}>Log in →</button>
+
+          {error && (
+            <div className={styles.errorBanner} role="alert">
+              {error}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            className={styles.submitBtn}
+            disabled={submitting}
+            aria-busy={submitting}
+          >
+            {submitting
+              ? isLogin ? 'Logging in...' : 'Creating account...'
+              : isLogin ? 'Log in →' : 'Create account →'}
+          </button>
         </form>
 
-        <div className={styles.terms}>By continuing you agree to the Terms · Privacy</div>
+        <div className={styles.terms}>
+          By continuing you agree to the Terms · Privacy
+        </div>
       </div>
     </div>
   )

--- a/src/frontend/src/store/__tests__/auth.test.ts
+++ b/src/frontend/src/store/__tests__/auth.test.ts
@@ -13,14 +13,14 @@ describe('useAuthStore', () => {
   })
 
   it('login sets token and user', () => {
-    useAuthStore.getState().login('real-token', { id: 'u1', username: 'alice', email: 'u@test.com' })
+    useAuthStore.getState().login('real-token', { username: 'alice', email: 'u@test.com' })
     expect(useAuthStore.getState().token).toBe('real-token')
     expect(useAuthStore.getState().currentUser?.email).toBe('u@test.com')
     expect(useAuthStore.getState().currentUser?.username).toBe('alice')
   })
 
   it('logout clears token and user', () => {
-    useAuthStore.getState().login('real-token', { id: 'u1', username: 'alice', email: 'u@test.com' })
+    useAuthStore.getState().login('real-token', { username: 'alice', email: 'u@test.com' })
     useAuthStore.getState().logout()
     expect(useAuthStore.getState().token).toBeNull()
     expect(useAuthStore.getState().currentUser).toBeNull()

--- a/src/frontend/src/store/__tests__/auth.test.ts
+++ b/src/frontend/src/store/__tests__/auth.test.ts
@@ -4,23 +4,23 @@ import { useAuthStore } from '../auth'
 
 describe('useAuthStore', () => {
   beforeEach(() => {
-    useAuthStore.setState({
-      token: 'dev-stub-token',
-      currentUser: { id: 'dev', email: 'dev@automana.local' },
-    })
+    useAuthStore.setState({ token: null, currentUser: null })
   })
 
-  it('initialises with stub token', () => {
-    expect(useAuthStore.getState().token).toBe('dev-stub-token')
+  it('initialises unauthenticated', () => {
+    expect(useAuthStore.getState().token).toBeNull()
+    expect(useAuthStore.getState().currentUser).toBeNull()
   })
 
   it('login sets token and user', () => {
-    useAuthStore.getState().login('real-token', { id: 'u1', email: 'u@test.com' })
+    useAuthStore.getState().login('real-token', { id: 'u1', username: 'alice', email: 'u@test.com' })
     expect(useAuthStore.getState().token).toBe('real-token')
     expect(useAuthStore.getState().currentUser?.email).toBe('u@test.com')
+    expect(useAuthStore.getState().currentUser?.username).toBe('alice')
   })
 
   it('logout clears token and user', () => {
+    useAuthStore.getState().login('real-token', { id: 'u1', username: 'alice', email: 'u@test.com' })
     useAuthStore.getState().logout()
     expect(useAuthStore.getState().token).toBeNull()
     expect(useAuthStore.getState().currentUser).toBeNull()

--- a/src/frontend/src/store/auth.ts
+++ b/src/frontend/src/store/auth.ts
@@ -2,9 +2,10 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-interface CurrentUser {
+export interface CurrentUser {
   id: string
-  email: string
+  username: string
+  email: string | null
 }
 
 interface AuthState {
@@ -17,11 +18,11 @@ interface AuthState {
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
-      token: 'dev-stub-token',
-      currentUser: { id: 'dev', email: 'dev@automana.local' },
+      token: null,
+      currentUser: null,
       login: (token, user) => set({ token, currentUser: user }),
       logout: () => set({ token: null, currentUser: null }),
     }),
-    { name: 'automana-auth' }
+    { name: 'automana-auth-v2' }
   )
 )

--- a/src/frontend/src/store/auth.ts
+++ b/src/frontend/src/store/auth.ts
@@ -1,9 +1,8 @@
 // src/frontend/src/store/auth.ts
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
+import { persist, createJSONStorage } from 'zustand/middleware'
 
 export interface CurrentUser {
-  id: string
   username: string
   email: string | null
 }
@@ -23,6 +22,9 @@ export const useAuthStore = create<AuthState>()(
       login: (token, user) => set({ token, currentUser: user }),
       logout: () => set({ token: null, currentUser: null }),
     }),
-    { name: 'automana-auth-v2' }
+    {
+      name: 'automana-auth-v2',
+      storage: createJSONStorage(() => sessionStorage),
+    }
   )
 )

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   ],
   server: {
     proxy: {
-      '/api': 'http://localhost:8000',
+      '/api': 'http://backend:8000',
     },
   },
 })

--- a/tests/unit/api/services/auth/test_user_service_register.py
+++ b/tests/unit/api/services/auth/test_user_service_register.py
@@ -1,0 +1,77 @@
+"""
+Tests for automana.api.services.user_management.user_service.register
+
+Regression test for the HTTPException passthrough bug:
+- user_service.register had a broad `except Exception` that re-wrapped HTTPException
+  as UserError, causing 409 Conflict responses to become 500 Internal Server Error.
+- Fix: add `except HTTPException: raise` before the broad handler.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi import HTTPException
+
+from automana.api.services.user_management import user_service
+from automana.api.schemas.user_management.user import BaseUser
+from automana.core.exceptions.service_layer_exceptions.user_management import user_exceptions
+
+pytestmark = pytest.mark.unit
+
+
+def _make_user() -> BaseUser:
+    return BaseUser(
+        username="alice",
+        email="alice@example.com",
+        fullname="Alice Example",
+        hashed_password="plaintext-for-test",
+    )
+
+
+class TestRegisterHTTPExceptionPassthrough:
+    """HTTPException (e.g. 409 Conflict) must propagate unchanged from register()."""
+
+    async def test_http_exception_is_not_swallowed_by_broad_handler(
+        self, mock_user_repository
+    ):
+        """When the repository raises an HTTPException it must not be re-wrapped as UserError."""
+        conflict = HTTPException(status_code=409, detail="Username already exists")
+        mock_user_repository.add = AsyncMock(side_effect=conflict)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await user_service.register(
+                user_repository=mock_user_repository,
+                user=_make_user(),
+            )
+
+        assert exc_info.value.status_code == 409, (
+            f"Expected 409, got {exc_info.value.status_code} — "
+            "HTTPException was re-wrapped by the broad except handler"
+        )
+
+    async def test_http_exception_detail_is_preserved(self, mock_user_repository):
+        """The original detail message on the HTTPException must survive passthrough."""
+        detail = "Email already registered"
+        mock_user_repository.add = AsyncMock(
+            side_effect=HTTPException(status_code=409, detail=detail)
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await user_service.register(
+                user_repository=mock_user_repository,
+                user=_make_user(),
+            )
+
+        assert exc_info.value.detail == detail
+
+    async def test_non_http_exception_still_raises_user_error(
+        self, mock_user_repository
+    ):
+        """Generic exceptions must still be wrapped as UserError (existing behavior)."""
+        mock_user_repository.add = AsyncMock(
+            side_effect=RuntimeError("connection refused")
+        )
+
+        with pytest.raises(user_exceptions.UserError):
+            await user_service.register(
+                user_repository=mock_user_repository,
+                user=_make_user(),
+            )


### PR DESCRIPTION
## Summary

- **Fix `archive_to_weekly` decompression error**: TimescaleDB compressed chunks blocked row-level DELETE with "tuple decompression limit exceeded". Now explicitly calls `decompress_chunk()` per batch and lifts the GUC limit via `SET LOCAL`. Batch size normalised to 7 days (one chunk). Archived 4.2M rows to Tier 3, removed 26.4M rows from Tier 2.
- **Unify Tier 2 + Tier 3 for price history**: The `weekly` query now UNIONs `print_price_daily` (Tier 2) and `print_price_weekly` (Tier 3) so historical prices remain accessible after archival. The `all` range switches to weekly aggregation for full multi-year coverage.
- **Fix 1w/1m/3m charts showing nothing**: `PriceCharts.tsx` required ≥2 non-null values across both series; lowered to ≥1 so charts render when only `sold_avg` has data (list prices stop at 2024-01-08 in current dataset).
- **Rename registration field**: `hashed_password` → `password` in API schema, service, and frontend to reflect that the server does the hashing.

## Test plan

- [ ] Run `CALL pricing.archive_to_weekly('5 years')` — should complete without "tuple decompression limit exceeded" warnings
- [ ] Check `SELECT COUNT(*) FROM pricing.print_price_weekly` — should have rows
- [ ] Visit a card detail page, toggle **all** range — should show historical weekly data spanning both Tier 2 and Tier 3
- [ ] Toggle **1w / 1m / 3m** — should render sold_avg line where data exists instead of "No price data"
- [ ] POST `/api/users/` with `{ "password": "..." }` — registration should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)