### PR TITLE
feat(ebay): setup wizard wiring + MTG listing builder

### DIFF
--- a/src/automana/api/routers/integrations/ebay/__init__.py
+++ b/src/automana/api/routers/integrations/ebay/__init__.py
@@ -2,8 +2,11 @@
 from automana.api.routers.integrations.ebay.ebay_auth import ebay_auth_router
 from automana.api.routers.integrations.ebay.ebay_browse import search_router
 from automana.api.routers.integrations.ebay.ebay_selling import ebay_listing_router
+from automana.api.routers.integrations.ebay.scopes import router as scopes_router
+
 ebay_router = APIRouter(prefix="/ebay", tags=["eBay"])
 
 ebay_router.include_router(ebay_auth_router)
 ebay_router.include_router(search_router)
 ebay_router.include_router(ebay_listing_router)
+ebay_router.include_router(scopes_router)

--- a/src/automana/api/routers/integrations/ebay/ebay_auth.py
+++ b/src/automana/api/routers/integrations/ebay/ebay_auth.py
@@ -1,11 +1,16 @@
 ﻿
+from urllib.parse import quote
 
 from fastapi import Cookie, HTTPException, APIRouter, Query, Request, Depends, Response, status
+from fastapi.responses import RedirectResponse
 from automana.api.dependancies.service_deps import ServiceManagerDep
 from automana.api.dependancies.auth.users import CurrentUserDep
 from automana.core.models.ebay.auth import AppRegistrationRequest, CreateAppRequest
 from automana.api.schemas.StandardisedQueryResponse import ApiResponse
+from automana.core.settings import get_settings
 from pydantic import BaseModel
+
+settings = get_settings()
 
 
 class UpdateRedirectUriRequest(BaseModel):
@@ -85,10 +90,17 @@ async def handle_ebay_callback(
     try:
         if error:
             logger.error("ebay_callback_error", extra={"error": error, "description": error_description})
-            raise HTTPException(status_code=400, detail=error_description or error)
+            msg = error_description or error or "Authorization denied"
+            return RedirectResponse(
+                url=f"{settings.FRONTEND_BASE_URL}/ebay/connected?status=error&message={quote(msg)}",
+                status_code=302,
+            )
         if not code:
             logger.error("ebay_callback_missing_code", extra={"has_state": bool(state)})
-            raise HTTPException(status_code=400, detail="Missing authorization code in eBay callback")
+            return RedirectResponse(
+                url=f"{settings.FRONTEND_BASE_URL}/ebay/connected?status=error&message={quote('Missing authorization code')}",
+                status_code=302,
+            )
         env = await service_manager.execute_service(
             "integrations.ebay.get_environment_callback",
             state=state,
@@ -110,9 +122,10 @@ async def handle_ebay_callback(
                 samesite="strict",
             )
         logger.info("ebay_callback_success", extra={"state": state})
-        return ApiResponse(
-            message="eBay authorization successful",
-            data={"status": "authorized", "state": state},
+        app_code_param = token_data['app_code'] if token_data else ''
+        return RedirectResponse(
+            url=f"{settings.FRONTEND_BASE_URL}/ebay/connected?status=authorized&app_code={app_code_param}",
+            status_code=302,
         )
     except HTTPException:
         raise

--- a/src/automana/api/routers/integrations/ebay/scopes.py
+++ b/src/automana/api/routers/integrations/ebay/scopes.py
@@ -19,7 +19,7 @@ async def list_scopes(
     try:
         scopes = await service_manager.execute_service(
             "integrations.ebay.get_scopes_by_environment",
-            environment=environment,
+            ebay_environment=environment,
         )
         return ApiResponse(message="Scopes retrieved", data={"scopes": scopes})
     except Exception as e:

--- a/src/automana/api/routers/integrations/ebay/scopes.py
+++ b/src/automana/api/routers/integrations/ebay/scopes.py
@@ -1,17 +1,35 @@
-﻿from fastapi import APIRouter,  Response, HTTPException
-from typing import Optional
+from fastapi import APIRouter, Response, HTTPException
+from typing import Literal, Optional
 from automana.api.dependancies.database import cursorDep
+from automana.api.dependancies.service_deps import ServiceManagerDep
+from automana.api.schemas.StandardisedQueryResponse import ApiResponse
 from automana.core.services.app_integration.ebay.scope_service import register_scope
 
 router = APIRouter(
     prefix='/scopes',
-    responses={404:{'description' : 'Not found'}}
+    responses={404: {'description': 'Not found'}}
 )
 
+
+@router.get('/', description='List all scopes available for a given eBay environment')
+async def list_scopes(
+    environment: Literal['SANDBOX', 'PRODUCTION'],
+    service_manager: ServiceManagerDep,
+):
+    try:
+        scopes = await service_manager.execute_service(
+            "integrations.ebay.get_scopes_by_environment",
+            environment=environment,
+        )
+        return ApiResponse(message="Scopes retrieved", data={"scopes": scopes})
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Could not retrieve scopes: {e}")
+
+
 @router.post('/', description='add a new scope to the the available scope')
-async def regist_scope(conn : cursorDep, scope: str, scope_description : Optional[str]):
+async def regist_scope(conn: cursorDep, scope: str, scope_description: Optional[str]):
     try:
         register_scope(conn, scope, scope_description)
     except Exception as e:
-        raise HTTPException(status_code=400, detail=f'Cound not register scope: {e}')
+        raise HTTPException(status_code=400, detail=f'Could not register scope: {e}')
     return Response(status_code=200, content='{scope} scope added')

--- a/src/automana/core/models/ebay/listing_inputs.py
+++ b/src/automana/core/models/ebay/listing_inputs.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from decimal import Decimal
 from enum import Enum
 from typing import Optional

--- a/src/automana/core/models/ebay/listing_inputs.py
+++ b/src/automana/core/models/ebay/listing_inputs.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+from uuid import UUID
+
+
+class Condition(str, Enum):
+    NM = "NM"
+    LP = "LP"
+    MP = "MP"
+    HP = "HP"
+    DMG = "DMG"
+
+
+class DescriptionMode(str, Enum):
+    MINIMAL = "minimal"
+    FULL = "full"
+
+
+@dataclass(frozen=True)
+class CardData:
+    card_version_id: UUID
+    card_name: str
+    set_name: str
+    set_code: str
+    collector_number: str
+    mana_cost: Optional[str]
+    oracle_text: Optional[str]
+    type_line: Optional[str]
+    rarity_name: str
+    color_identity: list[str]
+    power: Optional[str]
+    toughness: Optional[str]
+    loyalty: Optional[str]
+    image_url: Optional[str]
+    flavor_text: Optional[str]
+    scryfall_id: Optional[str]
+
+
+@dataclass(frozen=True)
+class SellerInput:
+    condition: Condition
+    quantity: int
+    foil: bool
+    lang: str = "en"
+    price_aud: Decimal = Decimal("0.00")
+    shipping_cost_aud: Decimal = Decimal("0.00")
+    condition_note: Optional[str] = None
+    description_mode: DescriptionMode = DescriptionMode.FULL
+
+
+@dataclass(frozen=True)
+class BrandConfig:
+    store_name: str = ""
+    store_tagline: str = "Fast AU Shipping"
+    title_suffix: str = ""
+    accent_color: str = "#1a73e8"
+    header_html: str = ""
+    footer_html: str = (
+        "<p>✅ Fast dispatch from Australia · Tracked postage available · "
+        "Combined shipping on multiple orders</p>"
+        "<p>Cards are shipped in a sleeve inside a rigid toploader, then "
+        "bubble-wrapped for protection.</p>"
+        "<p>Returns accepted within 30 days if item not as described. "
+        "Please message before opening a case.</p>"
+    )
+    return_policy_description: str = (
+        "Returns accepted within 30 days if item is not as described. "
+        "Please message us before opening a case."
+    )
+    dispatch_days: int = 3
+    tracked_shipping_cost_aud: str = "4.50"
+    seller_postcode: str = ""
+    seller_location_display: str = ""
+    seller_shipping_profile_id: Optional[int] = None
+    seller_return_profile_id: Optional[int] = None
+    seller_payment_profile_id: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class PricingInput:
+    buy_it_now_price_aud: Decimal
+    domestic_shipping_cost_aud: Decimal = Decimal("0.00")

--- a/src/automana/core/repositories/app_integration/ebay/auth_queries.py
+++ b/src/automana/core/repositories/app_integration/ebay/auth_queries.py
@@ -99,6 +99,15 @@ get_app_scopes_query = """
      WHERE sa.app_id = $1;
 """
 
+get_scopes_by_environment_query = """
+    SELECT DISTINCT s.scope_url, s.scope_description
+      FROM app_integration.scopes s
+      JOIN app_integration.scope_app sa ON sa.scope_id = s.scope_id
+      JOIN app_integration.app_info ai ON ai.app_id = sa.app_id
+     WHERE ai.environment = $1
+     ORDER BY s.scope_url;
+"""
+
 # Returns user-specific scopes for (user_id, app_id). Empty result means fall
 # back to app-level scopes. PK bug on scopes_user (missing app_id) is a known
 # issue; it does not affect single-app testing.

--- a/src/automana/core/repositories/app_integration/ebay/auth_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/auth_repository.py
@@ -112,6 +112,10 @@ class EbayAuthRepository(AbstractRepository):
         rows = self.execute_query_sync(query, (user_id, app_code, get_pgp_key()))
         return rows[0] if rows else None
 
+    async def get_scopes_by_environment(self, environment: str) -> list[dict]:
+        rows = await self.execute_query(auth_queries.get_scopes_by_environment_query, (environment,))
+        return [dict(r) for r in rows] if rows else []
+
     async def get_app_scopes(self, app_id: str) -> list:
         rows = await self.execute_query(auth_queries.get_app_scopes_query, (app_id,))
         return [r["scope_url"] for r in rows] if rows else []

--- a/src/automana/core/repositories/app_integration/ebay/listing_builder_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/listing_builder_repository.py
@@ -50,6 +50,21 @@ class EbayListingBuilderRepository(AbstractRepository):
     def name(self) -> str:
         return "EbayListingBuilderRepository"
 
+    async def add(self, item) -> None:
+        raise NotImplementedError
+
+    async def get(self, id: int) -> None:
+        raise NotImplementedError
+
+    async def update(self, item) -> None:
+        raise NotImplementedError
+
+    async def delete(self, id: int) -> None:
+        raise NotImplementedError
+
+    async def list(self, items) -> list:
+        raise NotImplementedError
+
     async def fetch_card_data(self, card_version_id: UUID) -> Optional[CardData]:
         """Return CardData for the given card version, or None if not found."""
         rows = await self.execute_query(_FETCH_CARD_SQL, (card_version_id,))

--- a/src/automana/core/repositories/app_integration/ebay/listing_builder_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/listing_builder_repository.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+from uuid import UUID
+
+from automana.core.models.ebay.listing_inputs import CardData
+from automana.core.repositories.abstract_repositories.AbstractDBRepository import (
+    AbstractRepository,
+)
+
+logger = logging.getLogger(__name__)
+
+_FETCH_CARD_SQL = """
+SELECT
+    v.card_version_id,
+    v.card_name,
+    v.set_name,
+    v.set_code,
+    v.collector_number,
+    v.mana_cost,
+    v.oracle_text,
+    v.type_line,
+    v.rarity_name,
+    v.color_identity,
+    v.power,
+    v.toughness,
+    v.loyalty,
+    COALESCE(
+        v.illustrations -> 0 -> 'image_uris' ->> 'large',
+        v.illustrations -> 0 -> 'image_uris' ->> 'normal'
+    ) AS image_url,
+    v.card_faces -> 0 ->> 'flavor_text' AS flavor_text,
+    ei.value AS scryfall_id
+FROM card_catalog.v_card_versions_complete v
+LEFT JOIN card_catalog.card_external_identifier ei
+    ON ei.card_version_id = v.card_version_id
+    AND ei.card_identifier_ref_id = (
+        SELECT card_identifier_ref_id
+        FROM card_catalog.card_identifier_ref
+        WHERE identifier_name = 'scryfall_id'
+    )
+WHERE v.card_version_id = $1
+"""
+
+
+class EbayListingBuilderRepository(AbstractRepository):
+
+    @property
+    def name(self) -> str:
+        return "EbayListingBuilderRepository"
+
+    async def fetch_card_data(self, card_version_id: UUID) -> Optional[CardData]:
+        """Return CardData for the given card version, or None if not found."""
+        rows = await self.execute_query(_FETCH_CARD_SQL, (card_version_id,))
+        if not rows:
+            logger.info(
+                "ebay_listing_builder_card_not_found",
+                extra={"card_version_id": str(card_version_id)},
+            )
+            return None
+        row = rows[0]
+        return CardData(
+            card_version_id=row["card_version_id"],
+            card_name=row["card_name"],
+            set_name=row["set_name"],
+            set_code=row["set_code"],
+            collector_number=row["collector_number"] or "",
+            mana_cost=row["mana_cost"],
+            oracle_text=row["oracle_text"],
+            type_line=row["type_line"],
+            rarity_name=row["rarity_name"],
+            color_identity=list(row["color_identity"] or []),
+            power=row["power"],
+            toughness=row["toughness"],
+            loyalty=row["loyalty"],
+            image_url=row["image_url"],
+            flavor_text=row["flavor_text"],
+            scryfall_id=row["scryfall_id"],
+        )

--- a/src/automana/core/service_registry.py
+++ b/src/automana/core/service_registry.py
@@ -159,6 +159,11 @@ ServiceRegistry.register_db_repository(
     "auth", "automana.core.repositories.app_integration.ebay.auth_repository", "EbayAuthRepository"
 )
 ServiceRegistry.register_db_repository(
+    "listing_builder",
+    "automana.core.repositories.app_integration.ebay.listing_builder_repository",
+    "EbayListingBuilderRepository",
+)
+ServiceRegistry.register_db_repository(
     "session", "automana.api.repositories.auth.session_repository", "SessionRepository"
 )
 ServiceRegistry.register_db_repository(

--- a/src/automana/core/services/app_integration/ebay/listing_build_service.py
+++ b/src/automana/core/services/app_integration/ebay/listing_build_service.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
+
+from automana.core.models.ebay.listing_inputs import (
+    BrandConfig,
+    Condition,
+    DescriptionMode,
+    PricingInput,
+    SellerInput,
+)
+from automana.core.repositories.app_integration.ebay.auth_repository import (
+    EbayAuthRepository,
+)
+from automana.core.repositories.app_integration.ebay.ApiSelling_repository import (
+    EbaySellingRepository,
+)
+from automana.core.repositories.app_integration.ebay.listing_builder_repository import (
+    EbayListingBuilderRepository,
+)
+from automana.core.service_registry import ServiceRegistry
+from automana.core.services.app_integration.ebay.listing_builder import build_mtg_listing
+from automana.core.services.app_integration.ebay.listings_write_service import (
+    create_listing,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@ServiceRegistry.register(
+    path="integrations.ebay.selling.listings.build_and_create",
+    db_repositories=["auth", "listing_builder"],
+    api_repositories=["selling"],
+)
+async def build_and_create_listing(
+    auth_repository: EbayAuthRepository,
+    listing_builder_repository: EbayListingBuilderRepository,
+    selling_repository: EbaySellingRepository,
+    user_id: UUID,
+    app_code: str,
+    card_version_id: UUID,
+    condition: str,
+    quantity: int,
+    price_aud: str,
+    foil: bool = False,
+    lang: str = "en",
+    shipping_cost_aud: str = "0.00",
+    condition_note: Optional[str] = None,
+    description_mode: str = "full",
+    brand_config: Optional[Dict[str, Any]] = None,
+    marketplace_id: str = "15",
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Fetch card data, build the ItemModel, and submit it to eBay.
+
+    price_aud and shipping_cost_aud are strings to survive JSON serialisation
+    through Celery task arguments; converted to Decimal here.
+    """
+    card_data = await listing_builder_repository.fetch_card_data(card_version_id)
+    if card_data is None:
+        raise ValueError(f"Card version {card_version_id} not found in card_catalog")
+
+    try:
+        condition_enum = Condition(condition.upper())
+    except ValueError:
+        raise ValueError(
+            f"Invalid condition '{condition}'. Must be one of: "
+            + ", ".join(c.value for c in Condition)
+        )
+
+    seller_input = SellerInput(
+        condition=condition_enum,
+        quantity=quantity,
+        foil=foil,
+        lang=lang,
+        price_aud=Decimal(price_aud),
+        shipping_cost_aud=Decimal(shipping_cost_aud),
+        condition_note=condition_note,
+        description_mode=DescriptionMode(description_mode),
+    )
+
+    brand = BrandConfig(**(brand_config or {})) if brand_config else BrandConfig()
+
+    pricing = PricingInput(
+        buy_it_now_price_aud=Decimal(price_aud),
+        domestic_shipping_cost_aud=Decimal(shipping_cost_aud),
+    )
+
+    item = build_mtg_listing(card_data, seller_input, brand, pricing)
+    idempotency_key = str(uuid4())
+
+    logger.info(
+        "ebay_build_and_create_listing",
+        extra={
+            "user_id": str(user_id),
+            "app_code": app_code,
+            "card_version_id": str(card_version_id),
+            "condition": condition,
+            "foil": foil,
+            "lang": lang,
+            "idempotency_key": idempotency_key,
+        },
+    )
+
+    return await create_listing(
+        auth_repository=auth_repository,
+        selling_repository=selling_repository,
+        user_id=user_id,
+        app_code=app_code,
+        item=item,
+        idempotency_key=idempotency_key,
+        marketplace_id=marketplace_id,
+    )

--- a/src/automana/core/services/app_integration/ebay/listing_build_service.py
+++ b/src/automana/core/services/app_integration/ebay/listing_build_service.py
@@ -82,7 +82,7 @@ async def build_and_create_listing(
         description_mode=DescriptionMode(description_mode),
     )
 
-    brand = BrandConfig(**(brand_config or {})) if brand_config else BrandConfig()
+    brand = BrandConfig(**(brand_config or {}))
 
     pricing = PricingInput(
         buy_it_now_price_aud=Decimal(price_aud),

--- a/src/automana/core/services/app_integration/ebay/listing_builder.py
+++ b/src/automana/core/services/app_integration/ebay/listing_builder.py
@@ -1,0 +1,389 @@
+"""Pure mapping functions: CardData + seller inputs → ItemModel fields.
+
+No DB access, no async, no side effects. Every public function is unit-testable
+with plain dataclass instances. The orchestrating service owns IO; this module
+owns decisions.
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Optional
+
+from automana.core.models.ebay.listing_inputs import (
+    BrandConfig,
+    CardData,
+    Condition,
+    DescriptionMode,
+    PricingInput,
+    SellerInput,
+)
+from automana.core.models.ebay.listings import (
+    BaseCostType,
+    CategoryType,
+    ItemModel,
+    ReturnPolicyType,
+    SellerProfilesType,
+    ShippingDetailsType,
+    ShippingServiceOptionType,
+)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EBAY_AU_SITE_ID: str = "15"
+EBAY_AU_MTG_CATEGORY_ID: str = "38292"
+EBAY_AU_CURRENCY: str = "AUD"
+EBAY_AU_COUNTRY: str = "AU"
+EBAY_AU_SITE_NAME: str = "Australia"
+
+_CONDITION_ID_MAP: dict[Condition, int] = {
+    Condition.NM: 3000,
+    Condition.LP: 4000,
+    Condition.MP: 5000,
+    Condition.HP: 6000,
+    Condition.DMG: 7000,
+}
+
+_CONDITION_DESCRIPTION_MAP: dict[Condition, str] = {
+    Condition.NM: "Card is Near Mint. No visible play wear. Stored in sleeve from opening.",
+    Condition.LP: "Card is Lightly Played. Minimal edge wear or light surface scratches. Does not affect gameplay.",
+    Condition.MP: "Card is Moderately Played. Noticeable wear on edges or surface. Fully playable.",
+    Condition.HP: "Card is Heavily Played. Significant wear. Suitable for casual play or proxy use.",
+    Condition.DMG: "Card is Damaged. Creases, tears, or markings present. Sold as-is.",
+}
+
+_RARITY_MAP: dict[str, str] = {
+    "common": "Common",
+    "uncommon": "Uncommon",
+    "rare": "Rare",
+    "mythic": "Mythic Rare",
+    "special": "Special",
+    "bonus": "Special",
+}
+
+_LANG_MAP: dict[str, str] = {
+    "en": "English", "ja": "Japanese", "de": "German", "fr": "French",
+    "it": "Italian", "es": "Spanish", "pt": "Portuguese", "ru": "Russian",
+    "ko": "Korean", "zhs": "Chinese Simplified", "zht": "Chinese Traditional",
+    "he": "Hebrew", "ar": "Arabic", "grc": "Ancient Greek", "la": "Latin",
+}
+
+_COLOR_MAP: dict[str, str] = {
+    "W": "White", "U": "Blue", "B": "Black", "R": "Red", "G": "Green",
+}
+
+# ---------------------------------------------------------------------------
+# Identity helpers
+# ---------------------------------------------------------------------------
+
+def build_title(card: CardData, seller: SellerInput) -> str:
+    """80-char max title following the spec formula."""
+    set_code = card.set_code.upper()
+    condition = seller.condition.value
+    tokens = [card.card_name, set_code, card.collector_number]
+    if seller.foil:
+        tokens.append("FOIL")
+    if seller.lang != "en":
+        tokens.append(seller.lang.upper())
+    tokens.extend([condition, "MTG"])
+
+    title = " ".join(tokens)
+    if len(title) <= 80:
+        return title
+
+    # Drop collector_number first
+    tokens = [card.card_name, set_code]
+    if seller.foil:
+        tokens.append("FOIL")
+    if seller.lang != "en":
+        tokens.append(seller.lang.upper())
+    tokens.extend([condition, "MTG"])
+    title = " ".join(tokens)
+    if len(title) <= 80:
+        return title
+
+    # Hard truncate as last resort (preserves card_name integrity)
+    return title[:77] + "..."
+
+
+def build_sku(card: CardData, seller: SellerInput) -> str:
+    identifier = card.scryfall_id or str(card.card_version_id)
+    foil_flag = "F" if seller.foil else "N"
+    return f"{identifier}-{seller.condition.value}-{foil_flag}"
+
+
+def build_subtitle(card: CardData, brand: BrandConfig) -> Optional[str]:
+    """Only generate for rare/mythic (AU$~2 fee — not worth it for commons)."""
+    if card.rarity_name not in ("rare", "mythic"):
+        return None
+    type_short = card.type_line.split("—")[0].strip() if card.type_line else ""
+    rarity_display = _RARITY_MAP.get(card.rarity_name, card.rarity_name.capitalize())
+    tagline = brand.store_tagline or "Fast AU Shipping"
+    parts = [card.set_name, rarity_display]
+    if type_short:
+        parts.append(type_short)
+    parts.append(tagline)
+    return " · ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Condition helpers
+# ---------------------------------------------------------------------------
+
+def map_condition_to_ebay_id(condition: Condition) -> int:
+    return _CONDITION_ID_MAP[condition]
+
+
+def build_condition_description(condition: Condition, note: Optional[str] = None) -> str:
+    base = _CONDITION_DESCRIPTION_MAP[condition]
+    if note:
+        return f"{base} Seller note: {note}"
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers
+# ---------------------------------------------------------------------------
+
+def map_rarity_to_ebay(rarity_name: str) -> str:
+    return _RARITY_MAP.get(rarity_name, "Special")
+
+
+def map_lang_to_ebay(lang: str) -> str:
+    return _LANG_MAP.get(lang, "Other")
+
+
+def map_color_to_ebay(color_identity: list[str]) -> str:
+    if not color_identity:
+        return "Colorless"
+    if len(color_identity) == 1:
+        color_code = color_identity[0]
+        for code, name in _COLOR_MAP.items():
+            if color_code.upper() == code or color_code == name:
+                return name
+        return color_identity[0]
+    return "Multi-Color"
+
+
+def build_item_specifics(card: CardData, seller: SellerInput) -> dict:
+    lang_label = map_lang_to_ebay(seller.lang)
+    finish_label = "Foil" if seller.foil else "Regular"
+    rarity_label = map_rarity_to_ebay(card.rarity_name)
+    color_label = map_color_to_ebay(card.color_identity)
+    type_short = card.type_line.split("—")[0].strip() if card.type_line else ""
+
+    required = [
+        {"Name": "Game", "Value": "Magic: The Gathering"},
+        {"Name": "Card Name", "Value": card.card_name},
+        {"Name": "Set", "Value": card.set_name},
+        {"Name": "Rarity", "Value": rarity_label},
+        {"Name": "Language", "Value": lang_label},
+        {"Name": "Finish", "Value": finish_label},
+        {"Name": "Graded", "Value": "No"},
+    ]
+    recommended = [
+        {"Name": "Card Number", "Value": card.collector_number},
+        {"Name": "Colour", "Value": color_label},
+    ]
+    if type_short:
+        recommended.append({"Name": "Type", "Value": type_short})
+    if card.mana_cost:
+        recommended.append({"Name": "Mana Cost", "Value": card.mana_cost})
+
+    return {"NameValueList": required + recommended}
+
+
+# ---------------------------------------------------------------------------
+# Description helpers
+# ---------------------------------------------------------------------------
+
+def _oracle_to_html(oracle_text: Optional[str]) -> str:
+    if not oracle_text:
+        return ""
+    return oracle_text.replace("\n", "<br/>")
+
+
+def _condition_label(condition: Condition) -> str:
+    labels = {
+        Condition.NM: "Near Mint (NM)",
+        Condition.LP: "Lightly Played (LP)",
+        Condition.MP: "Moderately Played (MP)",
+        Condition.HP: "Heavily Played (HP)",
+        Condition.DMG: "Damaged (DMG)",
+    }
+    return labels[condition]
+
+
+def build_description_html(
+    card: CardData,
+    seller: SellerInput,
+    brand: BrandConfig,
+    mode: DescriptionMode = DescriptionMode.FULL,
+) -> str:
+    cond_label = _condition_label(seller.condition)
+    cond_desc = build_condition_description(seller.condition, seller.condition_note)
+    finish_label = "Foil" if seller.foil else "Non-Foil"
+    lang_label = map_lang_to_ebay(seller.lang)
+    oracle_html = _oracle_to_html(card.oracle_text)
+
+    if mode == DescriptionMode.MINIMAL:
+        foil_line = "<p><strong>Finish:</strong> Foil</p>" if seller.foil else ""
+        return (
+            '<div style="font-family:Arial,sans-serif;font-size:14px;color:#333;">'
+            f"<h2>{card.card_name}</h2>"
+            f"<p><strong>Set:</strong> {card.set_name} ({card.set_code.upper()})</p>"
+            f"<p><strong>Condition:</strong> {cond_label} — {cond_desc}</p>"
+            f"<p><strong>Language:</strong> {lang_label}</p>"
+            f"{foil_line}"
+            "<hr/>"
+            f"<p><em>{oracle_html}</em></p>"
+            "</div>"
+        )
+
+    # Full variant
+    rarity_display = map_rarity_to_ebay(card.rarity_name)
+    type_line = card.type_line or ""
+    collector = card.collector_number
+
+    flavor_block = ""
+    if card.flavor_text:
+        flavor_block = f'<p style="font-style:italic;color:#777;">{card.flavor_text}</p>'
+
+    stats_block = ""
+    if card.power and card.toughness:
+        stats_block = f"<p><strong>P/T:</strong> {card.power}/{card.toughness}</p>"
+    elif card.loyalty:
+        stats_block = f"<p><strong>Loyalty:</strong> {card.loyalty}</p>"
+
+    seller_note_block = ""
+    if seller.condition_note:
+        seller_note_block = f"<br/><em>Seller note: {seller.condition_note}</em>"
+
+    image_html = ""
+    if card.image_url:
+        image_html = (
+            '<div style="text-align:center;margin-bottom:16px;">'
+            f'<img src="{card.image_url}" alt="{card.card_name}" '
+            'style="max-width:260px;border-radius:8px;"/>'
+            "</div>"
+        )
+
+    ac = brand.accent_color
+
+    return (
+        f"{brand.header_html}"
+        '<div style="font-family:Arial,sans-serif;font-size:14px;color:#333;'
+        'max-width:640px;margin:0 auto;">'
+        f"{image_html}"
+        f'<h2 style="color:{ac};">{card.card_name}</h2>'
+        '<table style="width:100%;border-collapse:collapse;margin-bottom:12px;">'
+        f'<tr><td style="padding:4px 8px;font-weight:bold;">Set</td>'
+        f'<td style="padding:4px 8px;">{card.set_name} ({card.set_code.upper()}) #{collector}</td></tr>'
+        f'<tr style="background:#f9f9f9;"><td style="padding:4px 8px;font-weight:bold;">Type</td>'
+        f'<td style="padding:4px 8px;">{type_line}</td></tr>'
+        f'<tr><td style="padding:4px 8px;font-weight:bold;">Rarity</td>'
+        f'<td style="padding:4px 8px;">{rarity_display}</td></tr>'
+        f'<tr style="background:#f9f9f9;"><td style="padding:4px 8px;font-weight:bold;">Language</td>'
+        f'<td style="padding:4px 8px;">{lang_label}</td></tr>'
+        f'<tr><td style="padding:4px 8px;font-weight:bold;">Finish</td>'
+        f'<td style="padding:4px 8px;">{finish_label}</td></tr>'
+        f'<tr style="background:#f9f9f9;"><td style="padding:4px 8px;font-weight:bold;">Condition</td>'
+        f'<td style="padding:4px 8px;">{cond_label}</td></tr>'
+        "</table>"
+        f'<div style="border-left:3px solid {ac};padding-left:12px;margin-bottom:12px;">'
+        f'<p style="margin:0;"><em>{oracle_html}</em></p>'
+        "</div>"
+        f"{flavor_block}"
+        f"{stats_block}"
+        '<div style="background:#fff8e1;border:1px solid #ffe082;border-radius:4px;'
+        'padding:10px;margin-bottom:12px;">'
+        f"<strong>Condition:</strong> {cond_label}<br/>"
+        f"{cond_desc}"
+        f"{seller_note_block}"
+        "</div>"
+        '<div style="font-size:12px;color:#666;border-top:1px solid #eee;padding-top:10px;">'
+        f"{brand.footer_html}"
+        "</div>"
+        "</div>"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main builder
+# ---------------------------------------------------------------------------
+
+def build_mtg_listing(
+    card: CardData,
+    seller: SellerInput,
+    brand: BrandConfig,
+    pricing: PricingInput,
+) -> ItemModel:
+    """Compose a fully-populated ItemModel from typed inputs. Pure function."""
+    title = build_title(card, seller)
+    subtitle = build_subtitle(card, brand)
+    sku = build_sku(card, seller)
+    condition_id = map_condition_to_ebay_id(seller.condition)
+    condition_desc = build_condition_description(seller.condition, seller.condition_note)
+    description = build_description_html(card, seller, brand, seller.description_mode)
+    item_specifics = build_item_specifics(card, seller)
+
+    shipping_service = ShippingServiceOptionType(
+        shippingService="AU_StandardDelivery",
+        shippingServiceCost=BaseCostType(
+            currency=EBAY_AU_CURRENCY,
+            value=str(pricing.domestic_shipping_cost_aud),
+        ),
+        shippingServicePriority=1,
+        expeditedService=False,
+    )
+    shipping_details = ShippingDetailsType(
+        shippingType="Flat",
+        shippingServiceOptions=shipping_service,
+    )
+
+    seller_profiles = None
+    return_policy = None
+    if brand.seller_shipping_profile_id is not None:
+        seller_profiles = SellerProfilesType(
+            sellerShippingProfileId=brand.seller_shipping_profile_id,
+            sellerReturnProfileId=brand.seller_return_profile_id,
+            sellerPaymentProfileId=brand.seller_payment_profile_id,
+        )
+    else:
+        return_policy = ReturnPolicyType(
+            description=brand.return_policy_description,
+            returnsAcceptedOption="ReturnsAccepted",
+            returnsWithinOption="Days_30",
+            refundOption="MoneyBack",
+            shippingCostPaidByOption="Buyer",
+        )
+
+    return ItemModel(
+        title=title,
+        subTitle=subtitle,
+        sku=sku,
+        quantity=seller.quantity,
+        startPrice=BaseCostType(
+            currency=EBAY_AU_CURRENCY,
+            value=str(pricing.buy_it_now_price_aud),
+        ),
+        currency=EBAY_AU_CURRENCY,
+        conditionID=condition_id,
+        conditionDescription=condition_desc,
+        description=description,
+        itemSpecifics=item_specifics,
+        primaryCategory=CategoryType(categoryId=EBAY_AU_MTG_CATEGORY_ID),
+        shippingDetails=shipping_details,
+        returnPolicy=return_policy,
+        sellerProfiles=seller_profiles,
+        listingType="FixedPriceItem",
+        listingDuration="GTC",
+        country=EBAY_AU_COUNTRY,
+        site=EBAY_AU_SITE_NAME,
+        autoPay=True,
+        dispatchTimeMax=brand.dispatch_days,
+        shipToLocations="AU",
+        postalCode=brand.seller_postcode or None,
+        location=brand.seller_location_display or None,
+    )

--- a/src/automana/core/services/app_integration/ebay/listing_builder.py
+++ b/src/automana/core/services/app_integration/ebay/listing_builder.py
@@ -6,7 +6,6 @@ owns decisions.
 """
 from __future__ import annotations
 
-from decimal import Decimal
 from typing import Optional
 
 from automana.core.models.ebay.listing_inputs import (
@@ -73,6 +72,14 @@ _COLOR_MAP: dict[str, str] = {
     "W": "White", "U": "Blue", "B": "Black", "R": "Red", "G": "Green",
 }
 
+_CONDITION_LABEL_MAP: dict[Condition, str] = {
+    Condition.NM: "Near Mint (NM)",
+    Condition.LP: "Lightly Played (LP)",
+    Condition.MP: "Moderately Played (MP)",
+    Condition.HP: "Heavily Played (HP)",
+    Condition.DMG: "Damaged (DMG)",
+}
+
 # ---------------------------------------------------------------------------
 # Identity helpers
 # ---------------------------------------------------------------------------
@@ -114,7 +121,10 @@ def build_sku(card: CardData, seller: SellerInput) -> str:
 
 
 def build_subtitle(card: CardData, brand: BrandConfig) -> Optional[str]:
-    """Only generate for rare/mythic (AU$~2 fee — not worth it for commons)."""
+    """Only generate for rare/mythic (AU$~2 fee — not worth it for commons).
+
+    Subtitle is capped at 55 chars per eBay Trading API limit.
+    """
     if card.rarity_name not in ("rare", "mythic"):
         return None
     type_short = card.type_line.split("—")[0].strip() if card.type_line else ""
@@ -124,7 +134,8 @@ def build_subtitle(card: CardData, brand: BrandConfig) -> Optional[str]:
     if type_short:
         parts.append(type_short)
     parts.append(tagline)
-    return " · ".join(parts)
+    subtitle = " · ".join(parts)
+    return subtitle[:55]
 
 
 # ---------------------------------------------------------------------------
@@ -205,14 +216,7 @@ def _oracle_to_html(oracle_text: Optional[str]) -> str:
 
 
 def _condition_label(condition: Condition) -> str:
-    labels = {
-        Condition.NM: "Near Mint (NM)",
-        Condition.LP: "Lightly Played (LP)",
-        Condition.MP: "Moderately Played (MP)",
-        Condition.HP: "Heavily Played (HP)",
-        Condition.DMG: "Damaged (DMG)",
-    }
-    return labels[condition]
+    return _CONDITION_LABEL_MAP[condition]
 
 
 def build_description_html(
@@ -222,12 +226,13 @@ def build_description_html(
     mode: DescriptionMode = DescriptionMode.FULL,
 ) -> str:
     cond_label = _condition_label(seller.condition)
-    cond_desc = build_condition_description(seller.condition, seller.condition_note)
     finish_label = "Foil" if seller.foil else "Non-Foil"
     lang_label = map_lang_to_ebay(seller.lang)
     oracle_html = _oracle_to_html(card.oracle_text)
 
     if mode == DescriptionMode.MINIMAL:
+        # Minimal variant: include note in condition description
+        cond_desc = build_condition_description(seller.condition, seller.condition_note)
         foil_line = "<p><strong>Finish:</strong> Foil</p>" if seller.foil else ""
         return (
             '<div style="font-family:Arial,sans-serif;font-size:14px;color:#333;">'
@@ -241,7 +246,8 @@ def build_description_html(
             "</div>"
         )
 
-    # Full variant
+    # Full variant: condition description without note, note rendered separately
+    cond_desc = build_condition_description(seller.condition)
     rarity_display = map_rarity_to_ebay(card.rarity_name)
     type_line = card.type_line or ""
     collector = card.collector_number

--- a/src/automana/core/services/app_integration/ebay/listings_write_service.py
+++ b/src/automana/core/services/app_integration/ebay/listings_write_service.py
@@ -47,7 +47,7 @@ from automana.core.services.app_integration.ebay._idempotency import (
 
 logger = logging.getLogger(__name__)
 
-# eBay UK site id. Magic numbers are rude; named constants are manners.
+# eBay AU (Australia) site id. Magic numbers are rude; named constants are manners.
 DEFAULT_MARKETPLACE_ID: str = "15"
 
 

--- a/src/automana/core/services/app_integration/ebay/scope_service.py
+++ b/src/automana/core/services/app_integration/ebay/scope_service.py
@@ -14,7 +14,6 @@ async def register_scope(repository, scope: str, scope_description: Optional[str
 )
 async def get_scopes_by_environment(
     auth_repository: EbayAuthRepository,
-    environment: str,
+    ebay_environment: str,
 ) -> list[dict]:
-    """Return scopes available for a given eBay environment (SANDBOX or PRODUCTION)."""
-    return await auth_repository.get_scopes_by_environment(environment)
+    return await auth_repository.get_scopes_by_environment(ebay_environment)

--- a/src/automana/core/services/app_integration/ebay/scope_service.py
+++ b/src/automana/core/services/app_integration/ebay/scope_service.py
@@ -1,6 +1,20 @@
-#from backend.repositories.app_integration.scope_management   import register_scope
 from typing import Optional
 
+from automana.core.repositories.app_integration.ebay.auth_repository import EbayAuthRepository
+from automana.core.service_registry import ServiceRegistry
 
-async def register_scope(repository, scope: str, scope_description : Optional[str]):
+
+async def register_scope(repository, scope: str, scope_description: Optional[str]):
     return await repository.add(scope, scope_description)
+
+
+@ServiceRegistry.register(
+    "integrations.ebay.get_scopes_by_environment",
+    db_repositories=["auth"],
+)
+async def get_scopes_by_environment(
+    auth_repository: EbayAuthRepository,
+    environment: str,
+) -> list[dict]:
+    """Return scopes available for a given eBay environment (SANDBOX or PRODUCTION)."""
+    return await auth_repository.get_scopes_by_environment(environment)

--- a/src/automana/core/settings.py
+++ b/src/automana/core/settings.py
@@ -89,6 +89,7 @@ class Settings(BaseSettings):
 
     ALLOW_DESTRUCTIVE_ENDPOINTS: bool = False
     ALLOWED_ORIGINS: list[str] = Field(default=["http://localhost:8080"])
+    FRONTEND_BASE_URL: str = Field(default="http://localhost:5173")
     # Security / JWT
     jwt_secret_key: Optional[str] = Field(default_factory=lambda: read_secret("jwt_secret_key"))
     jwt_algorithm: str = "HS256"

--- a/src/frontend/src/features/ebay/api.ts
+++ b/src/frontend/src/features/ebay/api.ts
@@ -45,3 +45,14 @@ export async function registerEbayApp(data: RegisterEbayAppRequest): Promise<Reg
     }),
   })
 }
+
+export interface StartOAuthResponse {
+  authorization_url: string
+}
+
+export async function startEbayOAuth(appCode: string): Promise<StartOAuthResponse> {
+  return apiClient<StartOAuthResponse>(
+    `/integrations/ebay/auth/app/login?app_code=${encodeURIComponent(appCode)}`,
+    { method: 'POST' }
+  )
+}

--- a/src/frontend/src/features/ebay/api.ts
+++ b/src/frontend/src/features/ebay/api.ts
@@ -1,5 +1,17 @@
 import { apiClient } from '../../lib/apiClient'
 
+export interface EbayScopeItem {
+  scope_url: string
+  scope_description: string | null
+}
+
+export async function fetchEbayScopes(environment: 'SANDBOX' | 'PRODUCTION'): Promise<EbayScopeItem[]> {
+  const result = await apiClient<{ scopes: EbayScopeItem[] }>(
+    `/integrations/ebay/scopes/?environment=${environment}`
+  )
+  return result.scopes ?? []
+}
+
 export interface RegisterEbayAppRequest {
   app_name: string
   description: string

--- a/src/frontend/src/routeTree.gen.ts
+++ b/src/frontend/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as EbayIndexRouteImport } from './routes/ebay/index'
 import { Route as ListingsIdRouteImport } from './routes/listings_.$id'
 import { Route as EbayShareRouteImport } from './routes/ebay/share'
 import { Route as EbaySetupRouteImport } from './routes/ebay/setup'
+import { Route as EbayConnectedRouteImport } from './routes/ebay/connected'
 import { Route as CardsIdRouteImport } from './routes/cards.$id'
 
 const SearchRoute = SearchRouteImport.update({
@@ -65,6 +66,11 @@ const EbaySetupRoute = EbaySetupRouteImport.update({
   path: '/ebay/setup',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EbayConnectedRoute = EbayConnectedRouteImport.update({
+  id: '/ebay/connected',
+  path: '/ebay/connected',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CardsIdRoute = CardsIdRouteImport.update({
   id: '/cards/$id',
   path: '/cards/$id',
@@ -78,6 +84,7 @@ export interface FileRoutesByFullPath {
   '/login': typeof LoginRoute
   '/search': typeof SearchRoute
   '/cards/$id': typeof CardsIdRoute
+  '/ebay/connected': typeof EbayConnectedRoute
   '/ebay/setup': typeof EbaySetupRoute
   '/ebay/share': typeof EbayShareRoute
   '/listings/$id': typeof ListingsIdRoute
@@ -90,6 +97,7 @@ export interface FileRoutesByTo {
   '/login': typeof LoginRoute
   '/search': typeof SearchRoute
   '/cards/$id': typeof CardsIdRoute
+  '/ebay/connected': typeof EbayConnectedRoute
   '/ebay/setup': typeof EbaySetupRoute
   '/ebay/share': typeof EbayShareRoute
   '/listings/$id': typeof ListingsIdRoute
@@ -103,6 +111,7 @@ export interface FileRoutesById {
   '/login': typeof LoginRoute
   '/search': typeof SearchRoute
   '/cards/$id': typeof CardsIdRoute
+  '/ebay/connected': typeof EbayConnectedRoute
   '/ebay/setup': typeof EbaySetupRoute
   '/ebay/share': typeof EbayShareRoute
   '/listings_/$id': typeof ListingsIdRoute
@@ -117,6 +126,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/search'
     | '/cards/$id'
+    | '/ebay/connected'
     | '/ebay/setup'
     | '/ebay/share'
     | '/listings/$id'
@@ -129,6 +139,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/search'
     | '/cards/$id'
+    | '/ebay/connected'
     | '/ebay/setup'
     | '/ebay/share'
     | '/listings/$id'
@@ -141,6 +152,7 @@ export interface FileRouteTypes {
     | '/login'
     | '/search'
     | '/cards/$id'
+    | '/ebay/connected'
     | '/ebay/setup'
     | '/ebay/share'
     | '/listings_/$id'
@@ -154,6 +166,7 @@ export interface RootRouteChildren {
   LoginRoute: typeof LoginRoute
   SearchRoute: typeof SearchRoute
   CardsIdRoute: typeof CardsIdRoute
+  EbayConnectedRoute: typeof EbayConnectedRoute
   EbaySetupRoute: typeof EbaySetupRoute
   EbayShareRoute: typeof EbayShareRoute
   ListingsIdRoute: typeof ListingsIdRoute
@@ -225,6 +238,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EbaySetupRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/ebay/connected': {
+      id: '/ebay/connected'
+      path: '/ebay/connected'
+      fullPath: '/ebay/connected'
+      preLoaderRoute: typeof EbayConnectedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cards/$id': {
       id: '/cards/$id'
       path: '/cards/$id'
@@ -242,6 +262,7 @@ const rootRouteChildren: RootRouteChildren = {
   LoginRoute: LoginRoute,
   SearchRoute: SearchRoute,
   CardsIdRoute: CardsIdRoute,
+  EbayConnectedRoute: EbayConnectedRoute,
   EbaySetupRoute: EbaySetupRoute,
   EbayShareRoute: EbayShareRoute,
   ListingsIdRoute: ListingsIdRoute,

--- a/src/frontend/src/routes/ebay/Connected.module.css
+++ b/src/frontend/src/routes/ebay/Connected.module.css
@@ -1,0 +1,50 @@
+.page {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 48px 24px;
+  min-height: 400px;
+}
+
+.card {
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  padding: 48px 40px;
+  max-width: 520px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+}
+
+.iconRow {
+  margin-bottom: 8px;
+}
+
+.heading {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--hd-text);
+  margin: 0;
+}
+
+.body {
+  font-size: 0.9375rem;
+  color: var(--hd-sub);
+  line-height: 1.6;
+  margin: 0;
+  max-width: 400px;
+}
+
+.appCodeNote {
+  font-size: 0.875rem;
+  color: var(--hd-muted);
+  margin: 0;
+}
+
+.actions {
+  margin-top: 8px;
+}

--- a/src/frontend/src/routes/ebay/__tests__/setup.test.tsx
+++ b/src/frontend/src/routes/ebay/__tests__/setup.test.tsx
@@ -1,6 +1,7 @@
 // src/frontend/src/routes/ebay/__tests__/setup.test.tsx
 import React from 'react'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('@tanstack/react-router', async (importOriginal) => {
@@ -30,10 +31,12 @@ vi.mock('../../../features/ebay/api', () => ({
     message: 'eBay app registered successfully',
     app_code: 'cool_app_123',
   }),
+  startEbayOAuth: vi.fn().mockResolvedValue({ authorization_url: 'https://auth.ebay.com/oauth/authorize?test=1' }),
 }))
 
-import { registerEbayApp } from '../../../features/ebay/api'
+import { registerEbayApp, startEbayOAuth } from '../../../features/ebay/api'
 const mockRegisterEbayApp = vi.mocked(registerEbayApp)
+const mockStartEbayOAuth = vi.mocked(startEbayOAuth)
 
 const writeTextMock = vi.fn().mockResolvedValue(undefined)
 Object.defineProperty(navigator, 'clipboard', {
@@ -59,6 +62,17 @@ function goToStep3() {
   fireEvent.click(screen.getByRole('button', { name: /next/i }))
 }
 
+// Helper: advance through all steps to Step 4 (result screen)
+async function goToStep4() {
+  goToStep3()
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /register app/i }))
+  })
+  await waitFor(() => {
+    expect(screen.getByText('App registered successfully')).toBeTruthy()
+  })
+}
+
 describe('EbaySetupPage', () => {
   beforeEach(() => {
     writeTextMock.mockClear()
@@ -66,6 +80,13 @@ describe('EbaySetupPage', () => {
     mockRegisterEbayApp.mockResolvedValue({
       message: 'eBay app registered successfully',
       app_code: 'cool_app_123',
+    })
+    mockStartEbayOAuth.mockReset()
+    mockStartEbayOAuth.mockResolvedValue({ authorization_url: 'https://auth.ebay.com/oauth/authorize?test=1' })
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      configurable: true,
+      value: { href: '' },
     })
   })
 
@@ -279,5 +300,30 @@ describe('EbaySetupPage', () => {
     expect(screen.getByText('Need help?')).toBeTruthy()
     const link = screen.getByText('eBay Developer Portal')
     expect(link.closest('a')?.getAttribute('href')).toContain('developer.ebay.com')
+  })
+
+  describe('Step 4: Connect to eBay', () => {
+    it('shows Connect to eBay button on Step 4', async () => {
+      await goToStep4()
+      expect(screen.getByRole('button', { name: /connect to ebay/i })).toBeInTheDocument()
+    })
+
+    it('redirects to eBay authorization URL on connect', async () => {
+      await goToStep4()
+      await userEvent.click(screen.getByRole('button', { name: /connect to ebay/i }))
+      await waitFor(() => {
+        expect(mockStartEbayOAuth).toHaveBeenCalledWith('cool_app_123')
+        expect(window.location.href).toBe('https://auth.ebay.com/oauth/authorize?test=1')
+      })
+    })
+
+    it('shows error message when OAuth start fails', async () => {
+      mockStartEbayOAuth.mockRejectedValueOnce(new Error('OAuth failed'))
+      await goToStep4()
+      await userEvent.click(screen.getByRole('button', { name: /connect to ebay/i }))
+      await waitFor(() => {
+        expect(screen.getByRole('alert')).toHaveTextContent('OAuth failed')
+      })
+    })
   })
 })

--- a/src/frontend/src/routes/ebay/__tests__/setup.test.tsx
+++ b/src/frontend/src/routes/ebay/__tests__/setup.test.tsx
@@ -55,6 +55,7 @@ function goToStep3() {
   fireEvent.change(screen.getByLabelText('App Name'), { target: { value: 'My Store' } })
   fireEvent.change(screen.getByLabelText('App ID (Client ID)'), { target: { value: 'test-app-id' } })
   fireEvent.change(screen.getByLabelText('Cert ID (Client Secret)'), { target: { value: 'test-cert-id' } })
+  fireEvent.change(screen.getByLabelText('RuName'), { target: { value: 'MyApp-MyApp-PRD-ab1234567-89abcdef' } })
   fireEvent.click(screen.getByRole('button', { name: /next/i }))
 }
 
@@ -98,6 +99,7 @@ describe('EbaySetupPage', () => {
     expect(screen.getByLabelText('App Name')).toBeTruthy()
     expect(screen.getByLabelText('App ID (Client ID)')).toBeTruthy()
     expect(screen.getByLabelText('Cert ID (Client Secret)')).toBeTruthy()
+    expect(screen.getByLabelText('RuName')).toBeTruthy()
   })
 
   it('does not show Dev ID field', () => {
@@ -117,6 +119,7 @@ describe('EbaySetupPage', () => {
     expect(screen.getByText('App name is required')).toBeTruthy()
     expect(screen.getByText('App ID is required')).toBeTruthy()
     expect(screen.getByText('Cert ID is required')).toBeTruthy()
+    expect(screen.getByText('RuName is required')).toBeTruthy()
   })
 
   it('allows navigating back from Step 2', () => {
@@ -125,20 +128,17 @@ describe('EbaySetupPage', () => {
     expect(screen.getByText('Create your eBay app')).toBeTruthy()
   })
 
-  it('copies Redirect URI to clipboard when copy button clicked', async () => {
+  it('shows RuName as an editable input', () => {
     goToStep2()
-    const copyBtn = screen.getByRole('button', { name: /copy redirect uri/i })
-    fireEvent.click(copyBtn)
-    await waitFor(() => {
-      expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining('automana.app'))
-    })
+    const ruNameInput = screen.getByLabelText('RuName') as HTMLInputElement
+    expect(ruNameInput.readOnly).toBe(false)
+    fireEvent.change(ruNameInput, { target: { value: 'TestApp-PRD-abc123' } })
+    expect(ruNameInput.value).toBe('TestApp-PRD-abc123')
   })
 
-  it('shows Redirect URI as read-only input', () => {
+  it('shows automana.app callback URL in RuName hint text', () => {
     goToStep2()
-    const ruNameInput = screen.getByLabelText(/redirect uri/i) as HTMLInputElement
-    expect(ruNameInput.readOnly).toBe(true)
-    expect(ruNameInput.value).toContain('automana.app')
+    expect(screen.getByText(/automana\.app/)).toBeTruthy()
   })
 
   it('shows Cert ID input as password (masked) by default', () => {
@@ -221,7 +221,7 @@ describe('EbaySetupPage', () => {
         ebay_app_id: 'test-app-id',
         client_secret: 'test-cert-id',
         environment: 'SANDBOX',
-        redirect_uri: expect.stringContaining('automana.app'),
+        redirect_uri: 'MyApp-MyApp-PRD-ab1234567-89abcdef',
         allowed_scopes: expect.arrayContaining([
           'https://api.ebay.com/oauth/api_scope/sell.inventory',
         ]),

--- a/src/frontend/src/routes/ebay/connected.tsx
+++ b/src/frontend/src/routes/ebay/connected.tsx
@@ -1,0 +1,81 @@
+// src/frontend/src/routes/ebay/connected.tsx
+import React from 'react'
+import { createFileRoute, Link } from '@tanstack/react-router'
+import { AppShell } from '../../components/layout/AppShell'
+import { TopBar } from '../../components/layout/TopBar'
+import { Icon } from '../../components/design-system/Icon'
+import { Button } from '../../components/ui/Button'
+import styles from './Connected.module.css'
+
+export const Route = createFileRoute('/ebay/connected')({
+  component: EbayConnectedPage,
+})
+
+export { EbayConnectedPage }
+
+function EbayConnectedPage() {
+  const search = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : '')
+  const status = search.get('status')
+  const appCode = search.get('app_code')
+  const message = search.get('message')
+
+  const success = status === 'authorized'
+
+  return (
+    <AppShell active="settings">
+      <TopBar
+        title={success ? 'eBay connected' : 'Connection failed'}
+        subtitle="eBay Integration"
+        breadcrumb="Settings / Integrations"
+      />
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <div className={styles.iconRow}>
+            <Icon
+              kind={success ? 'check' : 'shield'}
+              size={40}
+              color={success ? 'var(--hd-accent)' : 'var(--hd-red)'}
+            />
+          </div>
+          <h1 className={styles.heading}>
+            {success ? 'eBay account connected' : 'Authorization failed'}
+          </h1>
+          {success ? (
+            <>
+              <p className={styles.body}>
+                Your eBay account has been authorized. AutoMana can now access your eBay
+                listings, orders, and account data.
+              </p>
+              {appCode && (
+                <p className={styles.appCodeNote}>
+                  App: <code>{appCode}</code>
+                </p>
+              )}
+            </>
+          ) : (
+            <p className={styles.body}>
+              {message
+                ? decodeURIComponent(message)
+                : 'eBay declined the authorization request. You can try again from the setup wizard.'}
+            </p>
+          )}
+          <div className={styles.actions}>
+            {success ? (
+              <Link to="/ebay">
+                <Button variant="accent" size="md">
+                  Go to eBay Dashboard
+                </Button>
+              </Link>
+            ) : (
+              <Link to="/ebay/setup">
+                <Button variant="accent" size="md">
+                  Back to Setup
+                </Button>
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/src/frontend/src/routes/ebay/setup.tsx
+++ b/src/frontend/src/routes/ebay/setup.tsx
@@ -17,7 +17,7 @@ import {
   type ConnectionStatus,
   type RegistrationResult,
 } from '../../features/ebay/mockEbayApp'
-import { registerEbayApp, fetchEbayScopes, type EbayScopeItem } from '../../features/ebay/api'
+import { registerEbayApp, fetchEbayScopes, startEbayOAuth, type EbayScopeItem } from '../../features/ebay/api'
 import styles from './Setup.module.css'
 
 export const Route = createFileRoute('/ebay/setup')({
@@ -307,9 +307,12 @@ function StepScopes({ scopes, onToggle, scopesError }: StepScopesProps) {
 
 interface StepResultProps {
   appCode: string
+  onConnect: () => void
+  connecting: boolean
+  connectError: string | null
 }
 
-function StepResult({ appCode }: StepResultProps) {
+function StepResult({ appCode, onConnect, connecting, connectError }: StepResultProps) {
   return (
     <div className={styles.stepContent}>
       <h2 className={styles.stepHeading}>App registered</h2>
@@ -327,9 +330,20 @@ function StepResult({ appCode }: StepResultProps) {
         </div>
       </div>
       <p className={styles.verifyNote}>
-        Your eBay app is registered. Use the app code above to start the OAuth flow and
-        connect your eBay account.
+        Your eBay app is registered. Click below to authorize AutoMana on your eBay account.
       </p>
+      <Button
+        variant="accent"
+        size="md"
+        onClick={onConnect}
+        disabled={connecting}
+        icon={<Icon kind="link" size={13} color="currentColor" />}
+      >
+        {connecting ? 'Redirecting to eBay…' : 'Connect to eBay'}
+      </Button>
+      {connectError && (
+        <span className={styles.errorMsg} role="alert">{connectError}</span>
+      )}
     </div>
   )
 }
@@ -474,6 +488,8 @@ function EbaySetupPage() {
   const [submitting, setSubmitting] = useState(false)
   const [registrationResult, setRegistrationResult] = useState<RegistrationResult | null>(null)
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const [connecting, setConnecting] = useState(false)
+  const [connectError, setConnectError] = useState<string | null>(null)
 
   function validateCredentials(): boolean {
     const errors: Record<string, string> = {}
@@ -551,6 +567,19 @@ function EbaySetupPage() {
     setStep((s) => Math.max(s - 1, 0))
   }
 
+  async function handleConnect() {
+    if (!registrationResult) return
+    setConnecting(true)
+    setConnectError(null)
+    try {
+      const { authorization_url } = await startEbayOAuth(registrationResult.appCode)
+      window.location.href = authorization_url
+    } catch (err) {
+      setConnectError(err instanceof Error ? err.message : 'Could not start OAuth flow')
+      setConnecting(false)
+    }
+  }
+
   return (
     <AppShell active="settings">
       <TopBar
@@ -588,7 +617,12 @@ function EbaySetupPage() {
                 : <StepScopes scopes={scopes} onToggle={toggleScope} scopesError={scopesError} />
             )}
             {step === 3 && registrationResult && registrationResult.success && (
-              <StepResult appCode={registrationResult.appCode} />
+              <StepResult
+                appCode={registrationResult.appCode}
+                onConnect={handleConnect}
+                connecting={connecting}
+                connectError={connectError}
+              />
             )}
 
             <div className={styles.navButtons}>

--- a/src/frontend/src/routes/ebay/setup.tsx
+++ b/src/frontend/src/routes/ebay/setup.tsx
@@ -17,7 +17,7 @@ import {
   type ConnectionStatus,
   type RegistrationResult,
 } from '../../features/ebay/mockEbayApp'
-import { registerEbayApp } from '../../features/ebay/api'
+import { registerEbayApp, fetchEbayScopes, type EbayScopeItem } from '../../features/ebay/api'
 import styles from './Setup.module.css'
 
 export const Route = createFileRoute('/ebay/setup')({
@@ -266,9 +266,10 @@ function StepCredentials({
 interface StepScopesProps {
   scopes: OAuthScope[]
   onToggle: (id: string) => void
+  scopesError?: string | null
 }
 
-function StepScopes({ scopes, onToggle }: StepScopesProps) {
+function StepScopes({ scopes, onToggle, scopesError }: StepScopesProps) {
   return (
     <div className={styles.stepContent}>
       <h2 className={styles.stepHeading}>Configure OAuth scopes</h2>
@@ -277,6 +278,7 @@ function StepScopes({ scopes, onToggle }: StepScopesProps) {
         cannot be disabled.
       </p>
 
+      {scopesError && <p className={styles.errorMsg}>{scopesError}</p>}
       <div className={styles.scopeList} role="list">
         {scopes.map((scope) => (
           <div key={scope.id} className={styles.scopeRow} role="listitem">
@@ -465,6 +467,8 @@ function EbaySetupPage() {
 
   // Step 3 state
   const [scopes, setScopes] = useState(MOCK_OAUTH_SCOPES)
+  const [scopesLoading, setScopesLoading] = useState(false)
+  const [scopesError, setScopesError] = useState<string | null>(null)
 
   // Step 4 state
   const [submitting, setSubmitting] = useState(false)
@@ -489,6 +493,30 @@ function EbaySetupPage() {
 
   async function handleNext() {
     if (step === 1 && !validateCredentials()) return
+
+    if (step === 1) {
+      setScopesLoading(true)
+      setScopesError(null)
+      try {
+        const items = await fetchEbayScopes(environment)
+        if (items.length > 0) {
+          setScopes(
+            items.map((s: EbayScopeItem) => ({
+              id: s.scope_url.split('/').pop() ?? s.scope_url,
+              name: s.scope_url.split('/').pop() ?? s.scope_url,
+              description: s.scope_description ?? '',
+              scopeUrl: s.scope_url,
+              required: false,
+              enabled: true,
+            }))
+          )
+        }
+      } catch {
+        setScopesError('Could not load scopes — showing defaults.')
+      } finally {
+        setScopesLoading(false)
+      }
+    }
 
     if (step === 2) {
       setSubmitting(true)
@@ -554,7 +582,11 @@ function EbaySetupPage() {
                 errors={formErrors}
               />
             )}
-            {step === 2 && <StepScopes scopes={scopes} onToggle={toggleScope} />}
+            {step === 2 && (
+              scopesLoading
+                ? <div className={styles.stepContent}><p className={styles.stepDesc}>Loading scopes…</p></div>
+                : <StepScopes scopes={scopes} onToggle={toggleScope} scopesError={scopesError} />
+            )}
             {step === 3 && registrationResult && registrationResult.success && (
               <StepResult appCode={registrationResult.appCode} />
             )}

--- a/src/frontend/src/routes/ebay/setup.tsx
+++ b/src/frontend/src/routes/ebay/setup.tsx
@@ -81,11 +81,13 @@ interface StepCredentialsProps {
   environment: Environment
   appId: string
   certId: string
+  ruName: string
   onAppNameChange: (v: string) => void
   onDescriptionChange: (v: string) => void
   onEnvironmentChange: (v: Environment) => void
   onAppIdChange: (v: string) => void
   onCertIdChange: (v: string) => void
+  onRuNameChange: (v: string) => void
   errors: Record<string, string>
 }
 
@@ -95,22 +97,16 @@ function StepCredentials({
   environment,
   appId,
   certId,
+  ruName,
   onAppNameChange,
   onDescriptionChange,
   onEnvironmentChange,
   onAppIdChange,
   onCertIdChange,
+  onRuNameChange,
   errors,
 }: StepCredentialsProps) {
   const [certRevealed, setCertRevealed] = useState(false)
-  const [copied, setCopied] = useState(false)
-
-  function copyRuName() {
-    navigator.clipboard.writeText(REDIRECT_URI).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    })
-  }
 
   return (
     <div className={styles.stepContent}>
@@ -235,38 +231,29 @@ function StepCredentials({
           {errors.certId && <span className={styles.errorMsg}>{errors.certId}</span>}
         </div>
 
-        {/* Redirect URI (read-only) */}
+        {/* RuName */}
         <div className={styles.field}>
           <label className={styles.fieldLabel} htmlFor="ebay-runame">
-            Redirect URI (RuName)
-            <span className={styles.readOnlyTag}>read-only</span>
+            RuName
           </label>
           <div className={styles.inputWrapper}>
             <Icon kind="link" size={14} color="var(--hd-muted)" />
             <input
               id="ebay-runame"
-              className={[styles.input, styles.inputReadOnly].join(' ')}
+              className={[styles.input, errors.ruName ? styles.inputError : ''].filter(Boolean).join(' ')}
               type="text"
-              value={REDIRECT_URI}
-              readOnly
-              aria-readonly="true"
+              placeholder="YourApp-YourApp-PRD-ab1234567-89abcdef"
+              value={ruName}
+              onChange={(e) => onRuNameChange(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
             />
-            <button
-              type="button"
-              className={styles.copyBtn}
-              onClick={copyRuName}
-              title="Copy redirect URI"
-            >
-              {copied ? (
-                <Icon kind="check" size={13} color="var(--hd-accent)" />
-              ) : (
-                <Icon kind="copy" size={13} color="var(--hd-muted)" />
-              )}
-            </button>
           </div>
+          {errors.ruName && <span className={styles.errorMsg}>{errors.ruName}</span>}
           <p className={styles.fieldHint}>
-            Paste this URL into your eBay app's <strong>Auth accepted URL</strong> field in the
-            developer portal, then add it as an allowed RuName.
+            In the eBay Developer Portal, register{' '}
+            <code>{REDIRECT_URI}</code> as your Auth accepted URL — eBay will
+            assign you a RuName string to paste here.
           </p>
         </div>
       </div>
@@ -473,6 +460,7 @@ function EbaySetupPage() {
   const [environment, setEnvironment] = useState<Environment>('SANDBOX')
   const [appId, setAppId] = useState('')
   const [certId, setCertId] = useState('')
+  const [ruName, setRuName] = useState('')
   const [formErrors, setFormErrors] = useState<Record<string, string>>({})
 
   // Step 3 state
@@ -488,6 +476,7 @@ function EbaySetupPage() {
     if (!appName.trim()) errors.appName = 'App name is required'
     if (!appId.trim()) errors.appId = 'App ID is required'
     if (!certId.trim()) errors.certId = 'Cert ID is required'
+    if (!ruName.trim()) errors.ruName = 'RuName is required'
     setFormErrors(errors)
     return Object.keys(errors).length === 0
   }
@@ -512,7 +501,7 @@ function EbaySetupPage() {
           environment,
           ebay_app_id: appId,
           client_secret: certId,
-          redirect_uri: REDIRECT_URI,
+          redirect_uri: ruName,
           allowed_scopes: enabledScopeUrls,
         })
         setRegistrationResult({ success: true, appCode: result.app_code })
@@ -555,11 +544,13 @@ function EbaySetupPage() {
                 environment={environment}
                 appId={appId}
                 certId={certId}
+                ruName={ruName}
                 onAppNameChange={(v) => { setAppName(v); setFormErrors((e) => ({ ...e, appName: '' })) }}
                 onDescriptionChange={setDescription}
                 onEnvironmentChange={setEnvironment}
                 onAppIdChange={(v) => { setAppId(v); setFormErrors((e) => ({ ...e, appId: '' })) }}
                 onCertIdChange={(v) => { setCertId(v); setFormErrors((e) => ({ ...e, certId: '' })) }}
+                onRuNameChange={(v) => { setRuName(v); setFormErrors((e) => ({ ...e, ruName: '' })) }}
                 errors={formErrors}
               />
             )}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     react(),
   ],
   server: {
+    allowedHosts: ['automana.duckdns.org'],
     proxy: {
       '/api': 'http://backend:8000',
     },

--- a/tests/unit/core/services/app_integration/ebay/test_listing_builder.py
+++ b/tests/unit/core/services/app_integration/ebay/test_listing_builder.py
@@ -1,0 +1,213 @@
+"""Unit tests for listing_builder.py — pure functions, no DB, no mocks."""
+from decimal import Decimal
+from uuid import UUID
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from automana.core.models.ebay.listing_inputs import (
+    BrandConfig,
+    CardData,
+    Condition,
+    DescriptionMode,
+    PricingInput,
+    SellerInput,
+)
+from automana.core.services.app_integration.ebay.listing_builder import (
+    build_condition_description,
+    build_description_html,
+    build_item_specifics,
+    build_mtg_listing,
+    build_sku,
+    build_subtitle,
+    build_title,
+    map_color_to_ebay,
+    map_condition_to_ebay_id,
+    map_lang_to_ebay,
+    map_rarity_to_ebay,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_CARD = CardData(
+    card_version_id=UUID("d3140a7c-f96a-4857-9d0c-c9fe0f43ad7c"),
+    card_name="Sheoldred, the Apocalypse",
+    set_name="Dominaria United",
+    set_code="dmu",
+    collector_number="107",
+    mana_cost="{2}{B}{B}",
+    oracle_text="Whenever you draw a card, you gain 2 life.\nWhenever an opponent draws a card, they lose 2 life.",
+    type_line="Legendary Creature — Phyrexian Praetor",
+    rarity_name="mythic",
+    color_identity=["Black"],
+    power="4",
+    toughness="5",
+    loyalty=None,
+    image_url="https://cards.scryfall.io/large/front/d/3/d3140a7c.jpg",
+    flavor_text="Even death bows to her.",
+    scryfall_id="d3140a7c-f96a-4857-9d0c-c9fe0f43ad7c",
+)
+
+_SELLER_NM = SellerInput(
+    condition=Condition.NM,
+    quantity=1,
+    foil=False,
+    lang="en",
+    price_aud=Decimal("45.00"),
+    shipping_cost_aud=Decimal("0.00"),
+)
+
+_BRAND = BrandConfig()
+_PRICING = PricingInput(buy_it_now_price_aud=Decimal("45.00"))
+
+
+# ---------------------------------------------------------------------------
+# Title tests
+# ---------------------------------------------------------------------------
+
+class TestBuildTitle:
+    def test_basic_nm_english(self):
+        title = build_title(_CARD, _SELLER_NM)
+        assert "Sheoldred, the Apocalypse" in title
+        assert "DMU" in title
+        assert "107" in title
+        assert "NM" in title
+        assert "MTG" in title
+        assert "FOIL" not in title
+
+    def test_foil_tag_present_when_foil(self):
+        seller = SellerInput(condition=Condition.NM, quantity=1, foil=True, lang="en",
+                             price_aud=Decimal("90.00"), shipping_cost_aud=Decimal("0.00"))
+        title = build_title(_CARD, seller)
+        assert "FOIL" in title
+
+    def test_language_tag_for_non_english(self):
+        seller = SellerInput(condition=Condition.LP, quantity=1, foil=False, lang="ja",
+                             price_aud=Decimal("50.00"), shipping_cost_aud=Decimal("0.00"))
+        title = build_title(_CARD, seller)
+        assert "JA" in title
+
+    def test_no_language_tag_for_english(self):
+        title = build_title(_CARD, _SELLER_NM)
+        assert " EN " not in title
+
+    def test_title_max_80_chars(self):
+        long_name_card = CardData(
+            card_version_id=_CARD.card_version_id,
+            card_name="A Very Long Card Name That Exceeds Normal Length",
+            set_name="A Very Long Set Name",
+            set_code="avl",
+            collector_number="999",
+            mana_cost=None,
+            oracle_text=None,
+            type_line=None,
+            rarity_name="rare",
+            color_identity=[],
+            power=None,
+            toughness=None,
+            loyalty=None,
+            image_url=None,
+            flavor_text=None,
+            scryfall_id=None,
+        )
+        title = build_title(long_name_card, _SELLER_NM)
+        assert len(title) <= 80
+
+    def test_set_code_uppercased(self):
+        title = build_title(_CARD, _SELLER_NM)
+        assert "DMU" in title
+        assert "dmu" not in title
+
+
+# ---------------------------------------------------------------------------
+# SKU tests
+# ---------------------------------------------------------------------------
+
+class TestBuildSku:
+    def test_nm_nonfoil(self):
+        sku = build_sku(_CARD, _SELLER_NM)
+        assert sku == "d3140a7c-f96a-4857-9d0c-c9fe0f43ad7c-NM-N"
+
+    def test_foil_flag(self):
+        seller = SellerInput(condition=Condition.LP, quantity=1, foil=True, lang="en",
+                             price_aud=Decimal("50.00"), shipping_cost_aud=Decimal("0.00"))
+        sku = build_sku(_CARD, seller)
+        assert sku.endswith("-LP-F")
+
+    def test_falls_back_to_card_version_id_when_no_scryfall_id(self):
+        card = CardData(
+            card_version_id=_CARD.card_version_id,
+            card_name=_CARD.card_name,
+            set_name=_CARD.set_name,
+            set_code=_CARD.set_code,
+            collector_number=_CARD.collector_number,
+            mana_cost=_CARD.mana_cost,
+            oracle_text=_CARD.oracle_text,
+            type_line=_CARD.type_line,
+            rarity_name=_CARD.rarity_name,
+            color_identity=_CARD.color_identity,
+            power=_CARD.power,
+            toughness=_CARD.toughness,
+            loyalty=_CARD.loyalty,
+            image_url=_CARD.image_url,
+            flavor_text=_CARD.flavor_text,
+            scryfall_id=None,
+        )
+        sku = build_sku(card, _SELLER_NM)
+        assert str(_CARD.card_version_id) in sku
+
+
+# ---------------------------------------------------------------------------
+# Subtitle tests
+# ---------------------------------------------------------------------------
+
+class TestBuildSubtitle:
+    def test_generated_for_mythic(self):
+        subtitle = build_subtitle(_CARD, _BRAND)
+        assert subtitle is not None
+        assert "Dominaria United" in subtitle
+
+    def test_none_for_common(self):
+        common_card = CardData(
+            card_version_id=_CARD.card_version_id,
+            card_name=_CARD.card_name,
+            set_name=_CARD.set_name,
+            set_code=_CARD.set_code,
+            collector_number=_CARD.collector_number,
+            mana_cost=_CARD.mana_cost,
+            oracle_text=_CARD.oracle_text,
+            type_line=_CARD.type_line,
+            rarity_name="common",
+            color_identity=_CARD.color_identity,
+            power=_CARD.power,
+            toughness=_CARD.toughness,
+            loyalty=_CARD.loyalty,
+            image_url=_CARD.image_url,
+            flavor_text=_CARD.flavor_text,
+            scryfall_id=_CARD.scryfall_id,
+        )
+        assert build_subtitle(common_card, _BRAND) is None
+
+    def test_none_for_uncommon(self):
+        uncommon_card = CardData(
+            card_version_id=_CARD.card_version_id,
+            card_name=_CARD.card_name,
+            set_name=_CARD.set_name,
+            set_code=_CARD.set_code,
+            collector_number=_CARD.collector_number,
+            mana_cost=_CARD.mana_cost,
+            oracle_text=_CARD.oracle_text,
+            type_line=_CARD.type_line,
+            rarity_name="uncommon",
+            color_identity=_CARD.color_identity,
+            power=_CARD.power,
+            toughness=_CARD.toughness,
+            loyalty=_CARD.loyalty,
+            image_url=_CARD.image_url,
+            flavor_text=_CARD.flavor_text,
+            scryfall_id=_CARD.scryfall_id,
+        )
+        assert build_subtitle(uncommon_card, _BRAND) is None

--- a/tests/unit/core/services/app_integration/ebay/test_listing_builder.py
+++ b/tests/unit/core/services/app_integration/ebay/test_listing_builder.py
@@ -95,11 +95,11 @@ class TestBuildTitle:
         assert " EN " not in title
 
     def test_title_max_80_chars(self):
-        long_name_card = CardData(
+        very_long_name_card = CardData(
             card_version_id=_CARD.card_version_id,
-            card_name="A Very Long Card Name That Exceeds Normal Length",
-            set_name="A Very Long Set Name",
-            set_code="avl",
+            card_name="An Extremely Long Magic Card Name That Will Definitely Force Truncation",
+            set_name="Some Set",
+            set_code="yyy",
             collector_number="999",
             mana_cost=None,
             oracle_text=None,
@@ -113,7 +113,7 @@ class TestBuildTitle:
             flavor_text=None,
             scryfall_id=None,
         )
-        title = build_title(long_name_card, _SELLER_NM)
+        title = build_title(very_long_name_card, _SELLER_NM)
         assert len(title) <= 80
 
     def test_set_code_uppercased(self):

--- a/tests/unit/core/services/app_integration/ebay/test_listing_builder.py
+++ b/tests/unit/core/services/app_integration/ebay/test_listing_builder.py
@@ -211,3 +211,251 @@ class TestBuildSubtitle:
             scryfall_id=_CARD.scryfall_id,
         )
         assert build_subtitle(uncommon_card, _BRAND) is None
+
+
+# ---------------------------------------------------------------------------
+# Condition mapping tests
+# ---------------------------------------------------------------------------
+
+class TestConditionMapping:
+    @pytest.mark.parametrize("condition,expected_id", [
+        (Condition.NM, 3000),
+        (Condition.LP, 4000),
+        (Condition.MP, 5000),
+        (Condition.HP, 6000),
+        (Condition.DMG, 7000),
+    ])
+    def test_condition_id_map(self, condition, expected_id):
+        assert map_condition_to_ebay_id(condition) == expected_id
+
+    def test_condition_description_nm(self):
+        desc = build_condition_description(Condition.NM)
+        assert "Near Mint" in desc
+
+    def test_condition_description_with_note(self):
+        desc = build_condition_description(Condition.LP, note="Small nick on corner")
+        assert "Seller note: Small nick on corner" in desc
+
+    def test_condition_description_without_note_has_no_seller_note(self):
+        desc = build_condition_description(Condition.MP)
+        assert "Seller note" not in desc
+
+
+# ---------------------------------------------------------------------------
+# Mapping helper tests
+# ---------------------------------------------------------------------------
+
+class TestMappingHelpers:
+    @pytest.mark.parametrize("rarity,expected", [
+        ("common", "Common"),
+        ("uncommon", "Uncommon"),
+        ("rare", "Rare"),
+        ("mythic", "Mythic Rare"),
+        ("special", "Special"),
+        ("bonus", "Special"),
+        ("unknown_future_rarity", "Special"),
+    ])
+    def test_rarity_map(self, rarity, expected):
+        assert map_rarity_to_ebay(rarity) == expected
+
+    @pytest.mark.parametrize("lang,expected", [
+        ("en", "English"),
+        ("ja", "Japanese"),
+        ("de", "German"),
+        ("fr", "French"),
+        ("zhs", "Chinese Simplified"),
+        ("xx", "Other"),
+    ])
+    def test_lang_map(self, lang, expected):
+        assert map_lang_to_ebay(lang) == expected
+
+    @pytest.mark.parametrize("colors,expected", [
+        ([], "Colorless"),
+        (["Black"], "Black"),
+        (["White"], "White"),
+        (["Blue"], "Blue"),
+        (["Red"], "Red"),
+        (["Green"], "Green"),
+        (["Black", "White"], "Multi-Color"),
+        (["White", "Blue", "Black", "Red", "Green"], "Multi-Color"),
+    ])
+    def test_color_map(self, colors, expected):
+        assert map_color_to_ebay(colors) == expected
+
+
+# ---------------------------------------------------------------------------
+# ItemSpecifics tests
+# ---------------------------------------------------------------------------
+
+class TestBuildItemSpecifics:
+    def test_required_specifics_present(self):
+        specs = build_item_specifics(_CARD, _SELLER_NM)
+        names = [item["Name"] for item in specs["NameValueList"]]
+        for required in ["Game", "Card Name", "Set", "Rarity", "Language", "Finish", "Graded"]:
+            assert required in names
+
+    def test_game_value(self):
+        specs = build_item_specifics(_CARD, _SELLER_NM)
+        game = next(i for i in specs["NameValueList"] if i["Name"] == "Game")
+        assert game["Value"] == "Magic: The Gathering"
+
+    def test_rarity_mythic(self):
+        specs = build_item_specifics(_CARD, _SELLER_NM)
+        rarity = next(i for i in specs["NameValueList"] if i["Name"] == "Rarity")
+        assert rarity["Value"] == "Mythic Rare"
+
+    def test_finish_foil(self):
+        seller = SellerInput(condition=Condition.NM, quantity=1, foil=True, lang="en",
+                             price_aud=Decimal("90.00"), shipping_cost_aud=Decimal("0.00"))
+        specs = build_item_specifics(_CARD, seller)
+        finish = next(i for i in specs["NameValueList"] if i["Name"] == "Finish")
+        assert finish["Value"] == "Foil"
+
+    def test_finish_regular_for_nonfoil(self):
+        specs = build_item_specifics(_CARD, _SELLER_NM)
+        finish = next(i for i in specs["NameValueList"] if i["Name"] == "Finish")
+        assert finish["Value"] == "Regular"
+
+    def test_graded_always_no(self):
+        specs = build_item_specifics(_CARD, _SELLER_NM)
+        graded = next(i for i in specs["NameValueList"] if i["Name"] == "Graded")
+        assert graded["Value"] == "No"
+
+    def test_language_english(self):
+        specs = build_item_specifics(_CARD, _SELLER_NM)
+        lang = next(i for i in specs["NameValueList"] if i["Name"] == "Language")
+        assert lang["Value"] == "English"
+
+
+# ---------------------------------------------------------------------------
+# Description tests
+# ---------------------------------------------------------------------------
+
+class TestBuildDescriptionHtml:
+    def test_minimal_contains_card_name(self):
+        html = build_description_html(_CARD, _SELLER_NM, _BRAND, DescriptionMode.MINIMAL)
+        assert "Sheoldred, the Apocalypse" in html
+
+    def test_minimal_contains_oracle_text(self):
+        html = build_description_html(_CARD, _SELLER_NM, _BRAND, DescriptionMode.MINIMAL)
+        assert "you gain 2 life" in html
+
+    def test_minimal_no_image(self):
+        html = build_description_html(_CARD, _SELLER_NM, _BRAND, DescriptionMode.MINIMAL)
+        assert "<img" not in html
+
+    def test_full_contains_image(self):
+        html = build_description_html(_CARD, _SELLER_NM, _BRAND, DescriptionMode.FULL)
+        assert "<img" in html
+        assert _CARD.image_url in html
+
+    def test_full_contains_flavor_text(self):
+        html = build_description_html(_CARD, _SELLER_NM, _BRAND, DescriptionMode.FULL)
+        assert "Even death bows to her." in html
+
+    def test_full_shows_pt_for_creature(self):
+        html = build_description_html(_CARD, _SELLER_NM, _BRAND, DescriptionMode.FULL)
+        assert "4/5" in html
+
+    def test_full_shows_loyalty_for_planeswalker(self):
+        pw_card = CardData(
+            card_version_id=_CARD.card_version_id,
+            card_name=_CARD.card_name,
+            set_name=_CARD.set_name,
+            set_code=_CARD.set_code,
+            collector_number=_CARD.collector_number,
+            mana_cost=_CARD.mana_cost,
+            oracle_text=_CARD.oracle_text,
+            type_line=_CARD.type_line,
+            rarity_name=_CARD.rarity_name,
+            color_identity=_CARD.color_identity,
+            power=None,
+            toughness=None,
+            loyalty="5",
+            image_url=_CARD.image_url,
+            flavor_text=_CARD.flavor_text,
+            scryfall_id=_CARD.scryfall_id,
+        )
+        html = build_description_html(pw_card, _SELLER_NM, _BRAND, DescriptionMode.FULL)
+        assert "Loyalty" in html
+        assert "5" in html
+
+    def test_full_includes_brand_footer(self):
+        html = build_description_html(_CARD, _SELLER_NM, _BRAND, DescriptionMode.FULL)
+        assert "Fast dispatch from Australia" in html
+
+    def test_full_with_brand_header(self):
+        branded = BrandConfig(header_html="<div id='store-banner'>MyStore</div>")
+        html = build_description_html(_CARD, _SELLER_NM, branded, DescriptionMode.FULL)
+        assert "MyStore" in html
+
+    def test_condition_note_appears_once_in_full(self):
+        seller = SellerInput(condition=Condition.LP, quantity=1, foil=False, lang="en",
+                             price_aud=Decimal("40.00"), shipping_cost_aud=Decimal("0.00"),
+                             condition_note="Small crease on corner")
+        html = build_description_html(_CARD, seller, _BRAND, DescriptionMode.FULL)
+        assert html.count("Small crease on corner") == 1
+
+
+# ---------------------------------------------------------------------------
+# Full builder integration test
+# ---------------------------------------------------------------------------
+
+class TestBuildMtgListing:
+    def test_returns_item_model(self):
+        from automana.core.models.ebay.listings import ItemModel
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert isinstance(item, ItemModel)
+
+    def test_title_on_model(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert "Sheoldred" in item.Title
+
+    def test_price_on_model(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.StartPrice is not None
+        assert item.StartPrice.text == "45.00"
+
+    def test_condition_id_on_model(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.ConditionID == 3000
+
+    def test_listing_type_fixed_price(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.ListingType == "FixedPriceItem"
+
+    def test_listing_duration_gtc(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.ListingDuration == "GTC"
+
+    def test_currency_aud(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.Currency == "AUD"
+
+    def test_category_id(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.PrimaryCategory.CategoryID == "38292"
+
+    def test_inline_return_policy_when_no_seller_profiles(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.ReturnPolicy is not None
+        assert item.SellerProfiles is None
+
+    def test_seller_profiles_used_when_configured(self):
+        brand_with_profiles = BrandConfig(
+            seller_shipping_profile_id=111,
+            seller_return_profile_id=222,
+            seller_payment_profile_id=333,
+        )
+        item = build_mtg_listing(_CARD, _SELLER_NM, brand_with_profiles, _PRICING)
+        assert item.SellerProfiles is not None
+        assert item.SellerProfiles.SellerShippingProfileID == 111
+        assert item.ReturnPolicy is None
+
+    def test_ship_to_au_only(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.ShipToLocations == "AU"
+
+    def test_auto_pay_true(self):
+        item = build_mtg_listing(_CARD, _SELLER_NM, _BRAND, _PRICING)
+        assert item.AutoPay is True


### PR DESCRIPTION
## Summary

- **eBay setup wizard** — wired OAuth callback to redirect to `/ebay/connected`, added a success/error landing page, replaced read-only redirect URI field with editable RuName field, added Connect to eBay button on Step 4, and loads OAuth scopes dynamically from the DB by environment
- **MTG listing builder** — pure `build_mtg_listing()` function maps `CardData + SellerInput + BrandConfig + PricingInput → ItemModel` for eBay AU (site 15, category 38292, AUD); covers title (80-char), SKU, subtitle (55-char), 5-tier condition IDs, ItemSpecifics, two description variants (minimal/full), shipping, and return policy
- **Repository + service** — `EbayListingBuilderRepository` fetches card data from `card_catalog.v_card_versions_complete` with scryfall_id join; `build_and_create_listing` registered at `integrations.ebay.selling.listings.build_and_create`, wiring card fetch → builder → existing `create_listing`

## Test Plan

- [ ] Run `pytest tests/unit/core/services/app_integration/ebay/test_listing_builder.py -v` — 70 tests, all pass
- [ ] Verify `ServiceRegistry._repository_registry["listing_builder"]` is present after import
- [ ] Verify `ServiceRegistry._services["integrations.ebay.selling.listings.build_and_create"]` is present
- [ ] Test eBay OAuth flow end-to-end: initiate → authorize → callback redirects to `/ebay/connected`
- [ ] Confirm `/ebay/connected` page shows success state with valid token, error state on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)