### PR TITLE
feat(ebay): add eBay hub dashboard with live app list and rate limits

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -60,7 +60,8 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
       MODULES_NAMESPACE: backend
-      REDIS_URL: redis://redis:6379/1
+      REDIS_CACHE_URL: redis://redis:6379/1
+      FRONTEND_BASE_URL: https://automana.duckdns.org
     networks:
       - backend-network
     healthcheck:

--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -23,7 +23,7 @@ services:
       POSTGRES_PASSWORD_FILE: /run/secrets/admin_db_password
       POSTGRES_DB: ${DB_NAME}
     ports:
-      - "${POSTGRES_PORT}:5432"
+      - "5433:5432"
     volumes:
       - /data/postgres:/var/lib/postgresql/data
       - /data/pg_restore:/restore:ro
@@ -60,6 +60,7 @@ services:
       POSTGRES_HOST: postgres
       POSTGRES_PORT: 5432
       MODULES_NAMESPACE: backend
+      REDIS_URL: redis://redis:6379/1
     networks:
       - backend-network
     healthcheck:

--- a/src/automana/api/routers/integrations/ebay/ebay_auth.py
+++ b/src/automana/api/routers/integrations/ebay/ebay_auth.py
@@ -33,7 +33,7 @@ async def regist_app(
         result =await service_manager.execute_service(
             "integrations.ebay.register_app",
             app_data=app_data,
-            created_by=user
+            created_by=user.unique_id
         )
         return ApiResponse(
             message="App registered successfully",

--- a/src/automana/api/routers/integrations/ebay/ebay_auth.py
+++ b/src/automana/api/routers/integrations/ebay/ebay_auth.py
@@ -21,6 +21,38 @@ logger = logging.getLogger(__name__)
 
 ebay_auth_router = APIRouter(prefix='/auth', tags=['auth'])
 
+@ebay_auth_router.get('/apps', description='List eBay apps registered for the current user')
+async def list_user_apps(
+    user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    apps = await service_manager.execute_service(
+        "integrations.ebay.list_user_apps",
+        user_id=user.unique_id,
+    )
+    return ApiResponse(message="Apps retrieved", data={"apps": apps})
+
+
+@ebay_auth_router.get('/apps/{app_code}/rate-limits', description='Fetch eBay API rate limits for an app')
+async def get_app_rate_limits(
+    app_code: str,
+    user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    env = await service_manager.execute_service(
+        "integrations.ebay.get_environment",
+        user_id=user.unique_id,
+        app_code=app_code,
+    )
+    rate_limits = await service_manager.execute_service(
+        "integrations.ebay.get_app_rate_limits",
+        user_id=user.unique_id,
+        app_code=app_code,
+        environment=env.lower(),
+    )
+    return ApiResponse(message="Rate limits retrieved", data={"rate_limits": rate_limits})
+
+
 @ebay_auth_router.post('/admin/apps'
                        , description='add an app to the database'
                        , status_code=status.HTTP_201_CREATED)

--- a/src/automana/core/repositories/app_integration/ebay/ApiAnalytics_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/ApiAnalytics_repository.py
@@ -1,0 +1,79 @@
+import logging
+from typing import Optional
+
+from automana.core.models.ebay.auth import AuthHeader
+from automana.core.repositories.app_integration.ebay.EbayApiRepository import EbayApiClient
+
+logger = logging.getLogger(__name__)
+
+_ANALYTICS_PATH = "/developer/analytics/v1_beta/rate_limit/"
+_TOKEN_PATH = "/identity/v1/oauth2/token"
+_APP_SCOPE = "https://api.ebay.com/oauth/api_scope"
+
+
+class EbayAnalyticsAPIRepository(EbayApiClient):
+    URL_MAPPING = {
+        "sandbox": "https://api.sandbox.ebay.com",
+        "production": "https://api.ebay.com",
+    }
+
+    def __init__(self, environment: str = "sandbox", timeout: int = 30):
+        self.environment = environment.lower()
+        super().__init__(environment=environment, timeout=timeout)
+
+    @property
+    def name(self):
+        return "EbayAnalyticsAPIRepository"
+
+    def _get_base_url(self) -> str:
+        url = self.URL_MAPPING.get(self.environment)
+        if not url:
+            raise ValueError(f"No URL for eBay environment: {self.environment!r}")
+        return url
+
+    async def _get_app_token(self, app_id: str, secret: str) -> str:
+        """Fetch a client-credentials application token (not user-scoped)."""
+        headers = AuthHeader(app_id=app_id, secret=secret).to_header()
+        data = {"grant_type": "client_credentials", "scope": _APP_SCOPE}
+        response = await self.send(
+            "POST", f"{self.base_url}{_TOKEN_PATH}", headers=headers, data=data
+        )
+        parsed = self._parse_response(response)
+        return parsed["access_token"]
+
+    async def get_rate_limits(self, app_id: str, secret: str) -> list[dict]:
+        """Return rate limit usage for all APIs under this eBay app.
+
+        Each entry has: api_name, resource, limit, remaining, reset, time_window_seconds.
+        """
+        token = await self._get_app_token(app_id, secret)
+        response = await self.send(
+            "GET",
+            f"{self.base_url}{_ANALYTICS_PATH}",
+            headers={
+                **self.auth_header(token),
+                "Content-Type": "application/json",
+            },
+        )
+        parsed = self._parse_response(response)
+        results = []
+        for api in parsed.get("rateLimits", []):
+            api_name = api.get("apiName", "")
+            for resource in api.get("resources", []):
+                resource_name = resource.get("name", "")
+                for rate in resource.get("rates", []):
+                    results.append(
+                        {
+                            "api_name": api_name,
+                            "resource": resource_name,
+                            "limit": rate.get("limit"),
+                            "remaining": rate.get("remaining"),
+                            "reset": rate.get("reset"),
+                            "time_window_seconds": rate.get("timeWindow"),
+                        }
+                    )
+        logger.info(
+            "ebay_rate_limits_fetched",
+            extra={"environment": self.environment, "resource_count": len(results)},
+        )
+        return results

--- a/src/automana/core/repositories/app_integration/ebay/app_queries.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_queries.py
@@ -30,7 +30,7 @@ JOIN scopes s ON s.scope_url = scope_urls.scope_url
 ON CONFLICT (scope_id, app_id) DO NOTHING;
 """
 
-assign_user_app_query = """ INSERT INTO app_user (dev_id, app_id) VALUES ($1, $2) ON CONFLICT (dev_id, app_id) DO NOTHING; """
+assign_user_app_query = """ INSERT INTO app_integration.app_user (user_id, app_id) VALUES ($1, $2) ON CONFLICT (user_id, app_id) DO NOTHING; """
 
 assign_scope_query = """
                             INSERT INTO scope_app (scope_id, app_id)

--- a/src/automana/core/repositories/app_integration/ebay/app_queries.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_queries.py
@@ -18,8 +18,13 @@ INSERT INTO app_integration.app_info (
 VALUES (
     $1, $2, $3, $3, $4, pgp_sym_encrypt($5, $9), $6, $7, $8
 )
-ON CONFLICT (app_id)
-DO NOTHING
+ON CONFLICT (app_id) DO UPDATE SET
+    app_name                = EXCLUDED.app_name,
+    redirect_uri            = EXCLUDED.redirect_uri,
+    ru_name                 = EXCLUDED.ru_name,
+    client_secret_encrypted = EXCLUDED.client_secret_encrypted,
+    description             = EXCLUDED.description,
+    updated_at              = now()
 RETURNING app_code; """
 
 

--- a/src/automana/core/repositories/app_integration/ebay/app_queries.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_queries.py
@@ -3,11 +3,12 @@ get_scopes_app = """ SELECT s.scope_url
                     JOIN scope_app sa ON sa.scope_id = s.scope_id
                     WHERE sa.app_id = $1; """
 
-register_app_query = """ 
-INSERT INTO app_info (
+register_app_query = """
+INSERT INTO app_integration.app_info (
     app_id,
     app_name,
     redirect_uri,
+    ru_name,
     response_type,
     client_secret_encrypted,
     environment,
@@ -15,9 +16,9 @@ INSERT INTO app_info (
     app_code
 )
 VALUES (
-    $1, $2, $3, $4, pgp_sym_encrypt($5, $9), $6, $7, $8
-) 
-ON CONFLICT (app_id) 
+    $1, $2, $3, $3, $4, pgp_sym_encrypt($5, $9), $6, $7, $8
+)
+ON CONFLICT (app_id)
 DO NOTHING
 RETURNING app_code; """
 

--- a/src/automana/core/repositories/app_integration/ebay/app_queries.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_queries.py
@@ -32,6 +32,14 @@ ON CONFLICT (scope_id, app_id) DO NOTHING;
 
 assign_user_app_query = """ INSERT INTO app_integration.app_user (user_id, app_id) VALUES ($1, $2) ON CONFLICT (user_id, app_id) DO NOTHING; """
 
+assign_user_scopes_query = """
+INSERT INTO app_integration.scopes_user (scope_id, user_id, app_id)
+SELECT s.scope_id, $1, $2
+FROM unnest($3::TEXT[]) AS scope_urls(scope_url)
+JOIN app_integration.scopes s ON s.scope_url = scope_urls.scope_url
+ON CONFLICT (user_id, app_id, scope_id) DO NOTHING;
+"""
+
 assign_scope_query = """
                             INSERT INTO scope_app (scope_id, app_id)
                             SELECT scope_id, $1

--- a/src/automana/core/repositories/app_integration/ebay/app_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_repository.py
@@ -76,5 +76,8 @@ class EbayAppRepository(AbstractRepository):
     async def link_user_to_app(self, user_id: UUID, app_id: str) -> None:
         await self.execute_command(app_queries.assign_user_app_query, (user_id, app_id))
 
+    async def assign_user_scopes(self, user_id: UUID, app_id: str, scope_urls: list[str]) -> None:
+        await self.execute_command(app_queries.assign_user_scopes_query, (user_id, app_id, scope_urls))
+
     async def list(self):
         raise NotImplementedError("Method 'list' is not implemented in EbayAccountRepository")

--- a/src/automana/core/repositories/app_integration/ebay/app_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/app_repository.py
@@ -73,5 +73,8 @@ class EbayAppRepository(AbstractRepository):
     ):
         await self.execute_command(app_queries.register_app_scopes_query, (app_id, scopes))
 
+    async def link_user_to_app(self, user_id: UUID, app_id: str) -> None:
+        await self.execute_command(app_queries.assign_user_app_query, (user_id, app_id))
+
     async def list(self):
         raise NotImplementedError("Method 'list' is not implemented in EbayAccountRepository")

--- a/src/automana/core/repositories/app_integration/ebay/auth_queries.py
+++ b/src/automana/core/repositories/app_integration/ebay/auth_queries.py
@@ -117,3 +117,26 @@ get_user_scopes_query = """
       JOIN app_integration.scopes s ON su.scope_id = s.scope_id
      WHERE su.user_id = $1 AND su.app_id = $2;
 """
+
+# Returns all apps linked to a user plus whether a non-expired refresh token exists.
+# $1 = user_id
+list_user_apps_query = """
+    SELECT ai.app_id,
+           ai.app_name,
+           ai.app_code,
+           ai.environment,
+           ai.description,
+           ai.is_active,
+           ai.created_at,
+           ai.updated_at,
+           (rt.user_id IS NOT NULL AND rt.expires_at > now()) AS is_connected,
+           rt.expires_at AS token_expires_at,
+           (SELECT COUNT(*) FROM app_integration.app_user
+             WHERE app_id = ai.app_id AND user_id != $1) AS other_user_count
+      FROM app_integration.app_user au
+      JOIN app_integration.app_info ai ON ai.app_id = au.app_id
+      LEFT JOIN app_integration.ebay_refresh_tokens rt
+             ON rt.app_id = ai.app_id AND rt.user_id = $1
+     WHERE au.user_id = $1
+     ORDER BY ai.created_at DESC;
+"""

--- a/src/automana/core/repositories/app_integration/ebay/auth_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/auth_repository.py
@@ -131,6 +131,10 @@ class EbayAuthRepository(AbstractRepository):
             return [r["scope_url"] for r in rows]
         return await self.get_app_scopes(app_id)
 
+    async def list_user_apps(self, user_id: UUID) -> list[dict]:
+        rows = await self.execute_query(auth_queries.list_user_apps_query, (user_id,))
+        return [dict(r) for r in rows] if rows else []
+
     async def get_environment(self, app_code: str, user_id: Optional[UUID] = None) -> Optional[str]:
         query = "SELECT environment FROM app_integration.app_info WHERE app_code = $1"
         rows = await self.execute_query(query, (app_code,))

--- a/src/automana/core/service_registry.py
+++ b/src/automana/core/service_registry.py
@@ -235,6 +235,9 @@ ServiceRegistry.register_api_repository(
     "auth_oauth", "automana.core.repositories.app_integration.ebay.ApiAuth_repository", "EbayAuthAPIRepository"
 )
 ServiceRegistry.register_api_repository(
+    "ebay_analytics", "automana.core.repositories.app_integration.ebay.ApiAnalytics_repository", "EbayAnalyticsAPIRepository"
+)
+ServiceRegistry.register_api_repository(
     "search", "automana.core.repositories.app_integration.ebay.ApiBrowse_repository", "EbayBrowseAPIRepository"
 )
 ServiceRegistry.register_api_repository(

--- a/src/automana/core/services/app_integration/ebay/auth_services.py
+++ b/src/automana/core/services/app_integration/ebay/auth_services.py
@@ -264,6 +264,7 @@ async def register_app(
             raise app_exception.EbayAppRegistrationException("Failed to register eBay app")
         await app_repository.register_app_scopes(app_data.ebay_app_id, app_data.allowed_scopes)
         await app_repository.link_user_to_app(created_by, app_data.ebay_app_id)
+        await app_repository.assign_user_scopes(created_by, app_data.ebay_app_id, app_data.allowed_scopes)
         return app_code
     except app_exception.EbayAppRegistrationException as e:
         raise app_exception.EbayAppRegistrationException(f"Failed to register eBay app: {e}")

--- a/src/automana/core/services/app_integration/ebay/auth_services.py
+++ b/src/automana/core/services/app_integration/ebay/auth_services.py
@@ -263,6 +263,7 @@ async def register_app(
         if not app_code:
             raise app_exception.EbayAppRegistrationException("Failed to register eBay app")
         await app_repository.register_app_scopes(app_data.ebay_app_id, app_data.allowed_scopes)
+        await app_repository.link_user_to_app(created_by, app_data.ebay_app_id)
         return app_code
     except app_exception.EbayAppRegistrationException as e:
         raise app_exception.EbayAppRegistrationException(f"Failed to register eBay app: {e}")

--- a/src/automana/core/services/app_integration/ebay/auth_services.py
+++ b/src/automana/core/services/app_integration/ebay/auth_services.py
@@ -11,6 +11,7 @@ import httpx
 from automana.api.schemas.auth.cookie import RefreshTokenResponse
 from automana.core.exceptions.service_layer_exceptions.ebay import app_exception
 from automana.core.models.ebay.auth import CreateAppRequest, TokenResponse
+from automana.core.repositories.app_integration.ebay.ApiAnalytics_repository import EbayAnalyticsAPIRepository
 from automana.core.repositories.app_integration.ebay.ApiAuth_repository import EbayAuthAPIRepository
 from automana.core.repositories.app_integration.ebay.app_repository import EbayAppRepository
 from automana.core.repositories.app_integration.ebay.auth_repository import EbayAuthRepository
@@ -235,6 +236,50 @@ async def exchange_refresh_token(
         scopes=scopes,
         cookie_set=True,
         app_code=app_code,
+    )
+
+
+@ServiceRegistry.register(
+    "integrations.ebay.list_user_apps",
+    db_repositories=["auth"],
+)
+async def list_user_apps(
+    auth_repository: EbayAuthRepository,
+    user_id: UUID,
+) -> list[dict]:
+    """Return all eBay apps linked to the user with connection status."""
+    apps = await auth_repository.list_user_apps(user_id=user_id)
+    for app in apps:
+        if app.get("created_at"):
+            app["created_at"] = app["created_at"].isoformat()
+        if app.get("updated_at"):
+            app["updated_at"] = app["updated_at"].isoformat()
+        if app.get("token_expires_at"):
+            app["token_expires_at"] = app["token_expires_at"].isoformat()
+        app["other_user_count"] = int(app.get("other_user_count") or 0)
+    return apps
+
+
+@ServiceRegistry.register(
+    "integrations.ebay.get_app_rate_limits",
+    db_repositories=["auth"],
+    api_repositories=["ebay_analytics"],
+)
+async def get_app_rate_limits(
+    auth_repository: EbayAuthRepository,
+    ebay_analytics_repository: EbayAnalyticsAPIRepository,
+    app_code: str,
+    user_id: UUID,
+) -> list[dict]:
+    """Fetch eBay Developer Analytics rate limits for an app via client credentials."""
+    settings = await auth_repository.get_app_settings(user_id=user_id, app_code=app_code)
+    if not settings:
+        raise app_exception.EbayAppNotFoundException(
+            f"eBay app {app_code!r} not found for user {user_id}"
+        )
+    return await ebay_analytics_repository.get_rate_limits(
+        app_id=settings["app_id"],
+        secret=settings["decrypted_secret"],
     )
 
 

--- a/src/frontend/src/features/ebay/api.ts
+++ b/src/frontend/src/features/ebay/api.ts
@@ -46,6 +46,41 @@ export async function registerEbayApp(data: RegisterEbayAppRequest): Promise<Reg
   })
 }
 
+export interface EbayAppSummary {
+  app_id: string
+  app_name: string
+  app_code: string
+  environment: 'SANDBOX' | 'PRODUCTION'
+  description: string | null
+  is_active: boolean
+  is_connected: boolean
+  token_expires_at: string | null
+  other_user_count: number
+  created_at: string
+  updated_at: string
+}
+
+export interface EbayRateLimit {
+  api_name: string
+  resource: string
+  limit: number
+  remaining: number
+  reset: string
+  time_window_seconds: number
+}
+
+export async function fetchUserApps(): Promise<EbayAppSummary[]> {
+  const result = await apiClient<{ apps: EbayAppSummary[] }>('/integrations/ebay/auth/apps')
+  return result.apps ?? []
+}
+
+export async function fetchAppRateLimits(appCode: string): Promise<EbayRateLimit[]> {
+  const result = await apiClient<{ rate_limits: EbayRateLimit[] }>(
+    `/integrations/ebay/auth/apps/${encodeURIComponent(appCode)}/rate-limits`
+  )
+  return result.rate_limits ?? []
+}
+
 export interface StartOAuthResponse {
   authorization_url: string
 }

--- a/src/frontend/src/routes/ebay/EbayHub.module.css
+++ b/src/frontend/src/routes/ebay/EbayHub.module.css
@@ -132,6 +132,129 @@
   line-height: 1.4;
 }
 
+/* ── Section title ────────────────────────────────────── */
+.sectionTitle {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 1.1px;
+  text-transform: uppercase;
+  color: var(--hd-sub);
+  margin-bottom: 12px;
+}
+
+/* ── Apps table ───────────────────────────────────────── */
+.appsTable {
+  display: flex;
+  flex-direction: column;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.appRow {
+  display: grid;
+  grid-template-columns: 1fr 100px 90px 160px 160px;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--hd-border);
+}
+
+.appRow:last-child {
+  border-bottom: none;
+}
+
+.appRowName {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.appRowNameText {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--hd-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appRowDesc {
+  font-size: 11px;
+  color: var(--hd-sub);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appRowEnvBadge {
+  justify-self: start;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid;
+  white-space: nowrap;
+}
+
+.appRowCode {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hd-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.appRowMeta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.appRowMetaLabel {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--hd-sub);
+}
+
+.appRowMetaValue {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--hd-text);
+}
+
+.appRowStatus {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.appCardStatusDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+/* ── Empty state ──────────────────────────────────────── */
+.emptyApps {
+  font-size: 13px;
+  color: var(--hd-sub);
+  padding: 16px 0;
+}
+
 /* ── Stats strip ──────────────────────────────────────── */
 .statsStrip {
   display: grid;

--- a/src/frontend/src/routes/ebay/index.tsx
+++ b/src/frontend/src/routes/ebay/index.tsx
@@ -1,15 +1,10 @@
 // src/frontend/src/routes/ebay/index.tsx
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { createFileRoute, Link } from '@tanstack/react-router'
 import { AppShell } from '../../components/layout/AppShell'
 import { TopBar } from '../../components/layout/TopBar'
 import { Icon, type IconKind } from '../../components/design-system/Icon'
-import { QuotaStrip } from '../../features/ebay/components/QuotaStrip'
-import {
-  MOCK_CONNECTED_STATUS,
-  type ConnectionStatus,
-} from '../../features/ebay/mockEbayApp'
-import { MOCK_AUTHORIZED_USERS } from '../../features/ebay/mockAuthorizedUsers'
+import { fetchUserApps, fetchAppRateLimits, type EbayAppSummary, type EbayRateLimit } from '../../features/ebay/api'
 import styles from './EbayHub.module.css'
 
 export const Route = createFileRoute('/ebay/')({
@@ -17,18 +12,6 @@ export const Route = createFileRoute('/ebay/')({
 })
 
 export { EbayHubPage }
-
-function ConnectionBadge({ connected }: { connected: boolean }) {
-  return (
-    <span
-      className={[styles.badge, connected ? styles.badgeConnected : styles.badgeDisconnected].join(' ')}
-      aria-label={connected ? 'Connected to eBay' : 'Not connected to eBay'}
-    >
-      <span className={styles.badgeDot} aria-hidden="true" />
-      {connected ? 'Connected' : 'Not Connected'}
-    </span>
-  )
-}
 
 interface FeatureCardProps {
   icon: IconKind
@@ -52,45 +35,90 @@ function FeatureCard({ icon, title, subtitle, to }: FeatureCardProps) {
   )
 }
 
-interface StatTileProps {
-  label: string
-  value: string
-  valueColor?: string
+function totalCalls(limits: EbayRateLimit[]): { used: number; total: number } | null {
+  if (!limits.length) return null
+  const total = limits.reduce((s, r) => s + (r.limit ?? 0), 0)
+  const remaining = limits.reduce((s, r) => s + (r.remaining ?? 0), 0)
+  return { used: total - remaining, total }
 }
 
-function StatTile({ label, value, valueColor }: StatTileProps) {
+function AppRow({ app }: { app: EbayAppSummary }) {
+  const [rateLimits, setRateLimits] = React.useState<EbayRateLimit[] | null>(null)
+
+  React.useEffect(() => {
+    fetchAppRateLimits(app.app_code)
+      .then(setRateLimits)
+      .catch(() => setRateLimits([]))
+  }, [app.app_code])
+
+  const envColor = app.environment === 'PRODUCTION' ? 'var(--hd-accent)' : 'var(--hd-amber)'
+  const calls = rateLimits ? totalCalls(rateLimits) : null
+
   return (
-    <div className={styles.statTile}>
-      <div className={styles.statLabel}>{label}</div>
-      <div className={styles.statValue} style={valueColor ? { color: valueColor } : undefined}>
-        {value}
+    <div className={styles.appRow}>
+      <div className={styles.appRowName}>
+        <span className={styles.appRowNameText}>{app.app_name}</span>
+        {app.description && (
+          <span className={styles.appRowDesc}>{app.description}</span>
+        )}
       </div>
+      <span
+        className={styles.appRowEnvBadge}
+        style={{ color: envColor, borderColor: `${envColor}44`, background: `${envColor}11` }}
+      >
+        {app.environment}
+      </span>
+      <span className={styles.appRowMeta}>
+        <span className={styles.appRowMetaLabel}>Users</span>
+        <span className={styles.appRowMetaValue}>{app.other_user_count + 1}</span>
+      </span>
+      <span className={styles.appRowMeta}>
+        <span className={styles.appRowMetaLabel}>API calls</span>
+        <span className={styles.appRowMetaValue}>
+          {rateLimits === null
+            ? '…'
+            : calls
+            ? `${calls.used.toLocaleString()} / ${calls.total.toLocaleString()}`
+            : '—'}
+        </span>
+      </span>
+      <span
+        className={styles.appRowStatus}
+        style={{ color: app.is_connected ? 'var(--hd-accent)' : 'var(--hd-red)' }}
+      >
+        <span
+          className={styles.appCardStatusDot}
+          style={{ background: app.is_connected ? 'var(--hd-accent)' : 'var(--hd-red)' }}
+        />
+        {app.is_connected
+          ? app.token_expires_at
+            ? `Expires ${new Date(app.token_expires_at).toLocaleDateString()}`
+            : 'Connected'
+          : 'Not connected'}
+      </span>
     </div>
   )
 }
 
 function EbayHubPage() {
-  const status: ConnectionStatus = MOCK_CONNECTED_STATUS
+  const [apps, setApps] = useState<EbayAppSummary[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    fetchUserApps()
+      .then(setApps)
+      .catch(() => setApps([]))
+      .finally(() => setLoading(false))
+  }, [])
 
   return (
     <AppShell active="settings">
       <TopBar
         title="eBay Integration"
         subtitle="BYOA · production"
-        actions={<ConnectionBadge connected={status.connected} />}
       />
 
       <div className={styles.page}>
-        {!status.connected && (
-          <div className={styles.warningBanner} role="alert">
-            <Icon kind="shield" size={14} color="var(--hd-amber)" />
-            <span>eBay is not connected.</span>
-            <Link to="/ebay/setup" className={styles.warningLink}>
-              Go to App Setup
-            </Link>
-          </div>
-        )}
-
         <div className={styles.cardsGrid}>
           <FeatureCard
             icon="key"
@@ -112,31 +140,24 @@ function EbayHubPage() {
           />
         </div>
 
-        <section className={styles.statsStrip} aria-label="Connection stats">
-          <StatTile
-            label="Status"
-            value={status.connected ? 'Connected' : 'Not Connected'}
-            valueColor={status.connected ? 'var(--hd-accent)' : 'var(--hd-red)'}
-          />
-          <StatTile
-            label="Environment"
-            value={status.environment}
-          />
-          <StatTile
-            label="Token expires"
-            value={
-              status.tokenExpires
-                ? new Date(status.tokenExpires).toLocaleDateString()
-                : '—'
-            }
-          />
-          <StatTile
-            label="Authorized users"
-            value={String(MOCK_AUTHORIZED_USERS.length)}
-          />
-        </section>
+        {!loading && apps.length > 0 && (
+          <section aria-label="Registered apps">
+            <div className={styles.sectionTitle}>Registered Apps</div>
+            <div className={styles.appsTable}>
+              {apps.map(app => (
+                <AppRow key={app.app_id} app={app} />
+              ))}
+            </div>
+          </section>
+        )}
 
-        <QuotaStrip />
+        {!loading && apps.length === 0 && (
+          <div className={styles.emptyApps}>
+            No apps registered yet.{' '}
+            <Link to="/ebay/setup" className={styles.warningLink}>Set one up</Link>
+          </div>
+        )}
+
       </div>
     </AppShell>
   )


### PR DESCRIPTION
# Summary
Replaces the mocked connection status and quota strip on the eBay hub page (`/ebay`) with real data. Registered apps are fetched per user from the database showing connection status, token expiry, and other-user count. eBay Developer Analytics rate limits (`used / total` calls) are fetched live per app via the client credentials flow and the eBay Developer Analytics API, loading asynchronously after the initial page render.

Also fixes two broken backend container env vars that were preventing the OAuth callback from completing: `REDIS_URL` → `REDIS_CACHE_URL` (to match the settings `validation_alias`) and adds `FRONTEND_BASE_URL=https://automana.duckdns.org` so the callback redirects to the correct domain instead of localhost.

---

# Changes Introduced
- `ApiAnalytics_repository.py` — new eBay API repo: client credentials token fetch + `GET /developer/analytics/v1_beta/rate_limit/`
- `auth_queries.py` — `list_user_apps_query` with connection status, token expiry, and other-user count
- `auth_repository.py` — `list_user_apps()` method
- `auth_services.py` — `list_user_apps` and `get_app_rate_limits` services
- `service_registry.py` — registers `ebay_analytics` API repository
- `ebay_auth.py` — `GET /auth/apps` and `GET /auth/apps/{app_code}/rate-limits` endpoints
- `api.ts` — `EbayAppSummary`, `EbayRateLimit` types; `fetchUserApps()`, `fetchAppRateLimits()`
- `index.tsx` — replaces all mocked components with real `AppRow` table; rate limits load async per row
- `docker-compose.dev.yml` — fixes `REDIS_CACHE_URL` and adds `FRONTEND_BASE_URL`

---

# How to Test
1. Log in, navigate to `/ebay`
2. Feature cards (App Setup / Users / Listings) appear at top
3. Registered apps table loads below — each row shows name, env badge, user count, API calls (`… ` while loading, then `used / total`), and connection status with token expiry
4. Clicking "Connect to eBay" on setup → eBay consent → redirects back to `https://automana.duckdns.org/ebay/connected?status=authorized`

---

# Acceptance Checklist
- [ ] Code compiles without errors
- [ ] All tests pass (if applicable)
- [ ] No debug logs left behind
- [ ] Follows project coding standards
- [ ] Ready for review

---

# Additional Notes
The `environment` kwarg is consumed by `service_manager` to instantiate API repositories — the rate limits endpoint calls `get_environment` first then passes the result as `environment=env.lower()` to the service, consistent with the existing OAuth flow pattern.