### PR TITLE
docs: update API, deployment, and routing docs for eBay hub

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -174,16 +174,24 @@ Base: `/api/integrations`
 
 eBay (`/api/integrations/ebay`)
 
+App management (all require a user session):
+
+- `GET /api/integrations/ebay/auth/apps` — list all eBay apps linked to the current user; returns `app_name`, `app_code`, `environment`, `description`, `is_connected` (non-expired refresh token exists), `token_expires_at`, `other_user_count`
+- `GET /api/integrations/ebay/auth/apps/{app_code}/rate-limits` — fetch live eBay Developer Analytics rate limits for an app via client credentials flow; returns per-resource `limit`, `remaining`, `reset`, `time_window_seconds`
 - `POST /api/integrations/ebay/auth/admin/apps` — register eBay app (admin)
 - `PATCH /api/integrations/ebay/auth/admin/apps/{app_code}/redirect-uri` — update stored redirect URI for a registered app (admin)
+
+OAuth flow:
+
 - `POST /api/integrations/ebay/auth/app/login` — start OAuth flow; returns authorization URL; requires user session
-- `GET /api/integrations/ebay/auth/callback` — eBay OAuth callback; exchanges code for tokens, sets `ebay_access_{app_code}` httponly cookie
+- `GET /api/integrations/ebay/auth/callback` — eBay OAuth callback; exchanges code for tokens, sets `ebay_access_{app_code}` httponly cookie; redirects to `{FRONTEND_BASE_URL}/ebay/connected?status=authorized&app_code={app_code}` on success or `?status=error&message=...` on failure
 - `POST /api/integrations/ebay/auth/exange_token` — exchange stored refresh token for new access token, sets `ebay_access_{app_code}` cookie
 
 eBay OAuth scope notes:
-- Two levels of scope assignment: `scope_app` (scopes granted to the app by eBay) and `scopes_user` (per-user subset, enforced by DB trigger `trg_scopes_user_subset_check`).
+- Two levels of scope assignment: `scope_app` (scopes granted to the app by eBay) and `scopes_user` (per-user subset, enforced by DB trigger `trg_scopes_user_subset_check`). Both must be populated at registration time — `scopes_user` rows must be inserted after `scope_app` or the trigger blocks the insert.
 - The `scope` query parameter in the authorization URL must use **raw URLs** (e.g. `https://api.ebay.com/oauth/api_scope/sell.inventory.readonly`). eBay rejects percent-encoded scope URL characters (`%3A`, `%2F`). Spaces between scopes must be encoded as `%20`.
-- Refresh tokens are stored encrypted (`pgp_sym_encrypt`, AES-256) in `app_integration.ebay_refresh_tokens`, one row per `(user_id, app_id)`. Access tokens are never written to disk — cached in Redis with TTL = `expires_in - 60s`.
+- Refresh tokens are stored encrypted (`pgp_sym_encrypt`, AES-256) in `app_integration.ebay_refresh_tokens`, one row per `(user_id, app_id)`. Access tokens are never written to disk — cached in Redis (`REDIS_CACHE_URL`, db 1) with TTY = `expires_in - 60s`.
+- eBay sandbox may truncate or drop the `state` parameter on callback. The fallback is `get_latest_pending_request()` from `log_oauth_request`.
 - `GET /api/integrations/ebay/search/` — search listings (requires `app_code` and `q`)
 
 Listing endpoints (all require a user session and an `app_code` query parameter):

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -99,6 +99,15 @@ environment:
 
 This overrides `.env.dev`'s `localhost:5433` (which is for host-side tools only). Inside the Docker network, containers reach Postgres via the service name `postgres` on port `5432`.
 
+The `backend` service also sets two additional vars that must be present for the eBay integration to work correctly:
+
+| Env var | Required value (dev) | Purpose |
+|---------|----------------------|---------|
+| `REDIS_CACHE_URL` | `redis://redis:6379/1` | Redis URL for access-token cache (db 1). The settings alias is `REDIS_CACHE_URL` — using `REDIS_URL` will silently fall back to `localhost:6379` and break the OAuth callback. |
+| `FRONTEND_BASE_URL` | `https://automana.duckdns.org` | Base URL the backend appends to OAuth callback redirects. Defaults to `http://localhost:5173` if unset — wrong in any tunnelled/deployed environment. |
+
+Both are set in the `environment:` block of the `backend` service in `deploy/docker-compose.dev.yml`.
+
 Stop:
 
 ```bash

--- a/docs/frontend/architecture/ROUTING.md
+++ b/docs/frontend/architecture/ROUTING.md
@@ -2,47 +2,41 @@
 
 ## Route Structure Overview
 
-AutoMana uses **React Router v6** with a hierarchical route structure. All routes are defined in a central router configuration, with nested routes creating layout nesting and preserving breadcrumb context.
+AutoMana uses **TanStack Router** with file-based routing. Routes are defined as files under `src/frontend/src/routes/` and the route tree is auto-generated into `routeTree.gen.ts` by the Vite plugin. The `__root.tsx` file contains the auth guard that wraps all authenticated routes.
 
-### Route Tree Diagram
+> **Note:** Earlier versions of this doc referenced React Router v6 — that library is no longer used.
+
+### Current Route Tree
 
 ```
-/                              (RootLayout)
+/                              (__root — auth guard + AppShell)
 ├── /login                     (LoginPage)
-├── /signup                    (SignupPage)
-├── /dashboard                 (DashboardLayout)
-│   ├── /                      (DashboardHome)
-│   ├── /collections           (CollectionsPage)
-│   │   ├── /:id               (CollectionDetailPage)
-│   │   └── /new               (CollectionFormPage - create)
-│   ├── /pricing               (PricingPage)
-│   │   ├── /:id/history       (PriceHistoryPage)
-│   │   └── /bulk              (BulkPricingPage)
-│   ├── /portfolio             (PortfolioPage)
-│   │   └── /summary           (PortfolioSummaryPage)
-│   ├── /integrations          (IntegrationsPage)
-│   │   ├── /ebay              (EbayIntegrationPage)
-│   │   ├── /shopify           (ShopifyIntegrationPage)
-│   │   └── /settings          (IntegrationSettingsPage)
-│   ├── /sync                  (SyncPage)
-│   │   └── /history           (SyncHistoryPage)
-│   └── /settings              (SettingsPage)
-├── /oauth/callback/:provider  (OAuthCallbackPage)
-└── *                          (NotFoundPage)
+├── /ebay/
+│   ├── /                      (EbayHubPage — dashboard: registered apps, feature nav)
+│   ├── /setup                 (EbaySetupPage — BYOA wizard: credentials → scopes → register → connect)
+│   ├── /share                 (EbaySharePage — access control & invites)
+│   └── /connected             (EbayConnectedPage — OAuth callback landing; reads ?status & ?app_code)
+└── /listings                  (ListingsPage)
 ```
+
+The auto-generated `routeTree.gen.ts` must be committed whenever a new route file is added or removed.
+
+### eBay integration routes
+
+| Route | Component file | Purpose |
+|-------|---------------|---------|
+| `/ebay/` | `routes/ebay/index.tsx` | Hub: feature cards + live registered-app table (connection status, user count, rate limits) |
+| `/ebay/setup` | `routes/ebay/setup.tsx` | 4-step wizard: credentials, scope selection, app registration, OAuth connect |
+| `/ebay/share` | `routes/ebay/share.tsx` | User access management |
+| `/ebay/connected` | `routes/ebay/connected.tsx` | Post-OAuth landing; eBay redirects here after consent. Reads `?status=authorized&app_code=` or `?status=error&message=` from the backend callback redirect. |
+
+The `/ebay/connected` route is a public-facing landing page — eBay's OAuth callback is `GET /api/integrations/ebay/auth/callback` (backend), which exchanges the code and then issues a `302` redirect to `{FRONTEND_BASE_URL}/ebay/connected?...`.
 
 ### Nesting Hierarchy
 
-**Root Level** (`/`): Authentication gates, error boundaries, global layout
-- Routes: `/login`, `/signup`, `/oauth/callback/:provider`
+**Root Level** (`/`): Auth guard — unauthenticated users are redirected to `/login`
 
-**Dashboard Level** (`/dashboard`): Authenticated user routes with sidebar + header
-- Routes: All feature pages under `/dashboard/*`
-- Layout: Persistent sidebar, top header, breadcrumbs
-
-**Feature Level** (`/dashboard/collections`, `/dashboard/pricing`): Feature-specific routes
-- Routes: List view, detail view, form, sub-features
-- Layout: Feature-specific sidebar or tabs (optional)
+**Feature Level** (`/ebay/*`, `/listings`): Feature-specific pages using `AppShell` layout with persistent sidebar
 
 ---
 


### PR DESCRIPTION
# Summary
Brings three docs up to date with the eBay hub work landed in PR #195.

---

# Changes Introduced
- **`docs/API.md`** — adds the two new endpoints (`GET /auth/apps`, `GET /auth/apps/{code}/rate-limits`); clarifies OAuth callback redirect behaviour, scope insertion order constraint (`scope_app` before `scopes_user`), and the `REDIS_CACHE_URL` alias gotcha
- **`docs/DEPLOYMENT.md`** — documents `REDIS_CACHE_URL` and `FRONTEND_BASE_URL` as required backend env vars, with exact dev values and the failure mode if either is missing or wrong
- **`docs/frontend/architecture/ROUTING.md`** — replaces stale React Router v6 content with the actual TanStack file-based route tree; documents all four `/ebay/*` routes including the new `/ebay/connected` OAuth landing page and its relationship to the backend callback redirect

---

# Acceptance Checklist
- [ ] Code compiles without errors
- [ ] All tests pass (if applicable)
- [ ] Ready for review