### PR TITLE
feat(ebay): create & edit eBay listing frontend

### DIFF
--- a/docs/superpowers/plans/2026-05-09-create-edit-listing.md
+++ b/docs/superpowers/plans/2026-05-09-create-edit-listing.md
@@ -1,0 +1,2272 @@
+# Create & Edit eBay Listing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a create-listing flow at `/listings/new` and an inline edit-panel on `/listings`, both sharing a single `ListingFormPanel` component.
+
+**Architecture:** All work is frontend-only — the backend `POST /listing/` and `PUT /listing/{id}` endpoints are already implemented. A shared `ListingFormPanel` (mode: create | edit) drives both flows. The edit panel opens inline on the listings page (master-detail split); the create page uses a two-column layout with a card search picker on the left and the form on the right.
+
+**Tech Stack:** React 18, TanStack Router, TanStack Query, Zustand, Vitest + React Testing Library, CSS Modules
+
+---
+
+## File Map
+
+| Action | Path | Purpose |
+|--------|------|---------|
+| Modify | `src/frontend/src/features/ebay/api.ts` | Add `createListing` + `updateListing` |
+| Modify | `src/frontend/src/store/listings.ts` | Add `updateListing` action |
+| Create | `src/frontend/src/features/ebay/components/ListingDetailPanel.tsx` | Read-only detail panel |
+| Create | `src/frontend/src/features/ebay/components/ListingDetailPanel.module.css` | Detail panel styles |
+| Create | `src/frontend/src/features/ebay/components/ListingFormPanel.tsx` | Shared create/edit form |
+| Create | `src/frontend/src/features/ebay/components/ListingFormPanel.module.css` | Form styles |
+| Modify | `src/frontend/src/features/ebay/components/ListingsTable.tsx` | Row selection support |
+| Modify | `src/frontend/src/features/ebay/components/ListingsTable.module.css` | Selected row style |
+| Modify | `src/frontend/src/routes/listings.tsx` | Split-panel edit flow |
+| Modify | `src/frontend/src/routes/Listings.module.css` | Panel grid variant |
+| Modify | `src/frontend/src/features/cards/components/SearchResults.tsx` | `onSelect` prop |
+| Modify | `src/frontend/src/features/cards/components/SearchResults.module.css` | Selected card style |
+| Create | `src/frontend/src/features/ebay/components/CardPicker.tsx` | Card search for create flow |
+| Create | `src/frontend/src/features/ebay/components/CardPicker.module.css` | CardPicker styles |
+| Create | `src/frontend/src/routes/listings_.new.tsx` | Create listing page |
+| Create | `src/frontend/src/routes/ListingsNew.module.css` | Create page layout |
+
+All tests live in `__tests__/` inside each component's directory, or alongside the route file in `routes/__tests__/`.
+
+---
+
+### Task 1: Add `createListing` and `updateListing` to the frontend API
+
+**Files:**
+- Modify: `src/frontend/src/features/ebay/api.ts`
+- Test: `src/frontend/src/features/ebay/__tests__/api.listing.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/frontend/src/features/ebay/__tests__/api.listing.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createListing, updateListing } from '../api'
+
+vi.mock('../../../lib/apiClient', () => ({
+  apiClient: vi.fn(),
+}))
+
+import { apiClient } from '../../../lib/apiClient'
+const mockApiClient = vi.mocked(apiClient)
+
+beforeEach(() => {
+  mockApiClient.mockReset()
+  // crypto.randomUUID is available in jsdom via vitest
+})
+
+describe('createListing', () => {
+  it('POSTs to the correct URL with Idempotency-Key header', async () => {
+    mockApiClient.mockResolvedValueOnce(undefined)
+
+    await createListing('automana_au', {
+      title: 'Ragavan NM MTG',
+      startPrice: { currency: 'AUD', value: 12.5 },
+      quantity: 1,
+      conditionID: 3000,
+    })
+
+    expect(mockApiClient).toHaveBeenCalledOnce()
+    const [url, opts] = mockApiClient.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(url).toBe('/integrations/ebay/listing/?app_code=automana_au')
+    expect(opts.method).toBe('POST')
+    expect(opts.headers['Idempotency-Key']).toMatch(/^[0-9a-f-]{36}$/)
+    const body = JSON.parse(opts.body as string)
+    expect(body.title).toBe('Ragavan NM MTG')
+    expect(body.startPrice).toEqual({ currency: 'AUD', value: 12.5 })
+    expect(body.quantity).toBe(1)
+    expect(body.conditionID).toBe(3000)
+  })
+
+  it('includes description when provided', async () => {
+    mockApiClient.mockResolvedValueOnce(undefined)
+
+    await createListing('automana_au', {
+      title: 'Test',
+      startPrice: { currency: 'AUD', value: 5 },
+      quantity: 2,
+      conditionID: 4000,
+      description: 'Lightly played card',
+    })
+
+    const [, opts] = mockApiClient.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(opts.body as string)
+    expect(body.description).toBe('Lightly played card')
+  })
+})
+
+describe('updateListing', () => {
+  it('PUTs to the correct URL with itemID in the body', async () => {
+    mockApiClient.mockResolvedValueOnce(undefined)
+
+    await updateListing('automana_au', '123456789', {
+      title: 'Sheoldred NM MTG',
+      startPrice: { currency: 'AUD', value: 55 },
+      quantity: 1,
+      conditionID: 3000,
+    })
+
+    expect(mockApiClient).toHaveBeenCalledOnce()
+    const [url, opts] = mockApiClient.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/integrations/ebay/listing/123456789?app_code=automana_au')
+    expect(opts.method).toBe('PUT')
+    const body = JSON.parse(opts.body as string)
+    expect(body.itemID).toBe('123456789')
+    expect(body.title).toBe('Sheoldred NM MTG')
+    expect(body.startPrice).toEqual({ currency: 'AUD', value: 55 })
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd src/frontend && npm test -- api.listing
+```
+
+Expected: FAIL — `createListing` and `updateListing` are not yet exported from `api.ts`.
+
+- [ ] **Step 3: Add `createListing` and `updateListing` to `api.ts`**
+
+Append to `src/frontend/src/features/ebay/api.ts`:
+
+```ts
+// ── Listing writes ─────────────────────────────────────────────────────────
+
+export interface ListingItemPayload {
+  title: string
+  startPrice: { currency: string; value: number }
+  quantity: number
+  conditionID: number
+  description?: string
+}
+
+export async function createListing(
+  appCode: string,
+  item: ListingItemPayload,
+): Promise<void> {
+  await apiClient<unknown>(
+    `/integrations/ebay/listing/?app_code=${encodeURIComponent(appCode)}`,
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': crypto.randomUUID() },
+      body: JSON.stringify(item),
+    },
+  )
+}
+
+export async function updateListing(
+  appCode: string,
+  itemId: string,
+  item: ListingItemPayload,
+): Promise<void> {
+  await apiClient<unknown>(
+    `/integrations/ebay/listing/${encodeURIComponent(itemId)}?app_code=${encodeURIComponent(appCode)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({ itemID: itemId, ...item }),
+    },
+  )
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npm test -- api.listing
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/api.ts \
+        src/frontend/src/features/ebay/__tests__/api.listing.test.ts
+git commit -m "feat(ebay): add createListing and updateListing to frontend API"
+```
+
+---
+
+### Task 2: Add `updateListing` action to Zustand listings store
+
+**Files:**
+- Modify: `src/frontend/src/store/listings.ts`
+- Test: `src/frontend/src/store/__tests__/listings.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/frontend/src/store/__tests__/listings.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useListingsStore } from '../listings'
+import type { EbayLiveListing } from '../../features/ebay/mockListings'
+
+function makeListing(overrides: Partial<EbayLiveListing> = {}): EbayLiveListing {
+  return {
+    itemId: 'l1',
+    title: 'Ragavan MH2 NM',
+    cardName: 'Ragavan',
+    setCode: 'MH2',
+    setInfo: 'MH2',
+    price: 60,
+    currency: 'AUD',
+    conditionLabel: 'NM',
+    finish: 'Regular',
+    style: '',
+    daysListed: 5,
+    watchCount: 3,
+    viewItemUrl: 'https://ebay.com.au/itm/l1',
+    imageUrl: null,
+    appCode: 'app1',
+    appName: 'App 1',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useListingsStore.setState({ listings: [] })
+})
+
+describe('listings store', () => {
+  it('setListings replaces all listings', () => {
+    const l = makeListing()
+    useListingsStore.getState().setListings([l])
+    expect(useListingsStore.getState().listings).toHaveLength(1)
+  })
+
+  it('getById returns the matching listing', () => {
+    useListingsStore.getState().setListings([makeListing({ itemId: 'abc' })])
+    expect(useListingsStore.getState().getById('abc')?.itemId).toBe('abc')
+  })
+
+  it('getById returns undefined for unknown id', () => {
+    useListingsStore.getState().setListings([makeListing()])
+    expect(useListingsStore.getState().getById('nope')).toBeUndefined()
+  })
+
+  it('updateListing patches only the matching entry', () => {
+    const l1 = makeListing({ itemId: 'l1', price: 60 })
+    const l2 = makeListing({ itemId: 'l2', price: 10 })
+    useListingsStore.getState().setListings([l1, l2])
+
+    useListingsStore.getState().updateListing('l1', { price: 75, conditionLabel: 'LP' })
+
+    const updated = useListingsStore.getState().listings
+    expect(updated[0].price).toBe(75)
+    expect(updated[0].conditionLabel).toBe('LP')
+    expect(updated[1].price).toBe(10)
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd src/frontend && npm test -- listings.test
+```
+
+Expected: FAIL — `updateListing` is not defined on the store.
+
+- [ ] **Step 3: Add `updateListing` to the store**
+
+Replace `src/frontend/src/store/listings.ts` with:
+
+```ts
+import { create } from 'zustand'
+import type { EbayLiveListing } from '../features/ebay/mockListings'
+
+interface ListingsState {
+  listings: EbayLiveListing[]
+  setListings: (listings: EbayLiveListing[]) => void
+  getById: (itemId: string) => EbayLiveListing | undefined
+  updateListing: (itemId: string, patch: Partial<EbayLiveListing>) => void
+}
+
+export const useListingsStore = create<ListingsState>()((set, get) => ({
+  listings: [],
+  setListings: (listings) => set({ listings }),
+  getById: (itemId) => get().listings.find((l) => l.itemId === itemId),
+  updateListing: (itemId, patch) =>
+    set((state) => ({
+      listings: state.listings.map((l) =>
+        l.itemId === itemId ? { ...l, ...patch } : l
+      ),
+    })),
+}))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npm test -- listings.test
+```
+
+Expected: PASS — 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/store/listings.ts \
+        src/frontend/src/store/__tests__/listings.test.ts
+git commit -m "feat(ebay): add updateListing action to listings store"
+```
+
+---
+
+### Task 3: Build `ListingDetailPanel` (read-only panel)
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/components/ListingDetailPanel.tsx`
+- Create: `src/frontend/src/features/ebay/components/ListingDetailPanel.module.css`
+- Test: `src/frontend/src/features/ebay/components/__tests__/ListingDetailPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/frontend/src/features/ebay/components/__tests__/ListingDetailPanel.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ListingDetailPanel } from '../ListingDetailPanel'
+import type { EbayLiveListing } from '../../mockListings'
+
+function makeListing(overrides: Partial<EbayLiveListing> = {}): EbayLiveListing {
+  return {
+    itemId: 'l1',
+    title: 'Sheoldred MOM NM MTG',
+    cardName: 'Sheoldred, the Apocalypse',
+    setCode: 'MOM',
+    setInfo: 'MOM',
+    price: 55,
+    currency: 'AUD',
+    conditionLabel: 'Near Mint (NM)',
+    finish: 'Regular',
+    style: '',
+    daysListed: 3,
+    watchCount: 7,
+    viewItemUrl: 'https://www.ebay.com.au/itm/l1',
+    imageUrl: null,
+    appCode: 'app1',
+    appName: 'AutoMana AU',
+    ...overrides,
+  }
+}
+
+describe('ListingDetailPanel', () => {
+  it('renders card name, price, condition, and watchers', () => {
+    render(
+      <ListingDetailPanel
+        listing={makeListing()}
+        onEdit={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Sheoldred, the Apocalypse')).toBeInTheDocument()
+    expect(screen.getByText(/55\.00/)).toBeInTheDocument()
+    expect(screen.getByText('Near Mint (NM)')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('calls onEdit when Edit listing button is clicked', async () => {
+    const onEdit = vi.fn()
+    render(<ListingDetailPanel listing={makeListing()} onEdit={onEdit} onClose={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: /edit listing/i }))
+    expect(onEdit).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn()
+    render(<ListingDetailPanel listing={makeListing()} onEdit={vi.fn()} onClose={onClose} />)
+    await userEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows thumbnail when imageUrl is present', () => {
+    render(
+      <ListingDetailPanel
+        listing={makeListing({ imageUrl: 'https://example.com/img.jpg' })}
+        onEdit={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/img.jpg')
+  })
+
+  it('shows eBay link', () => {
+    render(<ListingDetailPanel listing={makeListing()} onEdit={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByRole('link', { name: /view/i })).toHaveAttribute('href', 'https://www.ebay.com.au/itm/l1')
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd src/frontend && npm test -- ListingDetailPanel.test
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `ListingDetailPanel.tsx`**
+
+```tsx
+// src/frontend/src/features/ebay/components/ListingDetailPanel.tsx
+import { Icon } from '../../../components/design-system/Icon'
+import type { EbayLiveListing } from '../mockListings'
+import styles from './ListingDetailPanel.module.css'
+
+interface ListingDetailPanelProps {
+  listing: EbayLiveListing
+  onEdit: () => void
+  onClose: () => void
+}
+
+export function ListingDetailPanel({ listing, onEdit, onClose }: ListingDetailPanelProps) {
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <span className={styles.title}>{listing.cardName}</span>
+        <button onClick={onClose} className={styles.closeBtn} aria-label="Close panel">
+          <Icon kind="close" size={14} color="currentColor" />
+        </button>
+      </div>
+
+      {listing.imageUrl ? (
+        <img src={listing.imageUrl} alt={listing.cardName} className={styles.image} />
+      ) : (
+        <div className={styles.imagePlaceholder}>
+          <span className={styles.placeholderName}>{listing.cardName}</span>
+          <span className={styles.placeholderSet}>{listing.setCode}</span>
+        </div>
+      )}
+
+      <div className={styles.fields}>
+        {[
+          { label: 'Set', value: listing.setCode || '—' },
+          { label: 'Condition', value: listing.conditionLabel || '—' },
+          { label: 'Days listed', value: listing.daysListed > 0 ? `${listing.daysListed}d` : '—' },
+          { label: 'App', value: listing.appName || listing.appCode },
+        ].map(({ label, value }) => (
+          <div key={label} className={styles.row}>
+            <span className={styles.label}>{label}</span>
+            <span className={styles.value}>{value}</span>
+          </div>
+        ))}
+        <div className={styles.row}>
+          <span className={styles.label}>Price</span>
+          <span className={styles.valueAccent}>
+            {listing.currency} {listing.price.toFixed(2)}
+          </span>
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>Watchers</span>
+          <span className={styles.value}>{listing.watchCount}</span>
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>eBay</span>
+          <a
+            href={listing.viewItemUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.link}
+          >
+            View ↗
+          </a>
+        </div>
+      </div>
+
+      <button onClick={onEdit} className={styles.editBtn}>
+        Edit listing
+      </button>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Create `ListingDetailPanel.module.css`**
+
+```css
+/* src/frontend/src/features/ebay/components/ListingDetailPanel.module.css */
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  padding: 20px;
+  position: sticky;
+  top: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--hd-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--hd-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  transition: color 0.1s;
+}
+.closeBtn:hover { color: var(--hd-text); }
+
+.image {
+  width: 100%;
+  border-radius: 8px;
+  object-fit: contain;
+  max-height: 180px;
+}
+
+.imagePlaceholder {
+  width: 100%;
+  aspect-ratio: 5 / 7;
+  max-height: 180px;
+  background: var(--hd-surface-alt);
+  border: 1px solid var(--hd-border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.placeholderName {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--hd-text);
+  text-align: center;
+  padding: 0 8px;
+}
+
+.placeholderSet {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  white-space: nowrap;
+}
+
+.value {
+  font-size: 12px;
+  color: var(--hd-text);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.valueAccent {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--hd-accent);
+  text-align: right;
+}
+
+.link {
+  font-size: 12px;
+  color: var(--hd-accent);
+  text-decoration: none;
+}
+.link:hover { text-decoration: underline; }
+
+.editBtn {
+  width: 100%;
+  padding: 10px 16px;
+  background: var(--hd-accent);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+.editBtn:hover { opacity: 0.88; }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npm test -- ListingDetailPanel.test
+```
+
+Expected: PASS — 5 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/ListingDetailPanel.tsx \
+        src/frontend/src/features/ebay/components/ListingDetailPanel.module.css \
+        src/frontend/src/features/ebay/components/__tests__/ListingDetailPanel.test.tsx
+git commit -m "feat(ebay): add ListingDetailPanel read-only component"
+```
+
+---
+
+### Task 4: Build `ListingFormPanel` (shared create/edit form)
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/components/ListingFormPanel.tsx`
+- Create: `src/frontend/src/features/ebay/components/ListingFormPanel.module.css`
+- Test: `src/frontend/src/features/ebay/components/__tests__/ListingFormPanel.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/frontend/src/features/ebay/components/__tests__/ListingFormPanel.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ListingFormPanel } from '../ListingFormPanel'
+import type { EbayAppSummary } from '../../api'
+
+function makeApp(overrides: Partial<EbayAppSummary> = {}): EbayAppSummary {
+  return {
+    app_id: 'a1',
+    app_name: 'AutoMana AU',
+    app_code: 'automana_au',
+    environment: 'PRODUCTION',
+    description: null,
+    is_active: true,
+    is_connected: true,
+    token_expires_at: null,
+    other_user_count: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ListingFormPanel', () => {
+  it('pre-fills fields from initialValues', () => {
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Sheoldred MOM NM', price: 55, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    expect(screen.getByDisplayValue('Sheoldred MOM NM')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('55')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument()
+  })
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn()
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Test', price: 10, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={onCancel}
+        isSaving={false}
+        error={null}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('calls onSave with current values when Save is clicked', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Ragavan MH2 NM', price: 62, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={onSave}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith(
+      { title: 'Ragavan MH2 NM', price: 62, quantity: 1, conditionId: 3000, description: '' },
+      'automana_au',
+    )
+  })
+
+  it('shows error message when error prop is set', () => {
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Test', price: 10, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error="eBay API error: token expired"
+      />
+    )
+    expect(screen.getByText('eBay API error: token expired')).toBeInTheDocument()
+  })
+
+  it('disables Save button while isSaving', () => {
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Test', price: 10, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={true}
+        error={null}
+      />
+    )
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled()
+  })
+
+  it('shows app dropdown in create mode', () => {
+    render(
+      <ListingFormPanel
+        mode="create"
+        initialValues={{}}
+        availableApps={[makeApp(), makeApp({ app_code: 'app2', app_name: 'App 2' })]}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    expect(screen.getByRole('combobox', { name: /app/i })).toBeInTheDocument()
+  })
+
+  it('validates price must be > 0 before calling onSave', async () => {
+    const onSave = vi.fn()
+    render(
+      <ListingFormPanel
+        mode="create"
+        initialValues={{ title: 'Test', price: 0, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /create/i }))
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.getByText(/price must be greater than 0/i)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd src/frontend && npm test -- ListingFormPanel.test
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `ListingFormPanel.tsx`**
+
+```tsx
+// src/frontend/src/features/ebay/components/ListingFormPanel.tsx
+import { useState } from 'react'
+import type { EbayAppSummary } from '../api'
+import styles from './ListingFormPanel.module.css'
+
+export interface ListingFormValues {
+  title: string
+  price: number
+  quantity: number
+  conditionId: number
+  description: string
+}
+
+const CONDITION_OPTIONS = [
+  { label: 'Near Mint (NM)', value: 3000 },
+  { label: 'Lightly Played (LP)', value: 4000 },
+  { label: 'Moderately Played (MP)', value: 5000 },
+  { label: 'Heavily Played (HP)', value: 6000 },
+  { label: 'Damaged (DMG)', value: 7000 },
+]
+
+interface ListingFormPanelProps {
+  mode: 'create' | 'edit'
+  initialValues: Partial<ListingFormValues>
+  availableApps: EbayAppSummary[]
+  appCode?: string
+  onSave: (values: ListingFormValues, appCode: string) => Promise<void>
+  onCancel: () => void
+  isSaving: boolean
+  error: string | null
+}
+
+export function ListingFormPanel({
+  mode,
+  initialValues,
+  availableApps,
+  appCode: fixedAppCode,
+  onSave,
+  onCancel,
+  isSaving,
+  error,
+}: ListingFormPanelProps) {
+  const [title, setTitle] = useState(initialValues.title ?? '')
+  const [price, setPrice] = useState(initialValues.price ?? 0)
+  const [quantity, setQuantity] = useState(initialValues.quantity ?? 1)
+  const [conditionId, setConditionId] = useState(initialValues.conditionId ?? 3000)
+  const [description, setDescription] = useState(initialValues.description ?? '')
+  const [selectedAppCode, setSelectedAppCode] = useState(
+    fixedAppCode ?? availableApps[0]?.app_code ?? '',
+  )
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  function validate(): boolean {
+    if (price <= 0) {
+      setValidationError('Price must be greater than 0')
+      return false
+    }
+    if (quantity < 1) {
+      setValidationError('Quantity must be at least 1')
+      return false
+    }
+    if (!title.trim()) {
+      setValidationError('Title is required')
+      return false
+    }
+    setValidationError(null)
+    return true
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    await onSave(
+      { title: title.trim(), price, quantity, conditionId, description },
+      selectedAppCode,
+    )
+  }
+
+  const saveLabel = mode === 'create' ? 'Create listing' : 'Save changes'
+  const displayError = validationError ?? error
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form} noValidate>
+      <div className={styles.header}>
+        <span className={styles.title}>
+          {mode === 'create' ? 'New listing' : 'Edit listing'}
+        </span>
+      </div>
+
+      <div className={styles.fields}>
+        <label className={styles.field}>
+          <span className={styles.label}>Title</span>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={80}
+            className={styles.input}
+            placeholder="Card name + set + condition"
+          />
+        </label>
+
+        <div className={styles.row}>
+          <label className={styles.field}>
+            <span className={styles.label}>Price (AUD)</span>
+            <input
+              type="number"
+              value={price}
+              onChange={(e) => setPrice(Number(e.target.value))}
+              step="0.01"
+              min="0.01"
+              className={styles.input}
+            />
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.label}>Qty</span>
+            <input
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(Number(e.target.value))}
+              step="1"
+              min="1"
+              className={styles.inputSmall}
+            />
+          </label>
+        </div>
+
+        <label className={styles.field}>
+          <span className={styles.label}>Condition</span>
+          <select
+            value={conditionId}
+            onChange={(e) => setConditionId(Number(e.target.value))}
+            className={styles.select}
+          >
+            {CONDITION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={styles.field}>
+          <span className={styles.label}>Description (optional)</span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={500}
+            rows={3}
+            className={styles.textarea}
+            placeholder="Any extra notes for the buyer"
+          />
+        </label>
+
+        {mode === 'create' && (
+          <label className={styles.field} aria-label="App">
+            <span className={styles.label}>App</span>
+            <select
+              value={selectedAppCode}
+              onChange={(e) => setSelectedAppCode(e.target.value)}
+              className={styles.select}
+            >
+              {availableApps.map((app) => (
+                <option key={app.app_code} value={app.app_code}>
+                  {app.app_name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </div>
+
+      {displayError && (
+        <div className={styles.error} role="alert">
+          {displayError}
+        </div>
+      )}
+
+      <div className={styles.actions}>
+        <button type="button" onClick={onCancel} className={styles.cancelBtn}>
+          Cancel
+        </button>
+        <button type="submit" disabled={isSaving} className={styles.saveBtn}>
+          {isSaving ? 'Saving…' : saveLabel}
+        </button>
+      </div>
+    </form>
+  )
+}
+```
+
+- [ ] **Step 4: Create `ListingFormPanel.module.css`**
+
+```css
+/* src/frontend/src/features/ebay/components/ListingFormPanel.module.css */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--hd-text);
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 80px;
+  gap: 10px;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.input,
+.select,
+.textarea {
+  background: var(--hd-bg);
+  border: 1px solid var(--hd-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 13px;
+  color: var(--hd-text);
+  font-family: var(--font-sans);
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.12s;
+}
+
+.input:focus,
+.select:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--hd-accent);
+}
+
+.inputSmall {
+  composes: input;
+  text-align: center;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.error {
+  padding: 8px 12px;
+  background: rgba(227, 94, 108, 0.08);
+  border: 1px solid rgba(227, 94, 108, 0.25);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--hd-red);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.cancelBtn {
+  padding: 8px 16px;
+  background: transparent;
+  border: 1px solid var(--hd-border);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--hd-muted);
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+}
+.cancelBtn:hover {
+  color: var(--hd-text);
+  border-color: var(--hd-text);
+}
+
+.saveBtn {
+  padding: 8px 18px;
+  background: var(--hd-accent);
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+.saveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.saveBtn:not(:disabled):hover {
+  opacity: 0.88;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npm test -- ListingFormPanel.test
+```
+
+Expected: PASS — 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/ListingFormPanel.tsx \
+        src/frontend/src/features/ebay/components/ListingFormPanel.module.css \
+        src/frontend/src/features/ebay/components/__tests__/ListingFormPanel.test.tsx
+git commit -m "feat(ebay): add shared ListingFormPanel create/edit form"
+```
+
+---
+
+### Task 5: Add row selection to `ListingsTable`
+
+**Files:**
+- Modify: `src/frontend/src/features/ebay/components/ListingsTable.tsx`
+- Modify: `src/frontend/src/features/ebay/components/ListingsTable.module.css`
+- Test: `src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx` (extend existing)
+
+- [ ] **Step 1: Write the new failing tests**
+
+Append to the existing `ListingsTable.test.tsx`:
+
+```tsx
+describe('ListingsTable — row selection', () => {
+  it('calls onRowClick with the listing itemId when a row is clicked', async () => {
+    const onRowClick = vi.fn()
+    const listing = makeListing({ itemId: 'abc123' })
+    render(
+      <ListingsTable
+        listings={[listing]}
+        isLoading={false}
+        onRowClick={onRowClick}
+      />
+    )
+    // Click the row (the <tr> itself)
+    const rows = document.querySelectorAll('tbody tr')
+    await userEvent.click(rows[0])
+    expect(onRowClick).toHaveBeenCalledWith('abc123')
+  })
+
+  it('adds a selected style class to the row matching selectedId', () => {
+    const listing = makeListing({ itemId: 'sel1' })
+    render(
+      <ListingsTable
+        listings={[listing]}
+        isLoading={false}
+        selectedId="sel1"
+        onRowClick={vi.fn()}
+      />
+    )
+    const rows = document.querySelectorAll('tbody tr')
+    expect(rows[0].className).toMatch(/rowSelected/)
+  })
+
+  it('renders card name as plain text (not a link) when onRowClick is provided', () => {
+    const listing = makeListing({ itemId: 'l1', cardName: 'Ragavan' })
+    render(
+      <ListingsTable
+        listings={[listing]}
+        isLoading={false}
+        onRowClick={vi.fn()}
+      />
+    )
+    // The card name should be text, not a router Link
+    expect(screen.queryByRole('link', { name: /ragavan/i })).toBeNull()
+    expect(screen.getByText('Ragavan')).toBeInTheDocument()
+  })
+})
+```
+
+You'll need to add `import userEvent from '@testing-library/user-event'` at the top of the test file if it's not already there.
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd src/frontend && npm test -- ListingsTable.test
+```
+
+Expected: new tests FAIL — `onRowClick` and `selectedId` props not yet supported.
+
+- [ ] **Step 3: Update `ListingsTable.tsx`**
+
+In `ListingsTable.tsx`, update the `ListingsTableProps` interface:
+
+```tsx
+interface ListingsTableProps {
+  listings: EbayLiveListing[]
+  isLoading?: boolean
+  selectedId?: string
+  onRowClick?: (id: string) => void
+}
+```
+
+Update the function signature:
+
+```tsx
+export function ListingsTable({ listings, isLoading = false, selectedId, onRowClick }: ListingsTableProps) {
+```
+
+In the `{!isLoading && visible.map((listing) => {` section, replace the `<tr>` opening tag:
+
+```tsx
+<tr
+  key={listing.itemId}
+  className={[
+    styles.row,
+    listing.itemId === selectedId ? styles.rowSelected : '',
+  ].filter(Boolean).join(' ')}
+  onClick={() => onRowClick?.(listing.itemId)}
+  style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+>
+```
+
+Replace the card name `<Link>` inside that row with conditional rendering:
+
+```tsx
+<div className={styles.nameText}>
+  {onRowClick ? (
+    <span className={styles.cardName}>{listing.cardName}</span>
+  ) : (
+    <Link
+      to="/listings_/$id"
+      params={{ id: listing.itemId }}
+      className={styles.cardName}
+    >
+      {listing.cardName}
+    </Link>
+  )}
+  <a
+    href={listing.viewItemUrl}
+    target="_blank"
+    rel="noopener noreferrer"
+    className={styles.ebayLink}
+    title="View on eBay"
+    onClick={(e) => e.stopPropagation()}
+  >
+    eBay ↗
+  </a>
+</div>
+```
+
+- [ ] **Step 4: Add `.rowSelected` to `ListingsTable.module.css`**
+
+Append to `ListingsTable.module.css`:
+
+```css
+.rowSelected {
+  background: rgba(var(--hd-accent-rgb), 0.07);
+}
+.rowSelected:hover {
+  background: rgba(var(--hd-accent-rgb), 0.11);
+}
+```
+
+- [ ] **Step 5: Run all ListingsTable tests to verify they pass**
+
+```bash
+cd src/frontend && npm test -- ListingsTable.test
+```
+
+Expected: PASS — all tests including the 3 new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/ListingsTable.tsx \
+        src/frontend/src/features/ebay/components/ListingsTable.module.css \
+        src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
+git commit -m "feat(ebay): add row selection support to ListingsTable"
+```
+
+---
+
+### Task 6: Wire the split-panel edit flow into `listings.tsx`
+
+**Files:**
+- Modify: `src/frontend/src/routes/listings.tsx`
+- Modify: `src/frontend/src/routes/Listings.module.css`
+- Test: `src/frontend/src/routes/__tests__/listings.test.tsx` (extend)
+
+- [ ] **Step 1: Write the new failing tests**
+
+Append to the existing `src/frontend/src/routes/__tests__/listings.test.tsx`:
+
+```tsx
+// Add these extra mocks at the top alongside the existing vi.mock calls:
+vi.mock('../../features/ebay/components/ListingDetailPanel', () => ({
+  ListingDetailPanel: ({ listing, onEdit, onClose }: { listing: { cardName: string }; onEdit: () => void; onClose: () => void }) => (
+    <div data-testid="detail-panel">
+      <span>{listing.cardName}</span>
+      <button onClick={onEdit}>Edit listing</button>
+      <button onClick={onClose}>Close panel</button>
+    </div>
+  ),
+}))
+
+vi.mock('../../features/ebay/components/ListingFormPanel', () => ({
+  ListingFormPanel: ({ onCancel }: { onCancel: () => void }) => (
+    <div data-testid="form-panel">
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}))
+
+vi.mock('../../features/ebay/api', () => ({
+  fetchUserApps: vi.fn(),
+  fetchActiveListings: vi.fn(),
+  fetchActiveListingsPaginated: vi.fn(),
+  updateListing: vi.fn(),
+}))
+
+// New test group:
+describe('ListingsPage — split-panel edit', () => {
+  beforeEach(() => {
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    mockFetchActiveListingsPaginated.mockResolvedValue({
+      items: [makeListing({ itemId: 'l1', cardName: 'Ragavan' })],
+      hasMore: false,
+    })
+  })
+
+  it('shows detail panel when a row is clicked', async () => {
+    render(<ListingsPage />)
+    await waitFor(() => expect(screen.queryByText('Loading')).not.toBeInTheDocument(), { timeout: 3000 })
+
+    // Simulate row click via ListingsTable mock's onRowClick
+    const table = screen.getByTestId('listings-table')
+    // The mock passes onRowClick — we need to update the ListingsTable mock to expose it
+    // For this test, trigger via data attribute or check panel existence via store
+    // The test verifies the panel appears after interaction
+  })
+})
+```
+
+> **Note:** The existing `ListingsTable` mock renders a `<div data-testid="listings-table">`. Update the mock in this test file to also call `onRowClick('l1')` when the div is clicked:
+>
+> ```tsx
+> vi.mock('../../features/ebay/components/ListingsTable', () => ({
+>   ListingsTable: ({
+>     listings,
+>     isLoading,
+>     onRowClick,
+>   }: {
+>     listings: { appName: string; itemId: string }[]
+>     isLoading?: boolean
+>     onRowClick?: (id: string) => void
+>   }) => (
+>     <div
+>       data-testid="listings-table"
+>       data-loading={String(isLoading)}
+>       data-count={listings.length}
+>       onClick={() => listings[0] && onRowClick?.(listings[0].itemId)}
+>     />
+>   ),
+> }))
+> ```
+>
+> Then write:
+
+```tsx
+describe('ListingsPage — split-panel edit', () => {
+  beforeEach(() => {
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    mockFetchActiveListingsPaginated.mockResolvedValue({
+      items: [makeListing({ itemId: 'l1', cardName: 'Ragavan' })],
+      hasMore: false,
+    })
+  })
+
+  it('shows detail panel after clicking a row', async () => {
+    render(<ListingsPage />)
+    await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
+
+    // Set listing in store so the panel can read it
+    const { useListingsStore } = await import('../../store/listings')
+    useListingsStore.getState().setListings([
+      makeListing({ itemId: 'l1', cardName: 'Ragavan' }),
+    ])
+
+    await userEvent.click(screen.getByTestId('listings-table'))
+    await waitFor(() => expect(screen.getByTestId('detail-panel')).toBeInTheDocument())
+  })
+
+  it('switches to form panel when Edit listing is clicked', async () => {
+    render(<ListingsPage />)
+    await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
+
+    const { useListingsStore } = await import('../../store/listings')
+    useListingsStore.getState().setListings([
+      makeListing({ itemId: 'l1', cardName: 'Ragavan' }),
+    ])
+
+    await userEvent.click(screen.getByTestId('listings-table'))
+    await waitFor(() => screen.getByTestId('detail-panel'))
+    await userEvent.click(screen.getByRole('button', { name: /edit listing/i }))
+    expect(screen.getByTestId('form-panel')).toBeInTheDocument()
+  })
+
+  it('returns to detail panel when Cancel is clicked in form', async () => {
+    render(<ListingsPage />)
+    await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
+
+    const { useListingsStore } = await import('../../store/listings')
+    useListingsStore.getState().setListings([
+      makeListing({ itemId: 'l1', cardName: 'Ragavan' }),
+    ])
+
+    await userEvent.click(screen.getByTestId('listings-table'))
+    await waitFor(() => screen.getByTestId('detail-panel'))
+    await userEvent.click(screen.getByRole('button', { name: /edit listing/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.getByTestId('detail-panel')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd src/frontend && npm test -- routes/__tests__/listings
+```
+
+Expected: new tests FAIL.
+
+- [ ] **Step 3: Update `listings.tsx`**
+
+Add the new imports at the top of `src/frontend/src/routes/listings.tsx`:
+
+```tsx
+import { ListingDetailPanel } from '../features/ebay/components/ListingDetailPanel'
+import { ListingFormPanel, type ListingFormValues } from '../features/ebay/components/ListingFormPanel'
+import { updateListing } from '../features/ebay/api'
+```
+
+Add the new state variables inside `ListingsPage` (after the existing state):
+
+```tsx
+const [selectedId, setSelectedId] = useState<string | null>(null)
+const [panelMode, setPanelMode] = useState<'detail' | 'edit'>('detail')
+const [isSaving, setIsSaving] = useState(false)
+const [saveError, setSaveError] = useState<string | null>(null)
+const [productionApps, setProductionApps] = useState<EbayAppSummary[]>([])
+const selectedListing = useListingsStore((s) => s.getById(selectedId ?? ''))
+const storeUpdateListing = useListingsStore((s) => s.updateListing)
+```
+
+In the `load()` effect, after `appsRef.current = productionApps`, also call:
+
+```tsx
+setProductionApps(productionApps)
+```
+
+Add the save handler after the `loadMore` function:
+
+```tsx
+async function handleUpdateListing(values: ListingFormValues, appCode: string) {
+  if (!selectedId || !selectedListing) return
+  setIsSaving(true)
+  setSaveError(null)
+  try {
+    await updateListing(appCode, selectedId, {
+      title: values.title,
+      startPrice: { currency: 'AUD', value: values.price },
+      quantity: values.quantity,
+      conditionID: values.conditionId,
+      ...(values.description ? { description: values.description } : {}),
+    })
+    storeUpdateListing(selectedId, { price: values.price, title: values.title })
+    setPanelMode('detail')
+  } catch (err) {
+    setSaveError(err instanceof Error ? err.message : 'Failed to update listing')
+  } finally {
+    setIsSaving(false)
+  }
+}
+```
+
+Replace the `{tab === 'active' && (...)}` block with:
+
+```tsx
+{tab === 'active' && (
+  <div className={selectedId ? styles.withPanel : undefined}>
+    <div>
+      <ListingsTable
+        listings={listings}
+        isLoading={isLoading}
+        selectedId={selectedId ?? undefined}
+        onRowClick={(id) => {
+          setSelectedId(id)
+          setPanelMode('detail')
+          setSaveError(null)
+        }}
+      />
+      {!isLoading && (
+        <>
+          <div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
+          {isLoadingMore && (
+            <div className={styles.loadingMore}>Loading more listings…</div>
+          )}
+          {!hasMore && listings.length > 0 && !isLoadingMore && (
+            <div className={styles.endOfList}>
+              {listings.length} listing{listings.length !== 1 ? 's' : ''} total
+            </div>
+          )}
+        </>
+      )}
+    </div>
+
+    {selectedId && selectedListing && (
+      <div>
+        {panelMode === 'detail' ? (
+          <ListingDetailPanel
+            listing={selectedListing}
+            onEdit={() => setPanelMode('edit')}
+            onClose={() => { setSelectedId(null); setPanelMode('detail') }}
+          />
+        ) : (
+          <ListingFormPanel
+            mode="edit"
+            initialValues={{
+              title: selectedListing.title,
+              price: selectedListing.price,
+              quantity: 1,
+              conditionId: 3000,
+              description: '',
+            }}
+            availableApps={productionApps}
+            appCode={selectedListing.appCode}
+            onSave={handleUpdateListing}
+            onCancel={() => setPanelMode('detail')}
+            isSaving={isSaving}
+            error={saveError}
+          />
+        )}
+      </div>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Add `.withPanel` to `Listings.module.css`**
+
+Append to `Listings.module.css`:
+
+```css
+/* ── Split-panel layout (active when a listing is selected) ─── */
+.withPanel {
+  display: grid;
+  grid-template-columns: 1fr 400px;
+  gap: 20px;
+  align-items: start;
+}
+
+@media (max-width: 1100px) {
+  .withPanel {
+    grid-template-columns: 1fr;
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npm test -- routes/__tests__/listings
+```
+
+Expected: PASS — all tests including the 3 new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/routes/listings.tsx \
+        src/frontend/src/routes/Listings.module.css \
+        src/frontend/src/routes/__tests__/listings.test.tsx
+git commit -m "feat(ebay): wire split-panel edit flow into listings page"
+```
+
+---
+
+### Task 7: Add `onSelect` mode to `SearchResults`
+
+**Files:**
+- Modify: `src/frontend/src/features/cards/components/SearchResults.tsx`
+- Modify: `src/frontend/src/features/cards/components/SearchResults.module.css`
+
+- [ ] **Step 1: Update `SearchResultsProps` in `SearchResults.tsx`**
+
+Add two optional props to the interface:
+
+```tsx
+interface SearchResultsProps {
+  cards: CardSummary[]
+  total: number
+  fetchNextPage: () => void
+  hasNextPage?: boolean
+  isFetchingNextPage?: boolean
+  onSelect?: (card: CardSummary) => void
+  selectedId?: string
+}
+```
+
+Update the function signature:
+
+```tsx
+export function SearchResults({
+  cards,
+  total,
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  onSelect,
+  selectedId,
+}: SearchResultsProps) {
+```
+
+Replace the `onClick` on the card button:
+
+```tsx
+onClick={() =>
+  onSelect
+    ? onSelect(card)
+    : navigate({ to: '/cards/$id', params: { id: card.card_version_id } })
+}
+```
+
+Add the selected style to the card button's `className`:
+
+```tsx
+className={[
+  styles.card,
+  card.card_version_id === selectedId ? styles.cardSelected : '',
+].filter(Boolean).join(' ')}
+```
+
+- [ ] **Step 2: Add `.cardSelected` to `SearchResults.module.css`**
+
+Append:
+
+```css
+.cardSelected {
+  outline: 2px solid var(--hd-accent);
+  outline-offset: -2px;
+}
+```
+
+- [ ] **Step 3: Run the full test suite to verify no regressions**
+
+```bash
+cd src/frontend && npm test
+```
+
+Expected: PASS — all existing tests still pass (new props are optional, default behaviour is unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/frontend/src/features/cards/components/SearchResults.tsx \
+        src/frontend/src/features/cards/components/SearchResults.module.css
+git commit -m "feat(cards): add optional onSelect mode to SearchResults"
+```
+
+---
+
+### Task 8: Build `CardPicker` (left panel for the create flow)
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/components/CardPicker.tsx`
+- Create: `src/frontend/src/features/ebay/components/CardPicker.module.css`
+- Test: `src/frontend/src/features/ebay/components/__tests__/CardPicker.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/frontend/src/features/ebay/components/__tests__/CardPicker.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { CardPicker } from '../CardPicker'
+import type { CardSummary } from '../../../features/cards/types'
+
+vi.mock('../../../features/cards/api', () => ({
+  cardInfiniteSearchQueryOptions: (params: { q?: string }) => ({
+    queryKey: ['cards', 'search', params],
+    queryFn: async () => ({
+      cards: [
+        {
+          card_version_id: 'cv1',
+          card_name: 'Ragavan, Nimble Pilferer',
+          set_code: 'mh2',
+          set_name: 'MH2',
+          finish: 'non-foil',
+          rarity_name: 'mythic',
+          price: 60,
+          price_change_1d: 0,
+          price_change_7d: 0,
+          price_change_30d: 0,
+          image_uri: null,
+          image_normal: null,
+          spark: [],
+        } satisfies CardSummary,
+      ],
+      pagination: { has_next: false, offset: 0, limit: 20 },
+    }),
+    initialPageParam: 0,
+    getNextPageParam: () => undefined,
+  }),
+}))
+
+vi.mock('../../../features/cards/components/SearchResults', () => ({
+  SearchResults: ({
+    cards,
+    onSelect,
+  }: {
+    cards: CardSummary[]
+    onSelect?: (c: CardSummary) => void
+  }) => (
+    <div data-testid="search-results">
+      {cards.map((c) => (
+        <button key={c.card_version_id} onClick={() => onSelect?.(c)}>
+          {c.card_name}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+describe('CardPicker', () => {
+  it('renders a search input', () => {
+    render(<CardPicker onSelect={vi.fn()} selectedId={undefined} />, { wrapper })
+    expect(screen.getByPlaceholderText(/search cards/i)).toBeInTheDocument()
+  })
+
+  it('shows search results', async () => {
+    render(<CardPicker onSelect={vi.fn()} selectedId={undefined} />, { wrapper })
+    await waitFor(() => expect(screen.getByTestId('search-results')).toBeInTheDocument())
+  })
+
+  it('calls onSelect with the clicked card', async () => {
+    const onSelect = vi.fn()
+    render(<CardPicker onSelect={onSelect} selectedId={undefined} />, { wrapper })
+    await waitFor(() => screen.getByText('Ragavan, Nimble Pilferer'))
+    await userEvent.click(screen.getByText('Ragavan, Nimble Pilferer'))
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ card_version_id: 'cv1' })
+    )
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd src/frontend && npm test -- CardPicker.test
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `CardPicker.tsx`**
+
+```tsx
+// src/frontend/src/features/ebay/components/CardPicker.tsx
+import { useState } from 'react'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { cardInfiniteSearchQueryOptions } from '../../../features/cards/api'
+import { SearchResults } from '../../../features/cards/components/SearchResults'
+import type { CardSummary } from '../../../features/cards/types'
+import styles from './CardPicker.module.css'
+
+interface CardPickerProps {
+  onSelect: (card: CardSummary) => void
+  selectedId: string | undefined
+}
+
+export function CardPicker({ onSelect, selectedId }: CardPickerProps) {
+  const [q, setQ] = useState('')
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useInfiniteQuery(cardInfiniteSearchQueryOptions({ q: q || undefined }))
+
+  const cards = data?.pages.flatMap((p) => p.cards) ?? []
+  const total = data?.pages[0]?.pagination?.total_count ?? cards.length
+
+  return (
+    <div className={styles.picker}>
+      <div className={styles.searchBar}>
+        <input
+          type="text"
+          className={styles.searchInput}
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search cards…"
+          aria-label="Search cards"
+        />
+      </div>
+      {isLoading ? (
+        <div className={styles.loading}>Loading…</div>
+      ) : (
+        <SearchResults
+          cards={cards}
+          total={total}
+          fetchNextPage={fetchNextPage}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onSelect={onSelect}
+          selectedId={selectedId}
+        />
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Create `CardPicker.module.css`**
+
+```css
+/* src/frontend/src/features/ebay/components/CardPicker.module.css */
+.picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  height: 100%;
+  overflow: hidden;
+  border-right: 1px solid var(--hd-border);
+}
+
+.searchBar {
+  padding: 16px;
+  border-bottom: 1px solid var(--hd-border);
+  background: var(--hd-surface);
+}
+
+.searchInput {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--hd-bg);
+  border: 1px solid var(--hd-border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--hd-text);
+  font-family: var(--font-sans);
+  transition: border-color 0.12s;
+}
+.searchInput:focus {
+  outline: none;
+  border-color: var(--hd-accent);
+}
+
+.loading {
+  padding: 24px;
+  font-size: 13px;
+  color: var(--hd-muted);
+  text-align: center;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npm test -- CardPicker.test
+```
+
+Expected: PASS — 3 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/CardPicker.tsx \
+        src/frontend/src/features/ebay/components/CardPicker.module.css \
+        src/frontend/src/features/ebay/components/__tests__/CardPicker.test.tsx
+git commit -m "feat(ebay): add CardPicker component for create listing flow"
+```
+
+---
+
+### Task 9: Build the `/listings/new` create listing page
+
+**Files:**
+- Create: `src/frontend/src/routes/listings_.new.tsx`
+- Create: `src/frontend/src/routes/ListingsNew.module.css`
+- Test: `src/frontend/src/routes/__tests__/listings.new.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/frontend/src/routes/__tests__/listings.new.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+
+vi.mock('../../components/layout/AppShell', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('../../components/layout/TopBar', () => ({
+  TopBar: ({ title }: { title: string }) => <div>{title}</div>,
+}))
+
+vi.mock('../../features/ebay/api', () => ({
+  fetchUserApps: vi.fn(),
+  createListing: vi.fn(),
+}))
+
+vi.mock('../../features/ebay/components/CardPicker', () => ({
+  CardPicker: ({
+    onSelect,
+  }: {
+    onSelect: (card: { card_version_id: string; card_name: string; set_code: string }) => void
+  }) => (
+    <div data-testid="card-picker">
+      <button
+        onClick={() =>
+          onSelect({ card_version_id: 'cv1', card_name: 'Ragavan', set_code: 'mh2' })
+        }
+      >
+        Pick Ragavan
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('../../features/ebay/components/ListingFormPanel', () => ({
+  ListingFormPanel: ({
+    mode,
+    initialValues,
+    onSave,
+    onCancel,
+  }: {
+    mode: string
+    initialValues: { title?: string }
+    onSave: (values: unknown, appCode: string) => Promise<void>
+    onCancel: () => void
+  }) => (
+    <div data-testid="form-panel" data-mode={mode} data-title={initialValues.title ?? ''}>
+      <button onClick={() => onSave({}, 'app1')}>Create listing</button>
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}))
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: () => ({ component: (c: unknown) => c }),
+    useNavigate: () => vi.fn(),
+  }
+})
+
+import { fetchUserApps, createListing } from '../../features/ebay/api'
+import type { EbayAppSummary } from '../../features/ebay/api'
+import { ListingsNewPage } from '../listings_.new'
+
+const mockFetchUserApps = vi.mocked(fetchUserApps)
+const mockCreateListing = vi.mocked(createListing)
+
+function makeApp(overrides: Partial<EbayAppSummary> = {}): EbayAppSummary {
+  return {
+    app_id: 'a1', app_name: 'AutoMana AU', app_code: 'automana_au',
+    environment: 'PRODUCTION', description: null, is_active: true,
+    is_connected: true, token_expires_at: null, other_user_count: 0,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ListingsNewPage', () => {
+  beforeEach(() => {
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    mockCreateListing.mockResolvedValue(undefined)
+  })
+
+  it('renders the card picker and an empty form state', async () => {
+    render(<ListingsNewPage />)
+    await waitFor(() => expect(screen.getByTestId('card-picker')).toBeInTheDocument())
+    expect(screen.getByText(/search for a card/i)).toBeInTheDocument()
+  })
+
+  it('shows the form panel pre-filled after a card is selected', async () => {
+    render(<ListingsNewPage />)
+    await waitFor(() => screen.getByTestId('card-picker'))
+    await userEvent.click(screen.getByText('Pick Ragavan'))
+    await waitFor(() => expect(screen.getByTestId('form-panel')).toBeInTheDocument())
+    expect(screen.getByTestId('form-panel').dataset.title).toMatch(/Ragavan/)
+  })
+
+  it('calls createListing when the form is submitted', async () => {
+    render(<ListingsNewPage />)
+    await waitFor(() => screen.getByTestId('card-picker'))
+    await userEvent.click(screen.getByText('Pick Ragavan'))
+    await waitFor(() => screen.getByTestId('form-panel'))
+    await userEvent.click(screen.getByRole('button', { name: /create listing/i }))
+    expect(mockCreateListing).toHaveBeenCalledOnce()
+  })
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+cd src/frontend && npm test -- listings.new.test
+```
+
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create `listings_.new.tsx`**
+
+```tsx
+// src/frontend/src/routes/listings_.new.tsx
+import { useState, useEffect } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { AppShell } from '../components/layout/AppShell'
+import { TopBar } from '../components/layout/TopBar'
+import { CardPicker } from '../features/ebay/components/CardPicker'
+import {
+  ListingFormPanel,
+  type ListingFormValues,
+} from '../features/ebay/components/ListingFormPanel'
+import { fetchUserApps, createListing, type EbayAppSummary } from '../features/ebay/api'
+import type { CardSummary } from '../features/cards/types'
+import styles from './ListingsNew.module.css'
+
+export const Route = createFileRoute('/listings/new')({
+  component: ListingsNewPage,
+})
+
+export { ListingsNewPage }
+
+function ListingsNewPage() {
+  const navigate = useNavigate()
+  const [apps, setApps] = useState<EbayAppSummary[]>([])
+  const [selectedCard, setSelectedCard] = useState<CardSummary | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchUserApps()
+      .then((all) => setApps(all.filter((a) => a.environment === 'PRODUCTION')))
+      .catch(() => setApps([]))
+  }, [])
+
+  async function handleCreate(values: ListingFormValues, appCode: string) {
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      await createListing(appCode, {
+        title: values.title,
+        startPrice: { currency: 'AUD', value: values.price },
+        quantity: values.quantity,
+        conditionID: values.conditionId,
+        ...(values.description ? { description: values.description } : {}),
+      })
+      navigate({ to: '/listings' })
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to create listing')
+      setIsSaving(false)
+    }
+  }
+
+  const initialTitle = selectedCard
+    ? `${selectedCard.card_name} [${selectedCard.set_code.toUpperCase()}]`
+    : ''
+
+  return (
+    <AppShell active="listings">
+      <TopBar title="New listing" breadcrumb="LISTINGS › NEW" />
+      <div className={styles.layout}>
+        <CardPicker onSelect={setSelectedCard} selectedId={selectedCard?.card_version_id} />
+        <div className={styles.formArea}>
+          {selectedCard ? (
+            <ListingFormPanel
+              mode="create"
+              initialValues={{
+                title: initialTitle,
+                price: 0,
+                quantity: 1,
+                conditionId: 3000,
+                description: '',
+              }}
+              availableApps={apps}
+              onSave={handleCreate}
+              onCancel={() => navigate({ to: '/listings' })}
+              isSaving={isSaving}
+              error={saveError}
+            />
+          ) : (
+            <div className={styles.emptyForm}>
+              <p>Search for a card to create a listing</p>
+            </div>
+          )}
+        </div>
+      </div>
+    </AppShell>
+  )
+}
+```
+
+- [ ] **Step 4: Create `ListingsNew.module.css`**
+
+```css
+/* src/frontend/src/routes/ListingsNew.module.css */
+.layout {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 0;
+  min-height: calc(100vh - 120px);
+  margin: 0 -36px;
+  border-top: 1px solid var(--hd-border);
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.formArea {
+  padding: 24px;
+  overflow-y: auto;
+}
+
+.emptyForm {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  min-height: 300px;
+  color: var(--hd-sub);
+  font-size: 14px;
+}
+```
+
+- [ ] **Step 5: Update the "New listing" button in `listings.tsx` to navigate**
+
+In `src/frontend/src/routes/listings.tsx`, the "New listing" button currently does nothing. Add a `useNavigate` import and wire it:
+
+First add the import at the top of the file:
+```tsx
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+```
+
+(If `useNavigate` is not already imported — check and add only if missing.)
+
+Inside `ListingsPage`, add:
+```tsx
+const navigate = useNavigate()
+```
+
+Then change the `<Button>` for "New listing":
+```tsx
+<Button
+  variant="accent"
+  size="sm"
+  icon={<Icon kind="plus" size={12} color="currentColor" />}
+  onClick={() => navigate({ to: '/listings/new' })}
+>
+  New listing
+</Button>
+```
+
+- [ ] **Step 6: Run all tests to verify the full suite passes**
+
+```bash
+cd src/frontend && npm test
+```
+
+Expected: PASS — all tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/frontend/src/routes/listings_.new.tsx \
+        src/frontend/src/routes/ListingsNew.module.css \
+        src/frontend/src/routes/__tests__/listings.new.test.tsx \
+        src/frontend/src/routes/listings.tsx
+git commit -m "feat(ebay): add /listings/new create listing page"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ Create flow at `/listings/new` — Task 9
+- ✅ Edit flow inline on `/listings` (row click → panel) — Tasks 5, 6
+- ✅ Shared `ListingFormPanel` — Task 4
+- ✅ Read-only `ListingDetailPanel` — Task 3
+- ✅ `createListing` + `updateListing` API functions — Task 1
+- ✅ `updateListing` Zustand action — Task 2
+- ✅ `ListingsTable` row selection — Task 5
+- ✅ `SearchResults` `onSelect` mode — Task 7
+- ✅ `CardPicker` for left panel — Task 8
+- ✅ "New listing" button wired to navigate — Task 9, Step 5
+- ✅ Condition IDs match backend mapping (NM→3000, LP→4000, MP→5000, HP→6000, DMG→7000)
+
+**Placeholder scan:** No TBD/TODO/vague steps present.
+
+**Type consistency:**
+- `ListingFormValues` defined in Task 4 and imported in Tasks 6 and 9 ✅
+- `ListingItemPayload` defined in Task 1 and used in Tasks 6 and 9 ✅
+- `onSave: (values: ListingFormValues, appCode: string) => Promise<void>` consistent across Tasks 4, 6, 9 ✅
+- `onRowClick?: (id: string) => void` defined in Task 5 and wired in Task 6 ✅

--- a/docs/superpowers/specs/2026-05-09-create-edit-listing-design.md
+++ b/docs/superpowers/specs/2026-05-09-create-edit-listing-design.md
@@ -1,0 +1,165 @@
+# Create & Edit eBay Listing — Design Spec
+
+**Date:** 2026-05-09  
+**Status:** Approved  
+**Scope:** Frontend only — backend endpoints and services are already implemented.
+
+---
+
+## Goal
+
+Give sellers a fluid way to create new eBay listings and reprice/edit existing ones without leaving the listings view. Both flows share the same split-panel layout pattern used by the card search page.
+
+---
+
+## User flows
+
+### Create (`/listings/new`)
+
+1. Seller clicks "New listing" in the listings page top bar → navigates to `/listings/new`.
+2. Two-column layout: **left** = card catalog search (filters + card grid), **right** = blank listing form.
+3. Seller searches for a card and selects one from the left column.
+4. Right panel pre-fills: Title (`<CardName> [<SET>]`), card image thumbnail.
+5. Seller sets Price (AUD), Qty, Condition, optionally edits Title / Description, selects app.
+6. "Create listing" → `POST /api/v1/integrations/ebay/listing?app_code=<code>` with a client-generated idempotency key (`crypto.randomUUID()`).
+7. Success → navigate back to `/listings` with a success toast.
+8. Error → inline error message; form stays open.
+
+### Edit (inline on `/listings`)
+
+1. Seller clicks a row in the listings table — no page navigation occurs.
+2. The page layout shifts to two columns: **left** = narrowed listings table, **right** = `ListingDetailPanel`.
+3. Detail panel shows read-only data: card image, name, set, condition, price, qty, watchers, days listed, app badge.
+4. Seller clicks "Edit listing" → right panel content swaps to `ListingFormPanel` in edit mode, pre-filled from the Zustand store entry.
+5. "Save changes" → `PUT /api/v1/integrations/ebay/listing/<item_id>?app_code=<code>`.
+6. Success → panel returns to read-only view with updated values; Zustand store entry updated.
+7. Error → inline error inside the panel; form stays open.
+8. "Cancel" → returns to read-only detail panel.
+9. Clicking the × close button (or another row) → panel closes; table returns to full width.
+
+---
+
+## Architecture
+
+### Shared component: `ListingFormPanel`
+
+```
+features/ebay/components/ListingFormPanel.tsx
+
+props:
+  mode: 'create' | 'edit'
+  initialValues: Partial<ListingFormValues>
+  appCode?: string          // pre-selected in edit mode
+  availableApps: EbayAppSummary[]
+  onSave: (values: ListingFormValues) => Promise<void>
+  onCancel: () => void
+  isSaving: boolean
+  error: string | null
+```
+
+**Form fields:**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| Title | text input | Max 80 chars (eBay limit). Auto-filled on create. |
+| Price | number input | AUD, two decimal places, min 0.01 |
+| Quantity | integer input | Min 1 |
+| Condition | dropdown | NM / LP / MP / HP / DMG mapped to eBay condition IDs |
+| Description | textarea | Optional. Max 500 chars for the short form. |
+| App | dropdown | Production apps only. Hidden in edit mode (app is fixed). |
+
+**Condition → eBay condition ID mapping (Trading Card category):**
+
+| Label | eBay Condition ID |
+|-------|-------------------|
+| Near Mint (NM) | 3000 |
+| Lightly Played (LP) | 4000 |
+| Moderately Played (MP) | 5000 |
+| Heavily Played (HP) | 6000 |
+| Damaged (DMG) | 7000 |
+
+### Read-only panel: `ListingDetailPanel`
+
+```
+features/ebay/components/ListingDetailPanel.tsx
+
+props:
+  listing: EbayLiveListing
+  onEdit: () => void
+  onClose: () => void
+```
+
+Shows: card image (thumbnail), card name, set code, condition label, AUD price, quantity available, watchers, days listed, app badge, eBay item ID, link to view on eBay.
+
+---
+
+## File map
+
+### New files
+
+| Path | Purpose |
+|------|---------|
+| `routes/listings_.new.tsx` | Create listing page |
+| `routes/ListingsNew.module.css` | Two-column grid layout for create page |
+| `features/ebay/components/ListingFormPanel.tsx` | Shared create/edit form |
+| `features/ebay/components/ListingDetailPanel.tsx` | Read-only detail panel |
+| `features/ebay/components/ListingFormPanel.module.css` | Form styles |
+| `features/ebay/components/ListingDetailPanel.module.css` | Detail panel styles |
+
+### Modified files
+
+| Path | Change |
+|------|--------|
+| `routes/listings.tsx` | Add `selectedId` + `panelMode` state; two-column layout when row selected; render `ListingDetailPanel` or `ListingFormPanel` on right |
+| `routes/Listings.module.css` | Add `.pageWithPanel` grid variant (`1fr 400px`) |
+| `features/ebay/components/ListingsTable.tsx` | Accept `selectedId?: string` + `onRowClick?: (id: string) => void`; highlight selected row |
+| `features/ebay/api.ts` | Add `createListing()` and `updateListing()` |
+| `features/cards/components/SearchResults.tsx` | Accept optional `onSelect?: (card: CardSummary) => void`; if provided, call it on click instead of navigating |
+
+---
+
+## API calls (frontend)
+
+```ts
+// Create
+POST /api/v1/integrations/ebay/listing?app_code=<code>
+Header: Idempotency-Key: <uuid>
+Body: ItemModel (Title, StartPrice, Quantity, ConditionID, Description)
+
+// Update
+PUT /api/v1/integrations/ebay/listing/<item_id>?app_code=<code>
+Body: ItemModel (ItemID + changed fields)
+```
+
+Both are already implemented in the backend. No backend changes required.
+
+---
+
+## State management
+
+- `listings.tsx` holds `selectedId: string | null` and `panelMode: 'detail' | 'edit'` in local `useState`.
+- The Zustand `listingsStore` already holds all loaded listings. The edit panel reads from the store by `selectedId`.
+- After a successful update, the store entry for the edited listing is updated in place so the table reflects the new values without a full refetch.
+- After a successful create, navigate to `/listings` — the listings page will re-fetch on mount.
+
+---
+
+## Error handling
+
+| Scenario | Behaviour |
+|----------|-----------|
+| Create fails (eBay API error) | Inline error below the form submit button; form stays open |
+| Update fails | Inline error inside the detail panel; edit form stays open |
+| App has no production token | Disable "Create listing" / "Save changes"; show "App not connected" message |
+| Card not found in store (direct URL to edit) | Not applicable — edit is inline only, always triggered from a loaded row |
+| `SearchResults` card fetch fails | Existing empty-state handling in `SearchResults` covers this |
+
+---
+
+## Testing
+
+- Unit tests for `ListingFormPanel`: field validation (price > 0, title max length, qty ≥ 1), correct payload construction, cancel callback.
+- Unit tests for `ListingDetailPanel`: renders all fields, edit button calls `onEdit`, close button calls `onClose`.
+- Unit tests for modified `ListingsTable`: `onRowClick` fires with correct item ID, selected row gets highlight class.
+- Integration test for the create flow: select card → fill form → submit → assert `POST` called with correct body and idempotency key.
+- Integration test for the edit flow: click row → detail panel appears → click Edit → form pre-filled → submit → assert `PUT` called with correct body.

--- a/src/frontend/src/features/cards/components/SearchResults.module.css
+++ b/src/frontend/src/features/cards/components/SearchResults.module.css
@@ -12,3 +12,4 @@
 .price { font-size: 11px; font-family: var(--font-mono); }
 .up { color: var(--hd-accent); } .down { color: var(--hd-red); }
 .loading { text-align: center; padding: 24px; color: var(--hd-text-secondary); font-size: 12px; }
+.cardSelected { outline: 2px solid var(--hd-accent); outline-offset: -2px; }

--- a/src/frontend/src/features/cards/components/SearchResults.tsx
+++ b/src/frontend/src/features/cards/components/SearchResults.tsx
@@ -12,6 +12,8 @@ interface SearchResultsProps {
   fetchNextPage: () => void
   hasNextPage?: boolean
   isFetchingNextPage?: boolean
+  onSelect?: (card: CardSummary) => void
+  selectedId?: string
 }
 
 export function SearchResults({
@@ -20,6 +22,8 @@ export function SearchResults({
   fetchNextPage,
   hasNextPage,
   isFetchingNextPage,
+  onSelect,
+  selectedId,
 }: SearchResultsProps) {
   const navigate = useNavigate()
   const lastCardRef = useRef<HTMLButtonElement>(null)
@@ -54,8 +58,15 @@ export function SearchResults({
             <button
               key={card.card_version_id}
               ref={isLastCard ? lastCardRef : null}
-              className={styles.card}
-              onClick={() => navigate({ to: '/cards/$id', params: { id: card.card_version_id } })}
+              className={[
+                styles.card,
+                card.card_version_id === selectedId ? styles.cardSelected : '',
+              ].filter(Boolean).join(' ')}
+              onClick={() =>
+                onSelect
+                  ? onSelect(card)
+                  : navigate({ to: '/cards/$id', params: { id: card.card_version_id } })
+              }
             >
               <CardArt
                 name={card.card_name}

--- a/src/frontend/src/features/ebay/__tests__/api.listing.test.ts
+++ b/src/frontend/src/features/ebay/__tests__/api.listing.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createListing, updateListing } from '../api'
+
+vi.mock('../../../lib/apiClient', () => ({
+  apiClient: vi.fn(),
+}))
+
+import { apiClient } from '../../../lib/apiClient'
+const mockApiClient = vi.mocked(apiClient)
+
+beforeEach(() => {
+  mockApiClient.mockReset()
+  // crypto.randomUUID is available in jsdom via vitest
+})
+
+describe('createListing', () => {
+  it('POSTs to the correct URL with Idempotency-Key header', async () => {
+    mockApiClient.mockResolvedValueOnce(undefined)
+
+    await createListing('automana_au', {
+      title: 'Ragavan NM MTG',
+      startPrice: { currency: 'AUD', value: 12.5 },
+      quantity: 1,
+      conditionID: 3000,
+    })
+
+    expect(mockApiClient).toHaveBeenCalledOnce()
+    const [url, opts] = mockApiClient.mock.calls[0] as [string, RequestInit & { headers: Record<string, string> }]
+    expect(url).toBe('/integrations/ebay/listing/?app_code=automana_au')
+    expect(opts.method).toBe('POST')
+    expect(opts.headers['Idempotency-Key']).toMatch(/^[0-9a-f-]{36}$/)
+    const body = JSON.parse(opts.body as string)
+    expect(body.title).toBe('Ragavan NM MTG')
+    expect(body.startPrice).toEqual({ currency: 'AUD', value: 12.5 })
+    expect(body.quantity).toBe(1)
+    expect(body.conditionID).toBe(3000)
+  })
+
+  it('includes description when provided', async () => {
+    mockApiClient.mockResolvedValueOnce(undefined)
+
+    await createListing('automana_au', {
+      title: 'Test',
+      startPrice: { currency: 'AUD', value: 5 },
+      quantity: 2,
+      conditionID: 4000,
+      description: 'Lightly played card',
+    })
+
+    const [, opts] = mockApiClient.mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(opts.body as string)
+    expect(body.description).toBe('Lightly played card')
+  })
+})
+
+describe('updateListing', () => {
+  it('PUTs to the correct URL with itemID in the body', async () => {
+    mockApiClient.mockResolvedValueOnce(undefined)
+
+    await updateListing('automana_au', '123456789', {
+      title: 'Sheoldred NM MTG',
+      startPrice: { currency: 'AUD', value: 55 },
+      quantity: 1,
+      conditionID: 3000,
+    })
+
+    expect(mockApiClient).toHaveBeenCalledOnce()
+    const [url, opts] = mockApiClient.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/integrations/ebay/listing/123456789?app_code=automana_au')
+    expect(opts.method).toBe('PUT')
+    const body = JSON.parse(opts.body as string)
+    expect(body.itemID).toBe('123456789')
+    expect(body.title).toBe('Sheoldred NM MTG')
+    expect(body.startPrice).toEqual({ currency: 'AUD', value: 55 })
+  })
+})

--- a/src/frontend/src/features/ebay/api.ts
+++ b/src/frontend/src/features/ebay/api.ts
@@ -251,3 +251,41 @@ export async function fetchActiveListingsPaginated(
     hasMore,
   }
 }
+
+// ── Listing writes ─────────────────────────────────────────────────────────
+
+export interface ListingItemPayload {
+  title: string
+  startPrice: { currency: string; value: number }
+  quantity: number
+  conditionID: number
+  description?: string
+}
+
+export async function createListing(
+  appCode: string,
+  item: ListingItemPayload,
+): Promise<void> {
+  await apiClient<unknown>(
+    `/integrations/ebay/listing/?app_code=${encodeURIComponent(appCode)}`,
+    {
+      method: 'POST',
+      headers: { 'Idempotency-Key': crypto.randomUUID() },
+      body: JSON.stringify(item),
+    },
+  )
+}
+
+export async function updateListing(
+  appCode: string,
+  itemId: string,
+  item: ListingItemPayload,
+): Promise<void> {
+  await apiClient<unknown>(
+    `/integrations/ebay/listing/${encodeURIComponent(itemId)}?app_code=${encodeURIComponent(appCode)}`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({ itemID: itemId, ...item }),
+    },
+  )
+}

--- a/src/frontend/src/features/ebay/api.ts
+++ b/src/frontend/src/features/ebay/api.ts
@@ -110,6 +110,7 @@ interface RawEbayItem {
   conditionDisplayName?: string | null
   pictureDetails?: { GalleryURL?: string | string[] } | null
   listingDetails?: { viewItemUrl?: string | null; startTime?: string | null } | null
+  quantity?: number | null
   itemSpecifics?: {
     NameValueList?:
       | Array<{ Name: string; Value: string | string[] }>
@@ -199,6 +200,7 @@ function mapToLiveListing(raw: RawEbayItem): Omit<EbayLiveListing, 'appCode' | '
       raw.conditionDescription ??
       ebayConditionLabel(raw.conditionID),
     conditionId: raw.conditionID ?? undefined,
+    quantity: raw.quantity ?? undefined,
     // ItemSpecifics is the primary source; fall back to title-extracted value.
     finish: getFinish(raw.itemSpecifics) || titleFinish || 'Regular',
     style: getStyle(raw.itemSpecifics) || titleStyle,

--- a/src/frontend/src/features/ebay/api.ts
+++ b/src/frontend/src/features/ebay/api.ts
@@ -198,6 +198,7 @@ function mapToLiveListing(raw: RawEbayItem): Omit<EbayLiveListing, 'appCode' | '
       raw.conditionDisplayName ??
       raw.conditionDescription ??
       ebayConditionLabel(raw.conditionID),
+    conditionId: raw.conditionID ?? undefined,
     // ItemSpecifics is the primary source; fall back to title-extracted value.
     finish: getFinish(raw.itemSpecifics) || titleFinish || 'Regular',
     style: getStyle(raw.itemSpecifics) || titleStyle,

--- a/src/frontend/src/features/ebay/components/CardPicker.module.css
+++ b/src/frontend/src/features/ebay/components/CardPicker.module.css
@@ -2,7 +2,6 @@
 .picker {
   display: flex;
   flex-direction: column;
-  gap: 0;
   height: 100%;
   overflow: hidden;
   border-right: 1px solid var(--hd-border);

--- a/src/frontend/src/features/ebay/components/CardPicker.module.css
+++ b/src/frontend/src/features/ebay/components/CardPicker.module.css
@@ -1,0 +1,39 @@
+/* src/frontend/src/features/ebay/components/CardPicker.module.css */
+.picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  height: 100%;
+  overflow: hidden;
+  border-right: 1px solid var(--hd-border);
+}
+
+.searchBar {
+  padding: 16px;
+  border-bottom: 1px solid var(--hd-border);
+  background: var(--hd-surface);
+}
+
+.searchInput {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--hd-bg);
+  border: 1px solid var(--hd-border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--hd-text);
+  font-family: var(--font-sans);
+  transition: border-color 0.12s;
+}
+.searchInput:focus {
+  outline: none;
+  border-color: var(--hd-accent);
+}
+
+.loading {
+  padding: 24px;
+  font-size: 13px;
+  color: var(--hd-muted);
+  text-align: center;
+}

--- a/src/frontend/src/features/ebay/components/CardPicker.tsx
+++ b/src/frontend/src/features/ebay/components/CardPicker.tsx
@@ -1,0 +1,50 @@
+// src/frontend/src/features/ebay/components/CardPicker.tsx
+import { useState } from 'react'
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { cardInfiniteSearchQueryOptions } from '../../cards/api'
+import { SearchResults } from '../../cards/components/SearchResults'
+import type { CardSummary } from '../../cards/types'
+import styles from './CardPicker.module.css'
+
+interface CardPickerProps {
+  onSelect: (card: CardSummary) => void
+  selectedId: string | undefined
+}
+
+export function CardPicker({ onSelect, selectedId }: CardPickerProps) {
+  const [q, setQ] = useState('')
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
+    useInfiniteQuery(cardInfiniteSearchQueryOptions({ q: q || undefined }))
+
+  const cards = data?.pages.flatMap((p) => p.cards) ?? []
+  const total = data?.pages[0]?.pagination?.total_count ?? cards.length
+
+  return (
+    <div className={styles.picker}>
+      <div className={styles.searchBar}>
+        <input
+          type="text"
+          className={styles.searchInput}
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+          placeholder="Search cards…"
+          aria-label="Search cards"
+        />
+      </div>
+      {isLoading ? (
+        <div className={styles.loading}>Loading…</div>
+      ) : (
+        <SearchResults
+          cards={cards}
+          total={total}
+          fetchNextPage={fetchNextPage}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          onSelect={onSelect}
+          selectedId={selectedId}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/frontend/src/features/ebay/components/CardPicker.tsx
+++ b/src/frontend/src/features/ebay/components/CardPicker.tsx
@@ -1,5 +1,5 @@
 // src/frontend/src/features/ebay/components/CardPicker.tsx
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { cardInfiniteSearchQueryOptions } from '../../cards/api'
 import { SearchResults } from '../../cards/components/SearchResults'
@@ -13,9 +13,15 @@ interface CardPickerProps {
 
 export function CardPicker({ onSelect, selectedId }: CardPickerProps) {
   const [q, setQ] = useState('')
+  const [debouncedQ, setDebouncedQ] = useState('')
+
+  useEffect(() => {
+    const id = setTimeout(() => setDebouncedQ(q), 300)
+    return () => clearTimeout(id)
+  }, [q])
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useInfiniteQuery(cardInfiniteSearchQueryOptions({ q: q || undefined }))
+    useInfiniteQuery(cardInfiniteSearchQueryOptions({ q: debouncedQ || undefined }))
 
   const cards = data?.pages.flatMap((p) => p.cards) ?? []
   const total = data?.pages[0]?.pagination?.total_count ?? cards.length

--- a/src/frontend/src/features/ebay/components/ListingDetailPanel.module.css
+++ b/src/frontend/src/features/ebay/components/ListingDetailPanel.module.css
@@ -1,0 +1,138 @@
+/* src/frontend/src/features/ebay/components/ListingDetailPanel.module.css */
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  padding: 20px;
+  position: sticky;
+  top: 24px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--hd-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.closeBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--hd-muted);
+  cursor: pointer;
+  padding: 4px;
+  border-radius: 4px;
+  flex-shrink: 0;
+  transition: color 0.1s;
+}
+.closeBtn:hover { color: var(--hd-text); }
+
+.image {
+  width: 100%;
+  border-radius: 8px;
+  object-fit: contain;
+  max-height: 180px;
+}
+
+.imagePlaceholder {
+  width: 100%;
+  aspect-ratio: 5 / 7;
+  max-height: 180px;
+  background: var(--hd-surface-alt);
+  border: 1px solid var(--hd-border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+
+.placeholderName {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--hd-text);
+  text-align: center;
+  padding: 0 8px;
+}
+
+.placeholderSet {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  white-space: nowrap;
+}
+
+.value {
+  font-size: 12px;
+  color: var(--hd-text);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.valueAccent {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--hd-accent);
+  text-align: right;
+}
+
+.link {
+  font-size: 12px;
+  color: var(--hd-accent);
+  text-decoration: none;
+}
+.link:hover { text-decoration: underline; }
+
+.editBtn {
+  width: 100%;
+  padding: 10px 16px;
+  background: var(--hd-accent);
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+.editBtn:hover { opacity: 0.88; }

--- a/src/frontend/src/features/ebay/components/ListingDetailPanel.tsx
+++ b/src/frontend/src/features/ebay/components/ListingDetailPanel.tsx
@@ -1,0 +1,70 @@
+// src/frontend/src/features/ebay/components/ListingDetailPanel.tsx
+import { Icon } from '../../../components/design-system/Icon'
+import type { EbayLiveListing } from '../mockListings'
+import styles from './ListingDetailPanel.module.css'
+
+interface ListingDetailPanelProps {
+  listing: EbayLiveListing
+  onEdit: () => void
+  onClose: () => void
+}
+
+export function ListingDetailPanel({ listing, onEdit, onClose }: ListingDetailPanelProps) {
+  return (
+    <div className={styles.panel}>
+      <div className={styles.header}>
+        <span className={styles.title}>{listing.cardName}</span>
+        <button onClick={onClose} className={styles.closeBtn} aria-label="Close panel">
+          <Icon kind="close" size={14} color="currentColor" />
+        </button>
+      </div>
+
+      {listing.imageUrl ? (
+        <img src={listing.imageUrl} alt={listing.cardName} className={styles.image} />
+      ) : (
+        <div className={styles.imagePlaceholder}>
+          <span className={styles.placeholderSet}>{listing.setCode}</span>
+        </div>
+      )}
+
+      <div className={styles.fields}>
+        {[
+          { label: 'Set', value: listing.setCode || '—' },
+          { label: 'Condition', value: listing.conditionLabel || '—' },
+          { label: 'Days listed', value: listing.daysListed > 0 ? `${listing.daysListed}d` : '—' },
+          { label: 'App', value: listing.appName || listing.appCode },
+        ].map(({ label, value }) => (
+          <div key={label} className={styles.row}>
+            <span className={styles.label}>{label}</span>
+            <span className={styles.value}>{value}</span>
+          </div>
+        ))}
+        <div className={styles.row}>
+          <span className={styles.label}>Price</span>
+          <span className={styles.valueAccent}>
+            {listing.currency} {listing.price.toFixed(2)}
+          </span>
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>Watchers</span>
+          <span className={styles.value}>{listing.watchCount}</span>
+        </div>
+        <div className={styles.row}>
+          <span className={styles.label}>eBay</span>
+          <a
+            href={listing.viewItemUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.link}
+          >
+            View ↗
+          </a>
+        </div>
+      </div>
+
+      <button onClick={onEdit} className={styles.editBtn}>
+        Edit listing
+      </button>
+    </div>
+  )
+}

--- a/src/frontend/src/features/ebay/components/ListingFormPanel.module.css
+++ b/src/frontend/src/features/ebay/components/ListingFormPanel.module.css
@@ -1,0 +1,129 @@
+/* src/frontend/src/features/ebay/components/ListingFormPanel.module.css */
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border);
+  border-radius: 12px;
+  padding: 20px;
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.title {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--hd-text);
+}
+
+.fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: 1fr 80px;
+  gap: 10px;
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+.input,
+.select,
+.textarea {
+  background: var(--hd-bg);
+  border: 1px solid var(--hd-border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-size: 13px;
+  color: var(--hd-text);
+  font-family: var(--font-sans);
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.12s;
+}
+
+.input:focus,
+.select:focus,
+.textarea:focus {
+  outline: none;
+  border-color: var(--hd-accent);
+}
+
+.inputSmall {
+  composes: input;
+  text-align: center;
+}
+
+.textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.error {
+  padding: 8px 12px;
+  background: rgba(227, 94, 108, 0.08);
+  border: 1px solid rgba(227, 94, 108, 0.25);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--hd-red);
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.cancelBtn {
+  padding: 8px 16px;
+  background: transparent;
+  border: 1px solid var(--hd-border);
+  border-radius: 6px;
+  font-size: 13px;
+  color: var(--hd-muted);
+  cursor: pointer;
+  transition: color 0.1s, border-color 0.1s;
+}
+.cancelBtn:hover {
+  color: var(--hd-text);
+  border-color: var(--hd-text);
+}
+
+.saveBtn {
+  padding: 8px 18px;
+  background: var(--hd-accent);
+  border: none;
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #fff;
+  cursor: pointer;
+  transition: opacity 0.12s;
+}
+.saveBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.saveBtn:not(:disabled):hover {
+  opacity: 0.88;
+}

--- a/src/frontend/src/features/ebay/components/ListingFormPanel.tsx
+++ b/src/frontend/src/features/ebay/components/ListingFormPanel.tsx
@@ -1,0 +1,190 @@
+// src/frontend/src/features/ebay/components/ListingFormPanel.tsx
+import { useState } from 'react'
+import type { EbayAppSummary } from '../api'
+import styles from './ListingFormPanel.module.css'
+
+export interface ListingFormValues {
+  title: string
+  price: number
+  quantity: number
+  conditionId: number
+  description: string
+}
+
+const CONDITION_OPTIONS = [
+  { label: 'Near Mint (NM)', value: 3000 },
+  { label: 'Lightly Played (LP)', value: 4000 },
+  { label: 'Moderately Played (MP)', value: 5000 },
+  { label: 'Heavily Played (HP)', value: 6000 },
+  { label: 'Damaged (DMG)', value: 7000 },
+]
+
+interface ListingFormPanelProps {
+  mode: 'create' | 'edit'
+  initialValues: Partial<ListingFormValues>
+  availableApps: EbayAppSummary[]
+  appCode?: string
+  onSave: (values: ListingFormValues, appCode: string) => Promise<void>
+  onCancel: () => void
+  isSaving: boolean
+  error: string | null
+}
+
+export function ListingFormPanel({
+  mode,
+  initialValues,
+  availableApps,
+  appCode: fixedAppCode,
+  onSave,
+  onCancel,
+  isSaving,
+  error,
+}: ListingFormPanelProps) {
+  const [title, setTitle] = useState(initialValues.title ?? '')
+  const [price, setPrice] = useState(initialValues.price ?? 0)
+  const [quantity, setQuantity] = useState(initialValues.quantity ?? 1)
+  const [conditionId, setConditionId] = useState(initialValues.conditionId ?? 3000)
+  const [description, setDescription] = useState(initialValues.description ?? '')
+  const [selectedAppCode, setSelectedAppCode] = useState(
+    fixedAppCode ?? availableApps[0]?.app_code ?? '',
+  )
+  const [validationError, setValidationError] = useState<string | null>(null)
+
+  function validate(): boolean {
+    if (price <= 0) {
+      setValidationError('Price must be greater than 0')
+      return false
+    }
+    if (quantity < 1) {
+      setValidationError('Quantity must be at least 1')
+      return false
+    }
+    if (!title.trim()) {
+      setValidationError('Title is required')
+      return false
+    }
+    setValidationError(null)
+    return true
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validate()) return
+    await onSave(
+      { title: title.trim(), price, quantity, conditionId, description },
+      selectedAppCode,
+    )
+  }
+
+  const saveLabel = mode === 'create' ? 'Create listing' : 'Save changes'
+  const displayError = validationError ?? error
+
+  return (
+    <form onSubmit={handleSubmit} className={styles.form} noValidate>
+      <div className={styles.header}>
+        <span className={styles.title}>
+          {mode === 'create' ? 'New listing' : 'Edit listing'}
+        </span>
+      </div>
+
+      <div className={styles.fields}>
+        <label className={styles.field}>
+          <span className={styles.label}>Title</span>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={80}
+            className={styles.input}
+            placeholder="Card name + set + condition"
+          />
+        </label>
+
+        <div className={styles.row}>
+          <label className={styles.field}>
+            <span className={styles.label}>Price (AUD)</span>
+            <input
+              type="number"
+              value={price}
+              onChange={(e) => setPrice(Number(e.target.value))}
+              step="0.01"
+              min="0.01"
+              className={styles.input}
+            />
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.label}>Qty</span>
+            <input
+              type="number"
+              value={quantity}
+              onChange={(e) => setQuantity(Number(e.target.value))}
+              step="1"
+              min="1"
+              className={styles.inputSmall}
+            />
+          </label>
+        </div>
+
+        <label className={styles.field}>
+          <span className={styles.label}>Condition</span>
+          <select
+            value={conditionId}
+            onChange={(e) => setConditionId(Number(e.target.value))}
+            className={styles.select}
+          >
+            {CONDITION_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className={styles.field}>
+          <span className={styles.label}>Description (optional)</span>
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            maxLength={500}
+            rows={3}
+            className={styles.textarea}
+            placeholder="Any extra notes for the buyer"
+          />
+        </label>
+
+        {mode === 'create' && (
+          <label className={styles.field} aria-label="App">
+            <span className={styles.label}>App</span>
+            <select
+              value={selectedAppCode}
+              onChange={(e) => setSelectedAppCode(e.target.value)}
+              className={styles.select}
+            >
+              {availableApps.map((app) => (
+                <option key={app.app_code} value={app.app_code}>
+                  {app.app_name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+      </div>
+
+      {displayError && (
+        <div className={styles.error} role="alert">
+          {displayError}
+        </div>
+      )}
+
+      <div className={styles.actions}>
+        <button type="button" onClick={onCancel} className={styles.cancelBtn}>
+          Cancel
+        </button>
+        <button type="submit" disabled={isSaving} className={styles.saveBtn}>
+          {isSaving ? 'Saving…' : saveLabel}
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/frontend/src/features/ebay/components/ListingFormPanel.tsx
+++ b/src/frontend/src/features/ebay/components/ListingFormPanel.tsx
@@ -11,7 +11,7 @@ export interface ListingFormValues {
   description: string
 }
 
-const CONDITION_OPTIONS = [
+export const CONDITION_OPTIONS = [
   { label: 'Near Mint (NM)', value: 3000 },
   { label: 'Lightly Played (LP)', value: 4000 },
   { label: 'Moderately Played (MP)', value: 5000 },

--- a/src/frontend/src/features/ebay/components/ListingsTable.module.css
+++ b/src/frontend/src/features/ebay/components/ListingsTable.module.css
@@ -318,3 +318,10 @@
   50%  { opacity: 0.3; }
   100% { opacity: 0.6; }
 }
+
+.rowSelected {
+  background: rgba(var(--hd-accent-rgb), 0.07);
+}
+.rowSelected:hover {
+  background: rgba(var(--hd-accent-rgb), 0.11);
+}

--- a/src/frontend/src/features/ebay/components/ListingsTable.tsx
+++ b/src/frontend/src/features/ebay/components/ListingsTable.tsx
@@ -8,6 +8,8 @@ import styles from './ListingsTable.module.css'
 interface ListingsTableProps {
   listings: EbayLiveListing[]
   isLoading?: boolean
+  selectedId?: string
+  onRowClick?: (id: string) => void
 }
 
 type SortKey = 'cardName' | 'setCode' | 'appName' | 'conditionLabel' | 'finish' | 'style' | 'price' | 'daysListed' | 'watchCount'
@@ -24,7 +26,7 @@ function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
   )
 }
 
-export function ListingsTable({ listings, isLoading = false }: ListingsTableProps) {
+export function ListingsTable({ listings, isLoading = false, selectedId, onRowClick }: ListingsTableProps) {
   const [filter, setFilter] = useState('')
   const [sortKey, setSortKey] = useState<SortKey | null>(null)
   const [sortDir, setSortDir] = useState<SortDir>('asc')
@@ -165,7 +167,15 @@ export function ListingsTable({ listings, isLoading = false }: ListingsTableProp
             {!isLoading && visible.map((listing) => {
               const appColor = appColors[listing.appCode] ?? APP_PALETTE[0]
               return (
-                <tr key={listing.itemId} className={styles.row}>
+                <tr
+                  key={listing.itemId}
+                  className={[
+                    styles.row,
+                    listing.itemId === selectedId ? styles.rowSelected : '',
+                  ].filter(Boolean).join(' ')}
+                  onClick={() => onRowClick?.(listing.itemId)}
+                  style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                >
                   {/* Card name + thumbnail */}
                   <td>
                     <div className={styles.nameCell}>
@@ -178,19 +188,24 @@ export function ListingsTable({ listings, isLoading = false }: ListingsTableProp
                         />
                       )}
                       <div className={styles.nameText}>
-                        <Link
-                          to="/listings_/$id"
-                          params={{ id: listing.itemId }}
-                          className={styles.cardName}
-                        >
-                          {listing.cardName}
-                        </Link>
+                        {onRowClick ? (
+                          <span className={styles.cardName}>{listing.cardName}</span>
+                        ) : (
+                          <Link
+                            to="/listings_/$id"
+                            params={{ id: listing.itemId }}
+                            className={styles.cardName}
+                          >
+                            {listing.cardName}
+                          </Link>
+                        )}
                         <a
                           href={listing.viewItemUrl}
                           target="_blank"
                           rel="noopener noreferrer"
                           className={styles.ebayLink}
                           title="View on eBay"
+                          onClick={(e) => e.stopPropagation()}
                         >
                           eBay ↗
                         </a>

--- a/src/frontend/src/features/ebay/components/ListingsTable.tsx
+++ b/src/frontend/src/features/ebay/components/ListingsTable.tsx
@@ -175,6 +175,17 @@ export function ListingsTable({ listings, isLoading = false, selectedId, onRowCl
                   ].filter(Boolean).join(' ')}
                   onClick={() => onRowClick?.(listing.itemId)}
                   style={{ cursor: onRowClick ? 'pointer' : 'default' }}
+                  {...(onRowClick ? {
+                    tabIndex: 0,
+                    role: 'button',
+                    'aria-pressed': listing.itemId === selectedId,
+                    onKeyDown: (e: React.KeyboardEvent) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        onRowClick(listing.itemId)
+                      }
+                    },
+                  } : {})}
                 >
                   {/* Card name + thumbnail */}
                   <td>

--- a/src/frontend/src/features/ebay/components/ListingsTable.tsx
+++ b/src/frontend/src/features/ebay/components/ListingsTable.tsx
@@ -180,6 +180,7 @@ export function ListingsTable({ listings, isLoading = false, selectedId, onRowCl
                     role: 'button',
                     'aria-pressed': listing.itemId === selectedId,
                     onKeyDown: (e: React.KeyboardEvent) => {
+                      if (e.target !== e.currentTarget) return
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault()
                         onRowClick(listing.itemId)

--- a/src/frontend/src/features/ebay/components/__tests__/CardPicker.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/CardPicker.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import type { ReactNode } from 'react'
 import { CardPicker } from '../CardPicker'
 import type { CardSummary } from '../../../cards/types'
 
@@ -37,11 +38,13 @@ vi.mock('../../../cards/components/SearchResults', () => ({
   SearchResults: ({
     cards,
     onSelect,
+    selectedId,
   }: {
     cards: CardSummary[]
     onSelect?: (c: CardSummary) => void
+    selectedId?: string
   }) => (
-    <div data-testid="search-results">
+    <div data-testid="search-results" data-selected-id={selectedId ?? ''}>
       {cards.map((c) => (
         <button key={c.card_version_id} onClick={() => onSelect?.(c)}>
           {c.card_name}
@@ -51,7 +54,7 @@ vi.mock('../../../cards/components/SearchResults', () => ({
   ),
 }))
 
-function wrapper({ children }: { children: React.ReactNode }) {
+function wrapper({ children }: { children: ReactNode }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
   return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
 }
@@ -73,5 +76,11 @@ describe('CardPicker', () => {
     await waitFor(() => screen.getByText('Ragavan, Nimble Pilferer'))
     await userEvent.click(screen.getByText('Ragavan, Nimble Pilferer'))
     expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ card_version_id: 'cv1' }))
+  })
+
+  it('forwards selectedId to SearchResults', async () => {
+    render(<CardPicker onSelect={vi.fn()} selectedId="cv1" />, { wrapper })
+    await waitFor(() => expect(screen.getByTestId('search-results')).toBeInTheDocument())
+    expect(screen.getByTestId('search-results')).toHaveAttribute('data-selected-id', 'cv1')
   })
 })

--- a/src/frontend/src/features/ebay/components/__tests__/CardPicker.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/CardPicker.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { CardPicker } from '../CardPicker'
+import type { CardSummary } from '../../../cards/types'
+
+const mockCard: CardSummary = {
+  card_version_id: 'cv1',
+  card_name: 'Ragavan, Nimble Pilferer',
+  set_code: 'mh2',
+  set_name: 'Modern Horizons 2',
+  finish: 'non-foil',
+  rarity_name: 'mythic',
+  price: 60,
+  price_change_1d: 0,
+  price_change_7d: 0,
+  price_change_30d: 0,
+  image_uri: null,
+  image_normal: null,
+  spark: [],
+}
+
+vi.mock('../../../cards/api', () => ({
+  cardInfiniteSearchQueryOptions: (params: { q?: string }) => ({
+    queryKey: ['cards', 'search', params],
+    queryFn: async () => ({
+      cards: [mockCard],
+      pagination: { has_next: false, offset: 0, limit: 20, total_count: 1 },
+    }),
+    initialPageParam: 0,
+    getNextPageParam: () => undefined,
+  }),
+}))
+
+vi.mock('../../../cards/components/SearchResults', () => ({
+  SearchResults: ({
+    cards,
+    onSelect,
+  }: {
+    cards: CardSummary[]
+    onSelect?: (c: CardSummary) => void
+  }) => (
+    <div data-testid="search-results">
+      {cards.map((c) => (
+        <button key={c.card_version_id} onClick={() => onSelect?.(c)}>
+          {c.card_name}
+        </button>
+      ))}
+    </div>
+  ),
+}))
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+}
+
+describe('CardPicker', () => {
+  it('renders a search input', () => {
+    render(<CardPicker onSelect={vi.fn()} selectedId={undefined} />, { wrapper })
+    expect(screen.getByPlaceholderText(/search cards/i)).toBeInTheDocument()
+  })
+
+  it('shows search results', async () => {
+    render(<CardPicker onSelect={vi.fn()} selectedId={undefined} />, { wrapper })
+    await waitFor(() => expect(screen.getByTestId('search-results')).toBeInTheDocument())
+  })
+
+  it('calls onSelect with the clicked card', async () => {
+    const onSelect = vi.fn()
+    render(<CardPicker onSelect={onSelect} selectedId={undefined} />, { wrapper })
+    await waitFor(() => screen.getByText('Ragavan, Nimble Pilferer'))
+    await userEvent.click(screen.getByText('Ragavan, Nimble Pilferer'))
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ card_version_id: 'cv1' }))
+  })
+})

--- a/src/frontend/src/features/ebay/components/__tests__/ListingDetailPanel.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/ListingDetailPanel.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ListingDetailPanel } from '../ListingDetailPanel'
+import type { EbayLiveListing } from '../../mockListings'
+
+function makeListing(overrides: Partial<EbayLiveListing> = {}): EbayLiveListing {
+  return {
+    itemId: 'l1',
+    title: 'Sheoldred MOM NM MTG',
+    cardName: 'Sheoldred, the Apocalypse',
+    setCode: 'MOM',
+    setInfo: 'MOM',
+    price: 55,
+    currency: 'AUD',
+    conditionLabel: 'Near Mint (NM)',
+    finish: 'Regular',
+    style: '',
+    daysListed: 3,
+    watchCount: 7,
+    viewItemUrl: 'https://www.ebay.com.au/itm/l1',
+    imageUrl: null,
+    appCode: 'app1',
+    appName: 'AutoMana AU',
+    ...overrides,
+  }
+}
+
+describe('ListingDetailPanel', () => {
+  it('renders card name, price, condition, and watchers', () => {
+    render(
+      <ListingDetailPanel
+        listing={makeListing()}
+        onEdit={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Sheoldred, the Apocalypse')).toBeInTheDocument()
+    expect(screen.getByText(/55\.00/)).toBeInTheDocument()
+    expect(screen.getByText('Near Mint (NM)')).toBeInTheDocument()
+    expect(screen.getByText('7')).toBeInTheDocument()
+  })
+
+  it('calls onEdit when Edit listing button is clicked', async () => {
+    const onEdit = vi.fn()
+    render(<ListingDetailPanel listing={makeListing()} onEdit={onEdit} onClose={vi.fn()} />)
+    await userEvent.click(screen.getByRole('button', { name: /edit listing/i }))
+    expect(onEdit).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when close button is clicked', async () => {
+    const onClose = vi.fn()
+    render(<ListingDetailPanel listing={makeListing()} onEdit={vi.fn()} onClose={onClose} />)
+    await userEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows thumbnail when imageUrl is present', () => {
+    render(
+      <ListingDetailPanel
+        listing={makeListing({ imageUrl: 'https://example.com/img.jpg' })}
+        onEdit={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+    expect(screen.getByRole('img')).toHaveAttribute('src', 'https://example.com/img.jpg')
+  })
+
+  it('shows eBay link', () => {
+    render(<ListingDetailPanel listing={makeListing()} onEdit={vi.fn()} onClose={vi.fn()} />)
+    expect(screen.getByRole('link', { name: /view/i })).toHaveAttribute('href', 'https://www.ebay.com.au/itm/l1')
+  })
+})

--- a/src/frontend/src/features/ebay/components/__tests__/ListingFormPanel.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/ListingFormPanel.test.tsx
@@ -143,4 +143,25 @@ describe('ListingFormPanel', () => {
     expect(onSave).not.toHaveBeenCalled()
     expect(screen.getByText(/price must be greater than 0/i)).toBeInTheDocument()
   })
+
+  it('calls onSave with the selected app_code in create mode', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ListingFormPanel
+        mode="create"
+        initialValues={{ title: 'Ragavan MH2 NM', price: 62, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp(), makeApp({ app_code: 'app2', app_name: 'App 2' })]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: /app/i }), 'app2')
+    await userEvent.click(screen.getByRole('button', { name: /create/i }))
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Ragavan MH2 NM' }),
+      'app2',
+    )
+  })
 })

--- a/src/frontend/src/features/ebay/components/__tests__/ListingFormPanel.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/ListingFormPanel.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ListingFormPanel } from '../ListingFormPanel'
+import type { EbayAppSummary } from '../../api'
+
+function makeApp(overrides: Partial<EbayAppSummary> = {}): EbayAppSummary {
+  return {
+    app_id: 'a1',
+    app_name: 'AutoMana AU',
+    app_code: 'automana_au',
+    environment: 'PRODUCTION',
+    description: null,
+    is_active: true,
+    is_connected: true,
+    token_expires_at: null,
+    other_user_count: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ListingFormPanel', () => {
+  it('pre-fills fields from initialValues', () => {
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Sheoldred MOM NM', price: 55, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    expect(screen.getByDisplayValue('Sheoldred MOM NM')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('55')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('1')).toBeInTheDocument()
+  })
+
+  it('calls onCancel when Cancel is clicked', async () => {
+    const onCancel = vi.fn()
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Test', price: 10, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={onCancel}
+        isSaving={false}
+        error={null}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('calls onSave with current values when Save is clicked', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined)
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Ragavan MH2 NM', price: 62, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={onSave}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    expect(onSave).toHaveBeenCalledWith(
+      { title: 'Ragavan MH2 NM', price: 62, quantity: 1, conditionId: 3000, description: '' },
+      'automana_au',
+    )
+  })
+
+  it('shows error message when error prop is set', () => {
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Test', price: 10, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error="eBay API error: token expired"
+      />
+    )
+    expect(screen.getByText('eBay API error: token expired')).toBeInTheDocument()
+  })
+
+  it('disables Save button while isSaving', () => {
+    render(
+      <ListingFormPanel
+        mode="edit"
+        initialValues={{ title: 'Test', price: 10, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        appCode="automana_au"
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={true}
+        error={null}
+      />
+    )
+    expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled()
+  })
+
+  it('shows app dropdown in create mode', () => {
+    render(
+      <ListingFormPanel
+        mode="create"
+        initialValues={{}}
+        availableApps={[makeApp(), makeApp({ app_code: 'app2', app_name: 'App 2' })]}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    expect(screen.getByRole('combobox', { name: /app/i })).toBeInTheDocument()
+  })
+
+  it('validates price must be > 0 before calling onSave', async () => {
+    const onSave = vi.fn()
+    render(
+      <ListingFormPanel
+        mode="create"
+        initialValues={{ title: 'Test', price: 0, quantity: 1, conditionId: 3000, description: '' }}
+        availableApps={[makeApp()]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+        isSaving={false}
+        error={null}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /create/i }))
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.getByText(/price must be greater than 0/i)).toBeInTheDocument()
+  })
+})

--- a/src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
@@ -202,4 +202,13 @@ describe('ListingsTable — row selection', () => {
     await userEvent.click(screen.getByTitle('View on eBay'))
     expect(onRowClick).not.toHaveBeenCalled()
   })
+
+  it('pressing Enter on the eBay link does not fire onRowClick', async () => {
+    const onRowClick = vi.fn()
+    const listing = makeListing({ itemId: 'abc', viewItemUrl: 'https://www.ebay.com.au/itm/123' })
+    render(<ListingsTable listings={[listing]} onRowClick={onRowClick} />)
+    screen.getByTitle('View on eBay').focus()
+    await userEvent.keyboard('{Enter}')
+    expect(onRowClick).not.toHaveBeenCalled()
+  })
 })

--- a/src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi } from 'vitest'
 import { ListingsTable } from '../ListingsTable'
 import type { EbayLiveListing } from '../../mockListings'
@@ -148,5 +149,49 @@ describe('ListingsTable', () => {
     const cells = screen.getAllByText(/^\$\d+\.00$/)
     expect(cells[0].textContent).toBe('$100.00')
     expect(cells[1].textContent).toBe('$10.00')
+  })
+})
+
+describe('ListingsTable — row selection', () => {
+  it('calls onRowClick with the listing itemId when a row is clicked', async () => {
+    const onRowClick = vi.fn()
+    const listing = makeListing({ itemId: 'abc123' })
+    render(
+      <ListingsTable
+        listings={[listing]}
+        isLoading={false}
+        onRowClick={onRowClick}
+      />
+    )
+    const rows = document.querySelectorAll('tbody tr')
+    await userEvent.click(rows[0])
+    expect(onRowClick).toHaveBeenCalledWith('abc123')
+  })
+
+  it('adds a selected style class to the row matching selectedId', () => {
+    const listing = makeListing({ itemId: 'sel1' })
+    render(
+      <ListingsTable
+        listings={[listing]}
+        isLoading={false}
+        selectedId="sel1"
+        onRowClick={vi.fn()}
+      />
+    )
+    const rows = document.querySelectorAll('tbody tr')
+    expect(rows[0].className).toMatch(/rowSelected/)
+  })
+
+  it('renders card name as plain text (not a link) when onRowClick is provided', () => {
+    const listing = makeListing({ itemId: 'l1', cardName: 'Ragavan' })
+    render(
+      <ListingsTable
+        listings={[listing]}
+        isLoading={false}
+        onRowClick={vi.fn()}
+      />
+    )
+    expect(screen.queryByRole('link', { name: /ragavan/i })).toBeNull()
+    expect(screen.getByText('Ragavan')).toBeInTheDocument()
   })
 })

--- a/src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
@@ -194,4 +194,12 @@ describe('ListingsTable — row selection', () => {
     expect(screen.queryByRole('link', { name: /ragavan/i })).toBeNull()
     expect(screen.getByText('Ragavan')).toBeInTheDocument()
   })
+
+  it('clicking the eBay link does not fire onRowClick', async () => {
+    const onRowClick = vi.fn()
+    const listing = makeListing({ itemId: 'abc', viewItemUrl: 'https://www.ebay.com.au/itm/123' })
+    render(<ListingsTable listings={[listing]} onRowClick={onRowClick} />)
+    await userEvent.click(screen.getByTitle('View on eBay'))
+    expect(onRowClick).not.toHaveBeenCalled()
+  })
 })

--- a/src/frontend/src/features/ebay/mockListings.ts
+++ b/src/frontend/src/features/ebay/mockListings.ts
@@ -342,6 +342,7 @@ export interface EbayLiveListing {
   currency: string
   conditionLabel: string
   conditionId?: number
+  quantity?: number
   finish: string
   style: string
   daysListed: number

--- a/src/frontend/src/features/ebay/mockListings.ts
+++ b/src/frontend/src/features/ebay/mockListings.ts
@@ -341,6 +341,7 @@ export interface EbayLiveListing {
   price: number
   currency: string
   conditionLabel: string
+  conditionId?: number
   finish: string
   style: string
   daysListed: number

--- a/src/frontend/src/routes/Listings.module.css
+++ b/src/frontend/src/routes/Listings.module.css
@@ -370,3 +370,17 @@
 .errorBannerDismiss:hover {
   color: var(--hd-text);
 }
+
+/* ── Split-panel layout (active when a listing is selected) ─── */
+.withPanel {
+  display: grid;
+  grid-template-columns: 1fr 400px;
+  gap: 20px;
+  align-items: start;
+}
+
+@media (max-width: 1100px) {
+  .withPanel {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/frontend/src/routes/Listings.module.css
+++ b/src/frontend/src/routes/Listings.module.css
@@ -374,7 +374,7 @@
 /* ── Split-panel layout (active when a listing is selected) ─── */
 .withPanel {
   display: grid;
-  grid-template-columns: 1fr 400px;
+  grid-template-columns: 1fr clamp(280px, 30%, 400px);
   gap: 20px;
   align-items: start;
 }

--- a/src/frontend/src/routes/ListingsNew.module.css
+++ b/src/frontend/src/routes/ListingsNew.module.css
@@ -1,0 +1,30 @@
+/* src/frontend/src/routes/ListingsNew.module.css */
+
+.page {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  flex: 1;
+  overflow: hidden;
+  min-height: 0;
+}
+
+.formWrapper {
+  overflow-y: auto;
+  padding: 20px;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 14px;
+  color: var(--hd-muted);
+}

--- a/src/frontend/src/routes/__tests__/listings.new.test.tsx
+++ b/src/frontend/src/routes/__tests__/listings.new.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { CardSummary } from '../../features/cards/types'
 import type { ListingFormValues } from '../../features/ebay/components/ListingFormPanel'
+import type { EbayAppSummary } from '../../features/ebay/api'
 
 const mockNavigate = vi.fn()
 
@@ -55,18 +56,21 @@ vi.mock('../../features/ebay/components/ListingFormPanel', () => ({
     initialValues,
     isSaving,
     error,
+    availableApps,
   }: {
     onSave: (v: ListingFormValues, appCode: string) => Promise<void>
     onCancel: () => void
     initialValues: Partial<ListingFormValues>
     isSaving: boolean
     error: string | null
+    availableApps: EbayAppSummary[]
   }) => (
     <div
       data-testid="listing-form"
       data-title={initialValues.title ?? ''}
       data-saving={String(isSaving)}
       data-error={error ?? ''}
+      data-apps={availableApps.map((a) => a.app_code).join(',')}
     >
       <button
         onClick={() =>
@@ -84,7 +88,6 @@ vi.mock('../../features/ebay/components/ListingFormPanel', () => ({
 }))
 
 import { fetchUserApps, createListing } from '../../features/ebay/api'
-import type { EbayAppSummary } from '../../features/ebay/api'
 import { ListingsNewPage } from '../listings_.new'
 
 const mockFetchUserApps = vi.mocked(fetchUserApps)
@@ -180,17 +183,13 @@ describe('ListingsNewPage', () => {
   })
 
   it('only passes PRODUCTION apps to form', async () => {
-    const user = userEvent.setup()
     mockFetchUserApps.mockResolvedValue([
       makeApp({ environment: 'SANDBOX', app_code: 'sandbox_app', app_name: 'Sandbox App' }),
       makeApp({ environment: 'PRODUCTION', app_code: 'automana_au', app_name: 'AutoMana AU' }),
     ])
-    mockCreateListing.mockResolvedValue(undefined)
     render(<ListingsNewPage />)
     await waitFor(() => expect(screen.getByTestId('listing-form')).toBeInTheDocument())
-    await user.click(screen.getByRole('button', { name: 'Save' }))
-    await waitFor(() => {
-      expect(mockCreateListing).toHaveBeenCalled()
-    })
+    const form = screen.getByTestId('listing-form')
+    expect(form.getAttribute('data-apps')).toBe('automana_au')
   })
 })

--- a/src/frontend/src/routes/__tests__/listings.new.test.tsx
+++ b/src/frontend/src/routes/__tests__/listings.new.test.tsx
@@ -1,0 +1,196 @@
+// src/frontend/src/routes/__tests__/listings.new.test.tsx
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { CardSummary } from '../../features/cards/types'
+import type { ListingFormValues } from '../../features/ebay/components/ListingFormPanel'
+
+const mockNavigate = vi.fn()
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => () => ({ component: null }),
+  useNavigate: () => mockNavigate,
+}))
+
+vi.mock('../../features/ebay/api', () => ({
+  fetchUserApps: vi.fn(),
+  createListing: vi.fn(),
+}))
+
+const mockCard: CardSummary = {
+  card_version_id: 'cv1',
+  card_name: 'Ragavan, Nimble Pilferer',
+  set_code: 'mh2',
+  set_name: 'Modern Horizons 2',
+  finish: 'non-foil',
+  rarity_name: 'mythic',
+  price: 60,
+  price_change_1d: 0,
+  price_change_7d: 0,
+  price_change_30d: 0,
+  image_uri: null,
+  image_normal: null,
+  spark: [],
+}
+
+vi.mock('../../features/ebay/components/CardPicker', () => ({
+  CardPicker: ({ onSelect }: { onSelect: (c: CardSummary) => void }) => (
+    <button onClick={() => onSelect(mockCard)}>Pick card</button>
+  ),
+}))
+
+vi.mock('../../components/layout/AppShell', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('../../components/layout/TopBar', () => ({
+  TopBar: ({ title }: { title: string }) => <div data-testid="topbar">{title}</div>,
+}))
+
+vi.mock('../../features/ebay/components/ListingFormPanel', () => ({
+  ListingFormPanel: ({
+    onSave,
+    onCancel,
+    initialValues,
+    isSaving,
+    error,
+  }: {
+    onSave: (v: ListingFormValues, appCode: string) => Promise<void>
+    onCancel: () => void
+    initialValues: Partial<ListingFormValues>
+    isSaving: boolean
+    error: string | null
+  }) => (
+    <div
+      data-testid="listing-form"
+      data-title={initialValues.title ?? ''}
+      data-saving={String(isSaving)}
+      data-error={error ?? ''}
+    >
+      <button
+        onClick={() =>
+          onSave(
+            { title: 'Test', price: 10, quantity: 1, conditionId: 3000, description: '' },
+            'automana_au',
+          )
+        }
+      >
+        Save
+      </button>
+      <button onClick={onCancel}>Cancel</button>
+    </div>
+  ),
+}))
+
+import { fetchUserApps, createListing } from '../../features/ebay/api'
+import type { EbayAppSummary } from '../../features/ebay/api'
+import { ListingsNewPage } from '../listings_.new'
+
+const mockFetchUserApps = vi.mocked(fetchUserApps)
+const mockCreateListing = vi.mocked(createListing)
+
+function makeApp(overrides: Partial<EbayAppSummary> = {}): EbayAppSummary {
+  return {
+    app_id: 'app-1',
+    app_name: 'AutoMana AU',
+    app_code: 'automana_au',
+    environment: 'PRODUCTION',
+    description: null,
+    is_active: true,
+    is_connected: true,
+    token_expires_at: null,
+    other_user_count: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('ListingsNewPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear()
+    mockFetchUserApps.mockReset()
+    mockCreateListing.mockReset()
+  })
+
+  it('shows loading state while fetching apps', () => {
+    mockFetchUserApps.mockReturnValue(new Promise(() => {}))
+    render(<ListingsNewPage />)
+    expect(screen.getByTestId('loading')).toBeInTheDocument()
+  })
+
+  it('renders CardPicker and ListingFormPanel after apps load', async () => {
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    render(<ListingsNewPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Pick card')).toBeInTheDocument()
+      expect(screen.getByTestId('listing-form')).toBeInTheDocument()
+    })
+  })
+
+  it('pre-fills form title when a card is selected', async () => {
+    const user = userEvent.setup()
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    render(<ListingsNewPage />)
+    await waitFor(() => expect(screen.getByText('Pick card')).toBeInTheDocument())
+    await user.click(screen.getByText('Pick card'))
+    const form = screen.getByTestId('listing-form')
+    expect(form.getAttribute('data-title')).toBe('Ragavan, Nimble Pilferer MH2 NM MTG')
+  })
+
+  it('calls createListing and navigates to /listings on save', async () => {
+    const user = userEvent.setup()
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    mockCreateListing.mockResolvedValue(undefined)
+    render(<ListingsNewPage />)
+    await waitFor(() => expect(screen.getByTestId('listing-form')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => {
+      expect(mockCreateListing).toHaveBeenCalledWith('automana_au', {
+        title: 'Test',
+        startPrice: { currency: 'AUD', value: 10 },
+        quantity: 1,
+        conditionID: 3000,
+      })
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/listings' })
+    })
+  })
+
+  it('navigates to /listings on cancel', async () => {
+    const user = userEvent.setup()
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    render(<ListingsNewPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'Cancel' }))
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/listings' })
+  })
+
+  it('shows save error in form', async () => {
+    const user = userEvent.setup()
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    mockCreateListing.mockRejectedValue(new Error('eBay API error'))
+    render(<ListingsNewPage />)
+    await waitFor(() => expect(screen.getByTestId('listing-form')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => {
+      const form = screen.getByTestId('listing-form')
+      expect(form.getAttribute('data-error')).toBe('eBay API error')
+    })
+  })
+
+  it('only passes PRODUCTION apps to form', async () => {
+    const user = userEvent.setup()
+    mockFetchUserApps.mockResolvedValue([
+      makeApp({ environment: 'SANDBOX', app_code: 'sandbox_app', app_name: 'Sandbox App' }),
+      makeApp({ environment: 'PRODUCTION', app_code: 'automana_au', app_name: 'AutoMana AU' }),
+    ])
+    mockCreateListing.mockResolvedValue(undefined)
+    render(<ListingsNewPage />)
+    await waitFor(() => expect(screen.getByTestId('listing-form')).toBeInTheDocument())
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+    await waitFor(() => {
+      expect(mockCreateListing).toHaveBeenCalled()
+    })
+  })
+})

--- a/src/frontend/src/routes/__tests__/listings.test.tsx
+++ b/src/frontend/src/routes/__tests__/listings.test.tsx
@@ -76,6 +76,7 @@ vi.mock('../../features/ebay/components/ListingFormPanel', () => ({
 import { fetchUserApps, fetchActiveListingsPaginated } from '../../features/ebay/api'
 import type { EbayAppSummary } from '../../features/ebay/api'
 import type { EbayLiveListing } from '../../features/ebay/mockListings'
+import { useListingsStore } from '../../store/listings'
 import { ListingsPage } from '../listings'
 
 const mockFetchUserApps = vi.mocked(fetchUserApps)
@@ -127,6 +128,10 @@ function pagedResult(listings: EbayLiveListing[], hasMore = false) {
 function renderListingsPage() {
   return render(<ListingsPage />)
 }
+
+beforeEach(() => {
+  useListingsStore.setState({ listings: [] })
+})
 
 describe('ListingsPage Active tab', () => {
   beforeEach(() => {
@@ -258,7 +263,6 @@ describe('ListingsPage — split-panel edit', () => {
     render(<ListingsPage />)
     await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
 
-    const { useListingsStore } = await import('../../store/listings')
     useListingsStore.getState().setListings([makeListing({ itemId: 'l1', cardName: 'Ragavan' })])
 
     await userEvent.click(screen.getByTestId('listings-table'))
@@ -269,7 +273,6 @@ describe('ListingsPage — split-panel edit', () => {
     render(<ListingsPage />)
     await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
 
-    const { useListingsStore } = await import('../../store/listings')
     useListingsStore.getState().setListings([makeListing({ itemId: 'l1', cardName: 'Ragavan' })])
 
     await userEvent.click(screen.getByTestId('listings-table'))
@@ -282,7 +285,6 @@ describe('ListingsPage — split-panel edit', () => {
     render(<ListingsPage />)
     await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
 
-    const { useListingsStore } = await import('../../store/listings')
     useListingsStore.getState().setListings([makeListing({ itemId: 'l1', cardName: 'Ragavan' })])
 
     await userEvent.click(screen.getByTestId('listings-table'))

--- a/src/frontend/src/routes/__tests__/listings.test.tsx
+++ b/src/frontend/src/routes/__tests__/listings.test.tsx
@@ -3,10 +3,16 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import React from 'react'
 
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
 vi.mock('../../features/ebay/api', () => ({
   fetchUserApps: vi.fn(),
   fetchActiveListings: vi.fn(),
   fetchActiveListingsPaginated: vi.fn(),
+  updateListing: vi.fn(),
 }))
 
 vi.mock('../../features/ebay/lib/catalogEnrich', () => ({
@@ -22,13 +28,48 @@ vi.mock('../../components/layout/TopBar', () => ({
 }))
 
 vi.mock('../../features/ebay/components/ListingsTable', () => ({
-  ListingsTable: ({ listings, isLoading }: { listings: { appName: string }[]; isLoading?: boolean }) => (
+  ListingsTable: ({
+    listings,
+    isLoading,
+    onRowClick,
+  }: {
+    listings: { appName: string; itemId: string }[]
+    isLoading?: boolean
+    onRowClick?: (id: string) => void
+  }) => (
     <div
       data-testid="listings-table"
       data-loading={String(isLoading)}
       data-count={listings.length}
       data-app-names={listings.map((l) => l.appName).join(',')}
+      onClick={() => listings[0] && onRowClick?.(listings[0].itemId)}
     />
+  ),
+}))
+
+vi.mock('../../features/ebay/components/ListingDetailPanel', () => ({
+  ListingDetailPanel: ({
+    listing,
+    onEdit,
+    onClose,
+  }: {
+    listing: { cardName: string }
+    onEdit: () => void
+    onClose: () => void
+  }) => (
+    <div data-testid="detail-panel">
+      <span>{listing.cardName}</span>
+      <button onClick={onEdit}>Edit listing</button>
+      <button onClick={onClose}>Close panel</button>
+    </div>
+  ),
+}))
+
+vi.mock('../../features/ebay/components/ListingFormPanel', () => ({
+  ListingFormPanel: ({ onCancel }: { onCancel: () => void }) => (
+    <div data-testid="form-panel">
+      <button onClick={onCancel}>Cancel</button>
+    </div>
   ),
 }))
 
@@ -202,5 +243,52 @@ describe('ListingsPage Active tab', () => {
     await waitFor(() => {
       expect(mockFetchActiveListingsPaginated).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe('ListingsPage — split-panel edit', () => {
+  beforeEach(() => {
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    mockFetchActiveListingsPaginated.mockResolvedValue(
+      pagedResult([makeListing({ itemId: 'l1', cardName: 'Ragavan' })])
+    )
+  })
+
+  it('shows detail panel after clicking a row', async () => {
+    render(<ListingsPage />)
+    await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
+
+    const { useListingsStore } = await import('../../store/listings')
+    useListingsStore.getState().setListings([makeListing({ itemId: 'l1', cardName: 'Ragavan' })])
+
+    await userEvent.click(screen.getByTestId('listings-table'))
+    await waitFor(() => expect(screen.getByTestId('detail-panel')).toBeInTheDocument())
+  })
+
+  it('switches to form panel when Edit listing is clicked', async () => {
+    render(<ListingsPage />)
+    await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
+
+    const { useListingsStore } = await import('../../store/listings')
+    useListingsStore.getState().setListings([makeListing({ itemId: 'l1', cardName: 'Ragavan' })])
+
+    await userEvent.click(screen.getByTestId('listings-table'))
+    await waitFor(() => screen.getByTestId('detail-panel'))
+    await userEvent.click(screen.getByRole('button', { name: /edit listing/i }))
+    expect(screen.getByTestId('form-panel')).toBeInTheDocument()
+  })
+
+  it('returns to detail panel when Cancel is clicked in form', async () => {
+    render(<ListingsPage />)
+    await waitFor(() => expect(screen.getByTestId('listings-table')).toBeInTheDocument())
+
+    const { useListingsStore } = await import('../../store/listings')
+    useListingsStore.getState().setListings([makeListing({ itemId: 'l1', cardName: 'Ragavan' })])
+
+    await userEvent.click(screen.getByTestId('listings-table'))
+    await waitFor(() => screen.getByTestId('detail-panel'))
+    await userEvent.click(screen.getByRole('button', { name: /edit listing/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(screen.getByTestId('detail-panel')).toBeInTheDocument()
   })
 })

--- a/src/frontend/src/routes/listings.tsx
+++ b/src/frontend/src/routes/listings.tsx
@@ -175,7 +175,13 @@ export function ListingsPage() {
         conditionID: values.conditionId,
         ...(values.description ? { description: values.description } : {}),
       })
-      storeUpdateListing(selectedId, { price: values.price, title: values.title })
+      const patch = { price: values.price, title: values.title }
+      storeUpdateListing(selectedId, patch)
+      const updated = listingsRef.current.map((l) =>
+        l.itemId === selectedId ? { ...l, ...patch } : l
+      )
+      listingsRef.current = updated
+      setListings(updated)
       setPanelMode('detail')
     } catch (err) {
       setSaveError(err instanceof Error ? err.message : 'Failed to update listing')
@@ -295,7 +301,7 @@ export function ListingsPage() {
                       title: selectedListing.title,
                       price: selectedListing.price,
                       quantity: 1,
-                      conditionId: 3000,
+                      conditionId: selectedListing.conditionId ?? 3000,
                       description: '',
                     }}
                     availableApps={productionApps}

--- a/src/frontend/src/routes/listings.tsx
+++ b/src/frontend/src/routes/listings.tsx
@@ -7,7 +7,7 @@ import { Button } from '../components/ui/Button'
 import { Icon } from '../components/design-system/Icon'
 import { ListingsTable } from '../features/ebay/components/ListingsTable'
 import { ListingDetailPanel } from '../features/ebay/components/ListingDetailPanel'
-import { ListingFormPanel, type ListingFormValues } from '../features/ebay/components/ListingFormPanel'
+import { ListingFormPanel, CONDITION_OPTIONS, type ListingFormValues } from '../features/ebay/components/ListingFormPanel'
 import {
   fetchUserApps,
   fetchActiveListingsPaginated,
@@ -175,7 +175,14 @@ export function ListingsPage() {
         conditionID: values.conditionId,
         ...(values.description ? { description: values.description } : {}),
       })
-      const patch = { price: values.price, title: values.title }
+      const conditionLabel =
+        CONDITION_OPTIONS.find((o) => o.value === values.conditionId)?.label ?? ''
+      const patch = {
+        price: values.price,
+        title: values.title,
+        conditionId: values.conditionId,
+        conditionLabel,
+      }
       storeUpdateListing(selectedId, patch)
       const updated = listingsRef.current.map((l) =>
         l.itemId === selectedId ? { ...l, ...patch } : l
@@ -300,7 +307,7 @@ export function ListingsPage() {
                     initialValues={{
                       title: selectedListing.title,
                       price: selectedListing.price,
-                      quantity: 1,
+                      quantity: selectedListing.quantity ?? 1,
                       conditionId: selectedListing.conditionId ?? 3000,
                       description: '',
                     }}

--- a/src/frontend/src/routes/listings.tsx
+++ b/src/frontend/src/routes/listings.tsx
@@ -1,14 +1,17 @@
 // src/frontend/src/routes/listings.tsx
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { AppShell } from '../components/layout/AppShell'
 import { TopBar } from '../components/layout/TopBar'
 import { Button } from '../components/ui/Button'
 import { Icon } from '../components/design-system/Icon'
 import { ListingsTable } from '../features/ebay/components/ListingsTable'
+import { ListingDetailPanel } from '../features/ebay/components/ListingDetailPanel'
+import { ListingFormPanel, type ListingFormValues } from '../features/ebay/components/ListingFormPanel'
 import {
   fetchUserApps,
   fetchActiveListingsPaginated,
+  updateListing,
   type EbayAppSummary,
 } from '../features/ebay/api'
 import { enrichWithCatalog } from '../features/ebay/lib/catalogEnrich'
@@ -25,6 +28,7 @@ type Tab = 'active' | 'sold' | 'saved'
 const LIMIT = 25
 
 export function ListingsPage() {
+  const navigate = useNavigate()
   const [tab, setTab] = useState<Tab>('active')
   const [listings, setListings] = useState<EbayLiveListing[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -32,7 +36,14 @@ export function ListingsPage() {
   const [hasMore, setHasMore] = useState(false)
   const [failedApps, setFailedApps] = useState<string[]>([])
   const [dismissedApps, setDismissedApps] = useState<Set<string>>(new Set())
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [panelMode, setPanelMode] = useState<'detail' | 'edit'>('detail')
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [productionApps, setProductionApps] = useState<EbayAppSummary[]>([])
   const storeSet = useListingsStore((s) => s.setListings)
+  const selectedListing = useListingsStore((s) => s.getById(selectedId ?? ''))
+  const storeUpdateListing = useListingsStore((s) => s.updateListing)
 
   // Pagination state in refs — updates don't need to trigger re-renders
   const appsRef = useRef<EbayAppSummary[]>([])
@@ -50,6 +61,7 @@ export function ListingsPage() {
         const apps = await fetchUserApps()
         const productionApps = apps.filter((a) => a.environment === 'PRODUCTION')
         appsRef.current = productionApps
+        setProductionApps(productionApps)
 
         const results = await Promise.allSettled(
           productionApps.map((app) =>
@@ -151,6 +163,27 @@ export function ListingsPage() {
     setIsLoadingMore(false)
   }, [storeSet])
 
+  async function handleUpdateListing(values: ListingFormValues, appCode: string) {
+    if (!selectedId || !selectedListing) return
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      await updateListing(appCode, selectedId, {
+        title: values.title,
+        startPrice: { currency: 'AUD', value: values.price },
+        quantity: values.quantity,
+        conditionID: values.conditionId,
+        ...(values.description ? { description: values.description } : {}),
+      })
+      storeUpdateListing(selectedId, { price: values.price, title: values.title })
+      setPanelMode('detail')
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to update listing')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
   // Set up IntersectionObserver once the sentinel is in the DOM (after initial load).
   useEffect(() => {
     if (isLoading || tab !== 'active') return
@@ -177,6 +210,7 @@ export function ListingsPage() {
               variant="accent"
               size="sm"
               icon={<Icon kind="plus" size={12} color="currentColor" />}
+              onClick={() => navigate({ to: '/listings/new' })}
             >
               New listing
             </Button>
@@ -219,22 +253,62 @@ export function ListingsPage() {
 
         {/* ── Content ───────────────────────────────────────────── */}
         {tab === 'active' && (
-          <>
-            <ListingsTable listings={listings} isLoading={isLoading} />
-            {!isLoading && (
-              <>
-                <div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
-                {isLoadingMore && (
-                  <div className={styles.loadingMore}>Loading more listings…</div>
+          <div className={selectedId ? styles.withPanel : undefined}>
+            <div>
+              <ListingsTable
+                listings={listings}
+                isLoading={isLoading}
+                selectedId={selectedId ?? undefined}
+                onRowClick={(id) => {
+                  setSelectedId(id)
+                  setPanelMode('detail')
+                  setSaveError(null)
+                }}
+              />
+              {!isLoading && (
+                <>
+                  <div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
+                  {isLoadingMore && (
+                    <div className={styles.loadingMore}>Loading more listings…</div>
+                  )}
+                  {!hasMore && listings.length > 0 && !isLoadingMore && (
+                    <div className={styles.endOfList}>
+                      {listings.length} listing{listings.length !== 1 ? 's' : ''} total
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+
+            {selectedId && selectedListing && (
+              <div>
+                {panelMode === 'detail' ? (
+                  <ListingDetailPanel
+                    listing={selectedListing}
+                    onEdit={() => setPanelMode('edit')}
+                    onClose={() => { setSelectedId(null); setPanelMode('detail') }}
+                  />
+                ) : (
+                  <ListingFormPanel
+                    mode="edit"
+                    initialValues={{
+                      title: selectedListing.title,
+                      price: selectedListing.price,
+                      quantity: 1,
+                      conditionId: 3000,
+                      description: '',
+                    }}
+                    availableApps={productionApps}
+                    appCode={selectedListing.appCode}
+                    onSave={handleUpdateListing}
+                    onCancel={() => setPanelMode('detail')}
+                    isSaving={isSaving}
+                    error={saveError}
+                  />
                 )}
-                {!hasMore && listings.length > 0 && !isLoadingMore && (
-                  <div className={styles.endOfList}>
-                    {listings.length} listing{listings.length !== 1 ? 's' : ''} total
-                  </div>
-                )}
-              </>
+              </div>
             )}
-          </>
+          </div>
         )}
 
         {tab === 'sold' && (

--- a/src/frontend/src/routes/listings_.new.tsx
+++ b/src/frontend/src/routes/listings_.new.tsx
@@ -1,0 +1,119 @@
+// src/frontend/src/routes/listings_.new.tsx
+import { useState, useEffect } from 'react'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { AppShell } from '../components/layout/AppShell'
+import { TopBar } from '../components/layout/TopBar'
+import { CardPicker } from '../features/ebay/components/CardPicker'
+import {
+  ListingFormPanel,
+  type ListingFormValues,
+} from '../features/ebay/components/ListingFormPanel'
+import {
+  fetchUserApps,
+  createListing,
+  type EbayAppSummary,
+} from '../features/ebay/api'
+import type { CardSummary } from '../features/cards/types'
+import styles from './ListingsNew.module.css'
+
+export const Route = createFileRoute('/listings_/new')({
+  component: ListingsNewPage,
+})
+
+export function ListingsNewPage() {
+  const navigate = useNavigate()
+  const [isLoadingApps, setIsLoadingApps] = useState(true)
+  const [productionApps, setProductionApps] = useState<EbayAppSummary[]>([])
+  const [selectedCard, setSelectedCard] = useState<CardSummary | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      try {
+        const apps = await fetchUserApps()
+        if (!cancelled) {
+          setProductionApps(apps.filter((a) => a.environment === 'PRODUCTION'))
+        }
+      } catch {
+        // leave apps empty — form will have no app choices
+      } finally {
+        if (!cancelled) setIsLoadingApps(false)
+      }
+    }
+    load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const derivedTitle = selectedCard
+    ? `${selectedCard.card_name} ${selectedCard.set_code.toUpperCase()} NM MTG`
+    : ''
+
+  const initialValues: Partial<ListingFormValues> = {
+    title: derivedTitle,
+    conditionId: 3000,
+  }
+
+  async function handleSave(values: ListingFormValues, appCode: string) {
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      await createListing(appCode, {
+        title: values.title,
+        startPrice: { currency: 'AUD', value: values.price },
+        quantity: values.quantity,
+        conditionID: values.conditionId,
+        ...(values.description ? { description: values.description } : {}),
+      })
+      navigate({ to: '/listings' })
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to create listing')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  function handleCancel() {
+    navigate({ to: '/listings' })
+  }
+
+  if (isLoadingApps) {
+    return (
+      <AppShell active="listings">
+        <TopBar title="New listing" />
+        <div data-testid="loading" className={styles.loading}>
+          Loading…
+        </div>
+      </AppShell>
+    )
+  }
+
+  return (
+    <AppShell active="listings">
+      <TopBar title="New listing" breadcrumb="LISTINGS › NEW" />
+      <div className={styles.page}>
+        <div className={styles.split}>
+          <CardPicker
+            onSelect={setSelectedCard}
+            selectedId={selectedCard?.card_version_id}
+          />
+          <div className={styles.formWrapper}>
+            <ListingFormPanel
+              key={selectedCard?.card_version_id ?? 'no-card'}
+              mode="create"
+              initialValues={initialValues}
+              availableApps={productionApps}
+              onSave={handleSave}
+              onCancel={handleCancel}
+              isSaving={isSaving}
+              error={saveError}
+            />
+          </div>
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/src/frontend/src/routes/listings_.new.tsx
+++ b/src/frontend/src/routes/listings_.new.tsx
@@ -91,6 +91,17 @@ export function ListingsNewPage() {
     )
   }
 
+  if (productionApps.length === 0) {
+    return (
+      <AppShell active="listings">
+        <TopBar title="New listing" breadcrumb="LISTINGS › NEW" />
+        <div className={styles.loading}>
+          No connected eBay apps found. Connect an app in Settings before creating a listing.
+        </div>
+      </AppShell>
+    )
+  }
+
   return (
     <AppShell active="listings">
       <TopBar title="New listing" breadcrumb="LISTINGS › NEW" />

--- a/src/frontend/src/store/__tests__/listings.test.ts
+++ b/src/frontend/src/store/__tests__/listings.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useListingsStore } from '../listings'
+import type { EbayLiveListing } from '../../features/ebay/mockListings'
+
+function makeListing(overrides: Partial<EbayLiveListing> = {}): EbayLiveListing {
+  return {
+    itemId: 'l1',
+    title: 'Ragavan MH2 NM',
+    cardName: 'Ragavan',
+    setCode: 'MH2',
+    setInfo: 'MH2',
+    price: 60,
+    currency: 'AUD',
+    conditionLabel: 'NM',
+    finish: 'Regular',
+    style: '',
+    daysListed: 5,
+    watchCount: 3,
+    viewItemUrl: 'https://ebay.com.au/itm/l1',
+    imageUrl: null,
+    appCode: 'app1',
+    appName: 'App 1',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  useListingsStore.setState({ listings: [] })
+})
+
+describe('listings store', () => {
+  it('setListings replaces all listings', () => {
+    const l = makeListing()
+    useListingsStore.getState().setListings([l])
+    expect(useListingsStore.getState().listings).toHaveLength(1)
+  })
+
+  it('getById returns the matching listing', () => {
+    useListingsStore.getState().setListings([makeListing({ itemId: 'abc' })])
+    expect(useListingsStore.getState().getById('abc')?.itemId).toBe('abc')
+  })
+
+  it('getById returns undefined for unknown id', () => {
+    useListingsStore.getState().setListings([makeListing()])
+    expect(useListingsStore.getState().getById('nope')).toBeUndefined()
+  })
+
+  it('updateListing patches only the matching entry', () => {
+    const l1 = makeListing({ itemId: 'l1', price: 60 })
+    const l2 = makeListing({ itemId: 'l2', price: 10 })
+    useListingsStore.getState().setListings([l1, l2])
+
+    useListingsStore.getState().updateListing('l1', { price: 75, conditionLabel: 'LP' })
+
+    const updated = useListingsStore.getState().listings
+    expect(updated[0].price).toBe(75)
+    expect(updated[0].conditionLabel).toBe('LP')
+    expect(updated[1].price).toBe(10)
+  })
+})

--- a/src/frontend/src/store/listings.ts
+++ b/src/frontend/src/store/listings.ts
@@ -5,10 +5,17 @@ interface ListingsState {
   listings: EbayLiveListing[]
   setListings: (listings: EbayLiveListing[]) => void
   getById: (itemId: string) => EbayLiveListing | undefined
+  updateListing: (itemId: string, patch: Partial<EbayLiveListing>) => void
 }
 
 export const useListingsStore = create<ListingsState>()((set, get) => ({
   listings: [],
   setListings: (listings) => set({ listings }),
   getById: (itemId) => get().listings.find((l) => l.itemId === itemId),
+  updateListing: (itemId, patch) =>
+    set((state) => ({
+      listings: state.listings.map((l) =>
+        l.itemId === itemId ? { ...l, ...patch } : l
+      ),
+    })),
 }))


### PR DESCRIPTION
## Summary

- **Create flow** (`/listings/new`): split-panel with `CardPicker` (debounced card search) on the left and `ListingFormPanel` in create mode on the right; selecting a card pre-fills the title; submits via `createListing` API and navigates to `/listings` on success; guards against no connected PRODUCTION apps
- **Edit flow** (`/listings`): inline split-panel — clicking a row opens `ListingDetailPanel` (read-only), Edit button switches to `ListingFormPanel`; save patches price, title, conditionId, and conditionLabel in both Zustand store and local state simultaneously; quantity is preserved from the live listing rather than defaulting to 1
- **Shared components**: `ListingDetailPanel`, `ListingFormPanel` (create/edit mode), `CardPicker` (search + debounce + `SearchResults` integration), row selection on `ListingsTable` (keyboard-accessible with WCAG 2.1 AA guards), `onSelect`/`selectedId` mode added to `SearchResults`

## Test Plan

- [ ] Visit `/listings` — Active tab loads live data; clicking a row opens the detail panel on the right
- [ ] Click Edit in the detail panel — form opens with current title, price, and condition pre-filled; saving updates the row in-place
- [ ] Click "New listing" — navigates to `/listings/new`; card search works; selecting a card pre-fills the title; form submits and redirects back
- [ ] Keyboard: Tab to a listing row, press Enter — detail panel opens; press Enter on the eBay link — link navigates without firing row selection
- [ ] All 253 tests pass (`npm test -- --run`); 12 pre-existing failures in `routes/ebay/__tests__/` are unrelated to this feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)