### PR TITLE
chore: add MTG finance knowledge base, plans, and SQL schemas/migration

### DIFF
--- a/docs/MTG_FINANCE_KNOWLEDGE_BASE.md
+++ b/docs/MTG_FINANCE_KNOWLEDGE_BASE.md
@@ -1,0 +1,423 @@
+# MTG Finance Knowledge Base
+
+*Compiled May 2026. Covers US, Canada, Europe, Japan, Australia/NZ markets.*
+
+---
+
+## Price Data Sources
+
+### Primary Aggregators / APIs
+
+| Name | Region | Type | API? | Notes |
+|------|--------|------|------|-------|
+| TCGPlayer | US (primary) | Retail market price + buylist | Yes — restricted (no new access since 2024) | Use JustTCG or TCGCSV as developer alternatives. Benchmark for US pricing. |
+| CardMarket (MKM) | Europe (primary) | Retail market + buylist | Deprecated June 2024; Price Guide CSV downloadable | Not accepting new API applications. apiv2.cardmarket.com for approved partners. |
+| MTGGoldfish | Global (US-centric) | Retail + buylist aggregator | No public API | Human-readable. Tracks spreads, buylist comparisons, metagame share, EV. |
+| MTGStocks | Global | Price change tracker | No official API (community scrapers exist) | Free + Premium ($4.99/mo). Best spike detection. Interests page is the community's primary buyout signal. |
+| MTGPrice / Trader Tools | US-centric | Retail tracker + buylist aggregator | No public API | ProTrader ($10/mo) unlocks full buylist aggregation and arbitrage tool across NA vendors. |
+| Scryfall | Global | Card metadata + price snapshot | Yes — free, no key, rate-limited 10 req/s | TCGPlayer Market Price + CardMarket Trend embedded daily. Bulk JSON. Best developer API. |
+| MTGJSON | Global | Card data + 90-day price history | Yes — open, bulk JSON/CSV/SQLite/PostgreSQL | Sources: CardKingdom, CardMarket, Cardsphere, TCGPlayer. Rebuilt daily. AllPrices.json + AllPricesToday.json. Best free foundation for pipelines. |
+| Card Kingdom | US | Retail + buylist | No | Best US buylist especially for eternal/older cards. 30% store credit bonus. |
+| Star City Games | US | Retail + buylist | No | Strong on eternal format staples; hosts major tournaments. |
+| ChannelFireball | US | Retail + buylist | No | Competitive buylist; strict grading. |
+| CardTrader | EU + Global | Retail marketplace | Yes — public REST at cardtrader.com/en/docs/api | Growing EU alternative to CardMarket. |
+| EchoMTG | US-primary | Collection tracker + prices | Yes — echomtg.com/api | Finance-oriented collection management with email reports and trade tracking. |
+| Cardsphere | Global | P2P trade/sell | No | 1% platform fee to seller; cash out at 10%. Often beats buylists. Tracked by MTGJSON as a price source. |
+
+### Third-Party APIs and Specialized Tools
+
+| Name | Region | Type | API? | Notes |
+|------|--------|------|------|-------|
+| JustTCG | US | TCGPlayer-derived retail | Yes | Condition-specific, foil pricing, bulk lookups. Best developer-friendly TCGPlayer alternative. |
+| TCGCSV | US | TCGPlayer price dump | Yes (public JSON/CSV, no auth) | Free public endpoint for TCGPlayer product/price data. |
+| TCGAPIs | Global | Multi-market aggregator | Yes | 80+ TCGs. Expanding to CardMarket/CardKingdom/Cardsphere. Unified schema. |
+| Flipzi | EU/US | Portfolio tracker + arbitrage | No (SaaS) | Side-by-side CardMarket EUR vs TCGPlayer USD. Real last-sold data. Free tier + Founding Member plan. |
+| Spellbook Finance | Global | Portfolio + arbitrage scanner | No (SaaS) | 14+ sources incl. TCGPlayer, CardKingdom, CardTrader, eBay. Transatlantic EU-to-US arbitrage scan. 10 buylist vendors. |
+| TCGPriceTracker | Global | Cross-market arbitrage alerts | No (SaaS) | Tracks CardMarket, TCGPlayer, eBay simultaneously. |
+| TCGSniper | US | Price drop alerts | No (SaaS) | Checks TCGPlayer and Card Kingdom multiple times/hour. Free forever tier. |
+| Beat the Buylist | North America | Cross-vendor buylist comparison | No | Shows which store to sell to for max value across NA vendors. |
+| MTG Collector Tools | US | Buyout detection + predictions | No (SaaS) | Tracks 35k+ cards; buyout alerts, price predictions, 23 active arbitrage opportunities. Free. |
+| MTGSingles.co.nz | AU/NZ | Price comparison aggregator | No | Searches across AU/NZ game shops. |
+
+---
+
+## Regional Marketplaces
+
+### United States
+
+| Store | URL | Notes |
+|-------|-----|-------|
+| TCGPlayer | tcgplayer.com | Dominant US marketplace; Market Price is the US benchmark |
+| Card Kingdom | cardkingdom.com | Best US buylist reliability; retail above TCGPlayer |
+| Star City Games | starcitygames.com | Strong on Alpha/Beta and eternal staples |
+| ABU Games | abugames.com | Strong on Reserved List; store credit 20-30% above cash equivalency |
+| CoolStuffInc | coolstuffinc.com | Competitive retail; $0.99 shipping on singles |
+| ChannelFireball | shop.channelfireball.com | Major retailer; strict grading on buylists |
+
+### Canada
+
+#### Canadian Price Aggregators
+
+| Tool | URL | Notes |
+|------|-----|-------|
+| Snapcaster.ca | snapcaster.ca | Primary Canadian MTG price aggregator; indexes 80+ Canadian stores for singles prices + dedicated buylist comparison tool (closest Canadian equivalent to MTGGoldfish). Free. |
+| MTGList.com | mtglist.com | Aggregates Canadian buylist prices specifically; indexes Face to Face, 401 Games, Three Kings Loot, Wizard's Tower, and others. |
+
+#### Ontario
+
+| Store | URL | Buylist | Notes |
+|-------|-----|---------|-------|
+| Face to Face Games | facetofacegames.com | buylist.facetofacegames.com | Canada's largest MTG retailer; ships nationally |
+| 401 Games | store.401games.ca | buylist.401games.ca | Toronto/Vaughan |
+| Wizard's Tower | store.wizardtower.com | buylist.wizardtower.com | Ottawa; daily buylist support hours |
+| Magic Stronghold | magicstronghold.com | Yes | Online-focused |
+| Hairy Tarantula | hairyt.com | hairyt.crystalcommerce.com/buylist | Toronto; 25% extra in store credit; mail-in accepted; large MTG inventory |
+| Black Knight Games | blackknightgames.ca | blackknightgames.ca/pages/sell-your-mtg | Hamilton; cash via e-transfer; pre-submit online before shipping |
+| Hobbiesville | hobbiesville.com | buylist.hobbiesville.com/retailer/buylist | Ottawa/Toronto; ships nationally and internationally |
+| Chimera Gaming | chimeragamingonline.com | chimeragamingonline.com/pages/buylist | Kitchener; mail-in accepted; hot items get trade bonus |
+| The Mana Lounge | manalounge.ca | manalounge.ca/blogs/selling-your-cards/online-buy-list | London, ON; 1-business-day review; mail-in or in-store |
+| Waypoint Games | waypointgames.ca | Yes | Ancaster (Hamilton area); strong Commander focus; on CardTrader |
+| Carta Magica Ottawa | cartamagicaottawa.com | cartamagicaottawa.com/buylist | Ottawa; shared CrystalCommerce backend with Montreal location |
+| Empire Trading | empiretradings.com | empiretradings.com/pages/buylist | Ottawa (Gloucester); bulk $5/1,000 cards; hosts events |
+| Meta-Games Unlimited | mguinc.com | mguinc.com/buylist/ | Online; 50–65% of TCG price in trade credit |
+| GT Games | gtgames.ca | Yes | Carleton Place, ON; ships to US; large multi-TCG inventory |
+
+#### Quebec
+
+| Store | URL | Buylist | Notes |
+|-------|-----|---------|-------|
+| Three Kings Loot | threekingsloot.com | threekingsloot.com/buylist | Montreal; 30% trade bonus; cash via PayPal |
+| Carta Magica Montreal | cartamagica.com | cartamagica.com/buylist | Montreal; long-established MTG specialist (10+ years) |
+| The Mythic Store | themythicstore.com | themythicstore.com/pages/sell-your-cards-buylist | Quebec; pays up to 80% of selling price; 25% store credit bonus; 24h processing; free tracked shipping over $250 CAD |
+| Le Coin du Jeu | lecoindujeu.ca | lecoindujeu.ca/pages/buylist | Terrebonne (north of Montreal); 25% store credit bonus |
+| Game Keeper Online | gamekeeperonline.com | gamekeeperonline.com/our-buylist | Montreal; 30% more in store credit; same-day processing; usable at physical Montreal store |
+| Card Brawlers | cardbrawlers.com | Yes | Montreal; free shipping over $40 CAD; hosts tournaments |
+| Silver Goblin | silvergoblin.cards | Yes | Downtown Montreal; bilingual; MTG + Flesh and Blood |
+| L'Imaginaire | imaginaire.com/en/magic | No prominent buylist | Large Quebec chain; free shipping from $79 in QC/ON/NB |
+
+#### Manitoba
+
+| Store | URL | Buylist | Notes |
+|-------|-----|---------|-------|
+| Fusion Gaming | fusiongamingonline.com | fusiongamingonline.com/buylist | Winnipeg; mail-in accepted; store credit never expires |
+| GameKnight Games | gameknight.ca | gameknight.ca/pages/buylist | Winnipeg; in-person only (no mail-in); 25% store credit bonus |
+
+#### Alberta
+
+| Store | URL | Buylist | Notes |
+|-------|-----|---------|-------|
+| Taps Games | tapsgames.com | tapsgames.com/pages/buy-list | Edmonton; WPN Premium store; prices guaranteed 4 days |
+| Sentry Box Cards | sentryboxcards.com | sentryboxcards.com/buylist | Calgary; premier Western Canada retailer; ships nationally; two weekly Pioneer tournaments |
+
+#### British Columbia
+
+| Store | URL | Buylist | Notes |
+|-------|-----|---------|-------|
+| Gauntlet Games Victoria | gauntletgamesvictoria.ca | gauntletgamesvictoria.ca/buylist/magic_singles/8 | Victoria; birthplace of Canadian Highlander format (1999); top dollar for MTG singles |
+
+#### Atlantic Canada
+
+| Store | URL | Buylist | Notes |
+|-------|-----|---------|-------|
+| The Comic Hunter | comichunter.net | comichunter.net/buylist/multi_search | Moncton + Fredericton, NB; serves Atlantic Canada; store credit never expires |
+| Vortex Games | vortexgames.ca | vortexgames.ca/pages/buylist-instructions | Sackville, NB; cash via PayPal or store credit |
+
+#### Online-Only / National
+
+| Store | URL | Buylist | Notes |
+|-------|-----|---------|-------|
+| Magic Market Canada | magicmarketcanada.com | No public buylist | Family-run; free shipping over $200 CAD; frequently cited as competitively priced |
+| MTG North | mtgnorth.ca | mtgnorth.ca/buylist | 20% store credit bonus over cash; online only |
+
+#### Canadian Market Dynamics
+
+**2025 Tariff (critical):** As of March 13, 2025, Canada imposed a **25% counter-tariff on playing cards** as part of the US-Canada trade war. This applies to sealed TCG product crossing from the US into Canada, directly raising costs for sealed product at Canadian retailers. Singles in envelopes are less directly affected but carry increased customs inspection risk.
+
+**CAD/USD pricing conventions:**
+- Sealed product: Canadian stores typically price 25–30% above USD retail (exchange rate + distributor costs), compounded by the 2025 tariff
+- Singles: Most stores price in CAD at 1.3–1.5x the TCGPlayer USD market price; Canadian stores lag in adjusting to US price spikes
+- Premium foils: Canadian foil prices frequently run 1.5–2x the equivalent US price (especially older foils from Time Spiral Remastered, Masters sets) — historically creates cross-border arbitrage at GP/event vendor halls
+- Store credit bonuses of 20–30% over cash are the industry norm
+
+**Canadian Highlander:** 100-card singleton 1v1 format originated in Victoria, BC (1999). Points system allows up to 10 points for restricted-list cards. Creates niche Canadian demand for Power Nine and dual lands beyond Legacy/Vintage. Official site: canadianhighlander.ca
+
+**TCGPlayer and Canada:** TCGPlayer does not ship to Canada from most sellers. Canadians use package-forwarding services (longstanding workaround). Cardsphere and Deckbox are the cleanest cross-border P2P trading mechanisms (card-for-card trades avoid customs treatment).
+
+**Canadian Community:**
+- r/CanadianGamingSales — primary Canadian gaming subreddit for P2P transactions; reputation/flair system
+- Facebook: "MTG Buy Sell Trade Canada Only" (facebook.com/groups/657130297692602) — national P2P; Interac e-transfer dominant
+- Facebook: "MTG Canadian Highlander: There Can Be Only One" (facebook.com/groups/288447914624649)
+- Canadian Highlander Discord — canadianhighlander.ca — active tournament org and weekly events
+
+### Europe
+
+| Store/Platform | URL | Notes |
+|-------|-----|-------|
+| CardMarket | cardmarket.com/en/Magic | Dominant EU marketplace; 30+ countries, 2M+ buyers; 5% commission; EUR pricing |
+| Three for One Trading | threeforonetrading.com/en | "Europe's leading Magic cards trader"; professional buylist |
+| CardTrader | cardtrader.com | Pan-EU alternative; has public API |
+| MagicMadhouse | magicmadhouse.co.uk | UK-based retailer |
+
+### Japan / Asia-Pacific
+
+| Store | URL | Notes |
+|-------|-----|-------|
+| Hareruya | hareruyamtg.com/en | Largest MTG store in Japan; 41 stores; ships internationally; competitive on staples buylist |
+| Grey Ogre Games | greyogregames.com | Singapore-based; buylist service available |
+| MTG Mint Card | mtgmintcard.com | Hong Kong-based; ships to EU; has buylist |
+
+### Australia / New Zealand
+
+| Store | URL | Notes |
+|-------|-----|-------|
+| Good Games TCG | tcg.goodgames.com.au | Australia's largest TCG chain; physical + online |
+| MTG Mate | mtgmate.com.au | AU-based; fast domestic shipping |
+| Ozzie Collectables | ozziecollectables.com | Singles and sealed |
+| Gameology | gameology.com.au | Broad TCG retailer |
+| MTGSingles.co.nz | mtgsingles.co.nz | NZ price comparison aggregator |
+| Trade Magic | trademagic.com.au | AU peer-to-peer trading platform |
+
+---
+
+## Community & Media Sources
+
+### Subreddits
+
+| Subreddit | Focus |
+|-----------|-------|
+| r/mtgfinance | Primary finance community; Wednesday AMA threads; spreadsheet/scraper sharing |
+| r/magicTCG | General MTG; large audience; spikes often surface here first |
+| r/EDH | Commander demand side; heavily influences card prices |
+| r/CompetitiveEDH | High-power Commander; staple demand signals |
+
+### Podcasts
+
+| Podcast | Notes |
+|---------|-------|
+| Brainstorm Brewery | Biweekly; oldest MTG finance podcast; covers speculation, buylist, Commander |
+| MTG Fast Finance | Biweekly; meta analysis, fast movers; produced via MTGPrice; James Chillcott + Cliff Daigle |
+| Quiet Speculation Podcast | Irregular; paired with Insider subscription |
+
+### YouTube (Finance-Focused)
+
+| Channel | Focus |
+|---------|-------|
+| Alpha Investments (Rudy) | Sealed product, Reserved List, long-term; large & influential audience |
+| Jake and Joel are Magic | Singles speculation, weekly price movement rundowns |
+| MTG Mox Man | Short-term speculation; near "day trading" style |
+| MTGStocks TV | Official MTGStocks market trends channel |
+| Tolarian Community College | Broad MTG; product reviews drive buy/sell signals; #1 MTG channel globally |
+| The Command Zone | Commander deck techs drive weekly price spikes |
+| MTGGoldfish (YouTube) | Budget brews + weekly meta reports |
+| EDHREC | Most-added cards list is a spike-prediction signal |
+
+### Discord Servers
+
+| Server | Notes |
+|--------|-------|
+| MTG Marketplace | 10,000+ members; buy/sell/trade |
+| MTGPrice Pro Trader | Via subscription; fastest signal delivery |
+| Quiet Speculation Insider | Via QS subscription; serious speculation community |
+| EchoMTG Discord | Meta and finance discussion |
+
+### Blogs & Written Content
+
+| Source | URL | Notes |
+|--------|-----|-------|
+| Quiet Speculation | quietspeculation.com | Oldest MTG finance site; Insider paywall for premium |
+| MTGPrice Blog | blog.mtgprice.com | Free articles; finance strategy |
+| Cardsphere Blog | blog.cardsphere.com | Trading and selling focus |
+| Draftsim MTG Finance Guide | draftsim.com/mtg-finance | Comprehensive free guide |
+| TCGPlayer Infinite | infinite.tcgplayer.com | Finance articles |
+| MTGRocks | mtgrocks.com | Finance news and price movement |
+
+---
+
+## MTG Finance Strategies
+
+### 1. Speculation (Long Positions)
+Buy underpriced cards expected to rise from format shifts, Commander adoption, or supply constraints. Sell into the spike, not after plateau. Typical hold: 3–24 months. Best targets: high casual/Commander ceiling, old low-print-run sets, synergy pieces adjacent to powerful new cards.
+
+### 2. Buylist Arbitrage
+Buy retail below another vendor's buylist price. Spread = buylist price − retail price. Near-zero or negative spread = trigger. Workflow: MTGPrice Trader Tools or MTGGoldfish buylist comparison → buy on TCGPlayer → sell to Card Kingdom (best US buylist) or SCG. Card Kingdom offers 30% store credit bonus.
+
+### 3. Cross-Regional Arbitrage (EU-to-US)
+Commander cards significantly cheaper on CardMarket EU than TCGPlayer US. Buy in EU → ship to US → sell on TCGPlayer or to a US buylist. Optimal: EUR/USD below 1.10; gap > 15% post-fees; card is Commander-only (Standard/Modern staples equalize faster). Requires EU forwarding address.
+
+Tools: Flipzi, Spellbook Finance, TCGPriceTracker.
+
+### 4. Reserved List Speculation
+Cards on Wizards' Reserved List cannot be reprinted. Fixed supply + growing player base = long-term appreciation. Buy during market dips (post-buyout correction, summer slowdown). Risk: coordinated buyouts can create artificial spikes that correct.
+
+### 5. Reprint Risk Analysis
+Non-RL cards face reprint risk from Masters sets, Bonus Sheets, Commander precons, Secret Lairs. Reprint risk score factors: retail price, Commander/casual demand, reprint frequency, RL status. Mitigation: maintain high-velocity inventory; avoid large positions in expensive, eligible non-RL cards.
+
+### 6. Set Release Cycle Timing
+- Spoiler/pre-release: Peak prices for new cards — sell hype here
+- Weeks 2–8 post-release: Supply saturates; most new card prices fall 20–60% — buy window
+- 3–6 months pre-rotation: Standard-only staples decline — sell or avoid
+- Post-rotation floor: Buy eternal/Commander staples at cheapest
+- Reprint spoiler: Affected card craters immediately — sell on first hint
+
+### 7. Ban/Unban Speculation
+Highest-volatility events. Unban plays: pre-buy candidates discussed as unban targets. 2025 examples: Panoptic Mirror $15 → $50+; Braids, Cabal Minion +1000%. Ban plays: identify likely bans; sell into strength before confirmation.
+
+### 8. Commander Spike (Content Creator Pickup)
+A prominent Commander YouTuber/streamer features a card → price spikes within 24–72 hours. Monitor Tolarian, Command Zone, EDHRec "most added this week." Maintain watchlist of cheap, high-potential Commander cards with low stock.
+
+### 9. Premium Treatment / Foil Arbitrage
+Modern sets have Extended Art, Borderless, Showcase, Serialized, Surge Foil, Halo Foil, Japanese Alt Art SKUs. Each has independent scarcity and price.
+
+Reference multipliers:
+- Foil: 1.5–3x non-foil
+- Extended Art: ~1.8–2.5x regular
+- Foil Extended Art (FEA) mythic: ~0.825% collector booster drop rate — very scarce
+- Japanese showcase foils: large global premiums; source from Hareruya directly
+
+### 10. MTGO-to-Paper Redemption Arbitrage
+Assemble a complete digital MTGO set and redeem for paper. MTGO prices often below paper. Requires capital, patience, and understanding of redemption cutoff dates. Less common as redemption windows have tightened.
+
+### 11. CAD/USD Swing (Canada Arbitrage)
+When CAD weakens (>1.40 USD/CAD), Face to Face Games and 401 Games CAD-denominated buylists effectively offer USD sellers a premium. Monitor the exchange rate.
+
+---
+
+## Key Trend Signals to Monitor
+
+### Tier 1 — Act within 24–48 hours
+
+| Signal | Source | Action |
+|--------|--------|--------|
+| Ban/Unban announcement | Wizards official site, Commander RC | Pre-buy unban candidates 1–7 days pre-announcement; sell banned cards immediately |
+| Content creator card pickup | Tolarian, Command Zone, EDHRec weekly | Buy before full view count materializes; sell into spike |
+| TCGPlayer buyout detected | MTG Collector Tools, MTGStocks | Buy immediately or hold if already positioned |
+| MTGStocks weekly Interests | mtgstocks.com/news | Confirmation spike in motion; assess remaining upside |
+
+### Tier 2 — Days to Weeks
+
+| Signal | Source | Action |
+|--------|--------|--------|
+| Set spoiler reveals | Magic official site, social | Buy synergy/enabler cards before headline card peaks |
+| Major tournament results | MTGTop8, SCG/RC coverage | Buy 4-of staples in winning deck immediately post-event |
+| CardMarket vs TCGPlayer spread | Flipzi, Spellbook Finance | >15% gap = EU arbitrage candidate |
+| Format rotation calendar | Wizards schedule | 3 months out: sell Standard-only staples; buy eternal staples near floor |
+| EDHREC "top added commanders" | edhrec.com | New popular Commander drives synergy card prices within 1–2 weeks |
+| Reprint set spoiler | Magic official site | Sell affected cards on first hint; buy after dust settles |
+
+### Tier 3 — Structural (Weeks to Months)
+
+| Signal | Source | Action |
+|--------|--------|--------|
+| Reserved List policy statements | Wizards announcements | Any RL mention = immediate RL card price reaction |
+| EUR/USD, JPY/USD, AUD/USD exchange rates | Financial data feeds | EUR/USD <1.10 = EU arbitrage window opens |
+| Print run sell-through speed | Vendor stock levels, community reports | Fast sellout = limited print run; long-term supply constraint |
+| Sealed product EV vs MSRP | MTGGoldfish sealed EV, Spellbook Finance | EV > MSRP = buy sealed; EV < MSRP = sell singles early |
+| Foil multiplier drift | MTGJSON price data, Scryfall | Expanding multiplier = foil demand growing; contracting = correction |
+| MTGGoldfish daily movers | mtggoldfish.com/movers | Confirmation signal; rarely early but useful for trend validation |
+
+---
+
+## Cross-Regional Arbitrage — Patterns and Methods
+
+### Pattern 1: EU (CardMarket) → US (TCGPlayer)
+**Why it works**: Commander dramatically more popular in US. Commander staples consistently 15–40% cheaper on CardMarket EU. EUR/USD differential amplifies the gap.
+
+**Optimal conditions**: EUR/USD below 1.10; gap > 15% post-fees; Commander/casual-demand card only; new set release weeks 1–6.
+
+**Logistics**: CardMarket requires a European address. Use EU forwarding/reshipping service. Model: CardMarket seller fees (5–9%) + EU shipping + reshipping + international postage + TCGPlayer seller fees (10–15%).
+
+**Tools**: Flipzi, Spellbook Finance, TCGPriceTracker.
+
+### Pattern 2: Japan (Hareruya) → US/EU
+**Why it works**: Japanese alternate art, serialized, and special-frame cards often cheaper at Japanese source than international resale. JPY weakness in 2024–2025 amplified this.
+
+**Optimal conditions**: JPY weak vs USD/EUR; Japanese-exclusive showcase foils or serialized cards in stock; gap > 20% after international shipping.
+
+**Logistics**: Hareruya ships internationally; English-language site. EMS or DHL; 1–2 week transit.
+
+### Pattern 3: US → Australia (Supply Arbitrage)
+US-sourced singles (TCGPlayer) + shipping to AU buyers at AUD premium (50–80% above USD equivalent). Viable for higher-value singles where shipping cost is proportionally small.
+
+### Pattern 4: Canada (CAD/USD Swing)
+When CAD weakens sharply against USD (>1.40 CAD/USD), Face to Face Games and 401 Games CAD buylists effectively pay USD sellers a premium. Monitor the exchange rate.
+
+---
+
+## AutoMana Integration Recommendations
+
+### Priority Data Sources for Pipeline
+
+1. **MTGJSON** (AllPricesToday.json + AllPrices.json) — free, daily rebuild, covers CardKingdom/CardMarket/Cardsphere/TCGPlayer retail and buylist with 90-day history. Best free machine-readable foundation.
+2. **Scryfall bulk data** — already integrated; card metadata + TCGPlayer/CardMarket price snapshots
+3. **TCGCSV or JustTCG** — real-time US retail pricing without TCGPlayer API restrictions
+4. **CardMarket Price Guide CSV** — EU pricing layer; requires authentication
+5. **MTGStocks signals** — buyout detection and spike early warning
+
+### Price Signals to Surface in Analytics Layer
+
+| Signal | Formula | Threshold |
+|--------|---------|-----------|
+| Buylist spread | `lowest_buylist / lowest_retail` | Values approaching 1.0 = arbitrage trigger |
+| Foil multiplier | `foil_price / non_foil_price` | Compare to set median; outliers = opportunity |
+| Cross-regional spread | `(TCGPlayer_USD - CardMarket_EUR × FX_rate) / TCGPlayer_USD` | > 15% = EU arbitrage candidate |
+| Buyout alert | Copies at lowest price tier dropping to zero faster than replenishment rate | Spike incoming |
+| Reprint risk score | RL status + reprint count last 5 years + retail price tier + set age | Higher = more risk |
+
+---
+
+## Pre-2012 Historical Price Data
+
+*Researched May 2026. The pre-2012 gap is real and severe — no single clean, machine-readable, comprehensive paper card price dataset exists from before 2012.*
+
+### Era Breakdown
+
+| Era | State of price data |
+|-----|-------------------|
+| 1993–1999 (pre-internet) | Print media only (Scrye, InQuest magazines). Partially scanned on archive.org. Not structured data. |
+| 2000–2009 (early internet) | Retail sites (SCG, MagicTraders, CrystalKeep) had prices. No systematic aggregator archived them. Ark42.com began scraping SCG around 2009. |
+| 2010–2012 (bridge era) | MTGPrice.com launched November 2011. MTGStocks launched Spring 2012. MTGGoldfish paper data starts January 19, 2013. |
+
+### Source-by-Source Floors
+
+| Source | Earliest Paper Data | Pre-2012? | Format | Free? | Notes |
+|--------|-------------------|-----------|--------|-------|-------|
+| MTGGoldfish | Jan 19, 2013 | No | Charts + Premium CSV | Mostly | Pre-2013 data is MTGO Supernovabots only |
+| MTGPrice.com | Nov 2011 | Barely | Charts | Partly | ProTrader for full history |
+| MTGStocks | Spring 2012 | No | Charts | Partly | Launched ~March 2012 |
+| Kaggle MTG dataset | May 2012 | No | CSV | Free | Derived from MTGPrice.com |
+| MTGJSON | 90-day rolling | No | JSON/CSV | Free | No historical depth |
+| TCGPlayer | ~2010 (internal) | No (public) | API restricted | Partly | Data not exposed before ~2014 |
+| **SvenskaMagic.com** | **~2005** | **Yes** | Web charts (SEK) | Free | The only live site with pre-2012 paper price charts. Swedish language, SEK currency. Covers all major sets. URL: svenskamagic.com — navigate via "Prishistorik". Requires scraping + FX conversion. |
+| **PriceCharting.com** | **~2010 (MTG)** | **Partially** | Charts + paid CSV | Free browse | eBay hammer prices (actual sales, not list prices). Best for high-value vintage cards (Power 9, duals). Monthly CSV export available per set at paid tier. |
+| ark42.com | ~2009 | Yes (DEFUNCT) | Web charts | Was free | Scraped SCG prices. Site shut down ~2013. Data effectively lost unless owner preserved dumps. Wayback Machine captures at `web.archive.org/web/*/ark42.com/mtg/` |
+| Wayback Machine (SCG) | ~1999–2000 | Yes | HTML snapshots | Free | Star City Games has been online since ~1999. Thousands of individual card pages. No bulk export — requires crawling. Use `web.archive.org` CDX API to enumerate captured URLs. |
+| PSA Auction Prices | ~2003 | Yes | Web (graded only) | Free | Real auction hammer prices. Covers Power 9 and Alpha/Beta staples. Thin coverage for non-vintage cards. URL: psacard.com/auctionprices |
+
+### Print Magazine Archives (Require OCR)
+
+These are the only sources for systematic pre-internet MTG prices. Both are on archive.org as PDF/image scans — not machine-readable without OCR.
+
+| Magazine | Run | Coverage | archive.org |
+|----------|-----|----------|-------------|
+| **Scrye** | June 1994 – April 2009 | Monthly Low/Mid/High for every card in every set. Was the de facto US price standard at game stores. | Confirmed issues: #1, #4, #7, #8, #52, #58, #68. Partial digitization. Full index at magiclibrarities.net |
+| **InQuest / InQuest Gamer** | May 1995 – 2007 | Similar monthly price guide. Competitor to Scrye. | Confirmed issues: #1, #6, #9, #17, #33, #40, #41, #65. Partial collection (20 issues 1995-2006) at archive.org/details/IQ.Gamer.Partial.Collection |
+| **Beckett Magic** | ~2000+ | Graded + ungraded price guides | Partial archive; some on archive.org |
+
+Key reference: MTGInformation.com digitized the Scrye #9 (Sept 1995) top-40 price list at `mtginformation.com/1995-scrye-prices`.
+
+### MTGO Pre-2012
+
+- **Supernovabots** (defunct) was an MTGO bot network that tracked digital card prices. MTGGoldfish absorbed their data but does not expose it as a raw download. The network was active by at least September 2011.
+- **GoatBots** (goatbots.com/card/tracker) tracks MTGO prices with a multi-year chart window but no bulk historical export.
+- MTGO price archives before 2013 are effectively inaccessible in public structured form.
+
+### Recommendation for AutoMana
+
+**Treat 2012 as the practical start date for automated historical price ingestion.**
+
+- For 2012-present: MTGPrice.com, MTGGoldfish (paper from Jan 2013), MTGStocks are the reliable automated sources.
+- For 2009–2012: Only SvenskaMagic.com (SEK, scrapeable) and Wayback Machine captures of ark42.com are candidates. High effort for partial coverage.
+- For 2003–2009 (vintage/Power 9 only): PriceCharting.com (eBay actuals) and PSA auction records provide real transaction prices for high-value cards.
+- For pre-2010 all-card coverage: Scrye/InQuest OCR is the only path. Significant engineering effort; data would be monthly, image-derived, US retail Mid price.
+
+If pre-2012 data points ever appear in the DB (e.g., from manual entry or a future OCR project), annotate them with `source: "scrye_scan"` or `source: "wayback_scg"` and a lower confidence flag. Do not architect the AutoMana pricing pipeline expecting a clean pre-2012 dataset.

--- a/docs/superpowers/plans/2026-05-07-consolidate-remaining-migrations.md
+++ b/docs/superpowers/plans/2026-05-07-consolidate-remaining-migrations.md
@@ -1,0 +1,731 @@
+# Consolidate Remaining Migrations into Schema Files
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate all remaining migrations by consolidating their DDL and data seeds into the appropriate schema files, leaving only dev-only and env-specific migrations.
+
+**Architecture:** The plan separates consolidation into buckets: already-absorbed migrations (delete immediately), migrations needing consolidation (add to schema files), and dev/env-specific migrations (keep as-is). A critical prerequisite is recovering the lost 12_staging_schema.sql file from git history. Consolidations follow dependency order: 02_card_schema → 05_ebay → 06_prices.
+
+**Tech Stack:** PostgreSQL, TimescaleDB, shell scripting for git history inspection.
+
+---
+
+## File Structure
+
+**Files to modify:**
+- `src/automana/database/SQL/schemas/02_card_schema.sql` — add `refresh_card_search_views()` procedure from migration_19_refresh_views_security_definer.sql
+- `src/automana/database/SQL/schemas/06_prices.sql` — add pricing tiers DDL and archive procedure from migrations 18–19
+- `src/automana/database/SQL/schemas/12_staging_schema.sql` — recover lost content from git history, replace 0-byte stub
+- `src/automana/database/SQL/schemas/13_reporting_schema.sql` — create new file with DDL from migration_24_reporting_schema.sql
+
+**Files to delete:**
+- `src/automana/database/SQL/migrations/migration_16_fix_staging_lower_set_code.sql`
+- `src/automana/database/SQL/migrations/migration_17_foil_finish_suffix.sql`
+- `src/automana/database/SQL/migrations/migration_18_fix_mtgjson_price_cents_overflow.sql`
+- `src/automana/database/SQL/migrations/migration_19_widen_redirect_uri.sql`
+- `src/automana/database/SQL/migrations/migration_20_sandbox_scopes.sql`
+- `src/automana/database/SQL/migrations/migration_18_pricing_tiers.sql` (after consolidation)
+- `src/automana/database/SQL/migrations/migration_19_archive_to_weekly_fix.sql` (after consolidation)
+- `src/automana/database/SQL/migrations/migration_19_refresh_views_security_definer.sql` (after consolidation)
+
+**Files to keep (dev/env-specific):**
+- `migration_22_ebay_refresh_tokens.sql` — dev-only TRUNCATE
+- `migration_23_scopes_user_subset_constraint.sql` — dev-only DELETE
+- `migration_24_prod_scopes_sync.sql` — prod-specific scope app linkage
+
+---
+
+## Task 1: Recover Lost 12_staging_schema.sql Content
+
+**Files:**
+- Inspect: `src/automana/database/SQL/schemas/12_staging_schema.sql`
+- Target: commit `ccee98e` and git history
+- Recover: original `11_staging_schema.sql` or `04_staging_schema.sql`
+
+- [ ] **Step 1: Check current state of 12_staging_schema.sql**
+
+```bash
+wc -c src/automana/database/SQL/schemas/12_staging_schema.sql
+```
+
+Expected: Output shows 0 bytes
+
+- [ ] **Step 2: Find the schema file in git history**
+
+```bash
+git log --all --full-history --oneline -- "src/automana/database/SQL/schemas/11_staging_schema.sql" | head -5
+```
+
+Expected: Commit list showing when file was changed/deleted
+
+- [ ] **Step 3: Recover content from commit ccee98e**
+
+```bash
+git show ccee98e:src/automana/database/SQL/schemas/11_staging_schema.sql > /tmp/staging_schema_recovered.sql
+wc -l /tmp/staging_schema_recovered.sql
+```
+
+Expected: Non-zero line count; file contains staging schema DDL
+
+- [ ] **Step 4: If Step 3 fails, check for 04_staging_schema.sql in history**
+
+```bash
+git log --all --full-history --oneline -- "src/automana/database/SQL/schemas/04_staging_schema.sql" | head -5
+git show <commit>:src/automana/database/SQL/schemas/04_staging_schema.sql > /tmp/staging_schema_recovered.sql
+```
+
+- [ ] **Step 5: If file still not found, query live database for schema structure**
+
+```bash
+docker compose --env-file config/env/.env.dev -f deploy/docker-compose.dev.yml exec \
+  postgres psql -U app_agent -d automana \
+  -c "\dt staging.*; \dv staging.*; \df staging.*"
+```
+
+Expected: List of all objects in staging schema
+
+- [ ] **Step 6: Copy recovered content into 12_staging_schema.sql**
+
+```bash
+cat /tmp/staging_schema_recovered.sql > src/automana/database/SQL/schemas/12_staging_schema.sql
+wc -l src/automana/database/SQL/schemas/12_staging_schema.sql
+```
+
+Expected: File now contains full staging schema (100+ lines expected)
+
+- [ ] **Step 7: Commit recovered schema**
+
+```bash
+git add src/automana/database/SQL/schemas/12_staging_schema.sql
+git commit -m "restore: recover lost 12_staging_schema.sql from git history"
+```
+
+---
+
+## Task 2: Add refresh_card_search_views() to 02_card_schema.sql
+
+**Files:**
+- Modify: `src/automana/database/SQL/schemas/02_card_schema.sql`
+- Source: `src/automana/database/SQL/migrations/migration_19_refresh_views_security_definer.sql`
+
+- [ ] **Step 1: Read the target migration file to understand the procedure**
+
+```bash
+cat src/automana/database/SQL/migrations/migration_19_refresh_views_security_definer.sql
+```
+
+Expected: Contains `CREATE OR REPLACE PROCEDURE card_catalog.refresh_card_search_views()` with SECURITY DEFINER and two REFRESH statements
+
+- [ ] **Step 2: Find the right insertion point in 02_card_schema.sql**
+
+Read the end of 02_card_schema.sql to find where procedures are defined (after materialized view definitions).
+
+```bash
+tail -100 src/automana/database/SQL/schemas/02_card_schema.sql
+```
+
+Expected: Should show end of file with GRANT statements
+
+- [ ] **Step 3: Add the procedure and grant to 02_card_schema.sql**
+
+Append these lines before the final GRANT statements:
+
+```sql
+-- Refresh materialized views (SECURITY DEFINER so celery can refresh without needing MAINTAIN VIEW)
+CREATE OR REPLACE PROCEDURE card_catalog.refresh_card_search_views()
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = card_catalog, pg_catalog
+AS $$
+BEGIN
+    REFRESH MATERIALIZED VIEW CONCURRENTLY card_catalog.v_card_versions_complete;
+    REFRESH MATERIALIZED VIEW CONCURRENTLY card_catalog.v_card_name_suggest;
+END;
+$$;
+
+GRANT EXECUTE ON PROCEDURE card_catalog.refresh_card_search_views()
+    TO app_celery, app_rw, app_admin;
+```
+
+- [ ] **Step 4: Verify syntax is correct**
+
+```bash
+docker compose --env-file config/env/.env.dev -f deploy/docker-compose.dev.yml exec postgres psql -d automana -f src/automana/database/SQL/schemas/02_card_schema.sql -v ON_ERROR_STOP=1
+```
+
+Expected: No syntax errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/automana/database/SQL/schemas/02_card_schema.sql
+git commit -m "feat: consolidate migration_19 refresh_views into 02_card_schema.sql"
+```
+
+---
+
+## Task 3: Add Pricing Tiers DDL to 06_prices.sql (migrations 18–19)
+
+**Files:**
+- Modify: `src/automana/database/SQL/schemas/06_prices.sql`
+- Source: `migration_18_pricing_tiers.sql` + `migration_19_archive_to_weekly_fix.sql`
+
+**IMPORTANT:** Use migration_19's `archive_to_weekly()` procedure body (the one with `decompress_chunk()` loop and GUC settings), not migration_18's version.
+
+- [ ] **Step 1: Read both migration files to understand the full DDL**
+
+```bash
+cat src/automana/database/SQL/migrations/migration_18_pricing_tiers.sql
+cat src/automana/database/SQL/migrations/migration_19_archive_to_weekly_fix.sql
+```
+
+Expected: See table definitions, TimescaleDB hypertables, procedures, and GUC settings
+
+- [ ] **Step 2: Extract the 4 table definitions from migration_18**
+
+Note the exact column definitions and indexes for:
+- `pricing.print_price_daily` (TimescaleDB hypertable, 7-day chunks, compressed)
+- `pricing.print_price_weekly` (TimescaleDB hypertable, 28-day chunks, compressed)
+- `pricing.print_price_latest` (plain table)
+- `pricing.tier_watermark` (plain table with PK on `tier_name`)
+
+- [ ] **Step 3: Find insertion point in 06_prices.sql**
+
+Find the line where other pricing tables are created (after `pricing.price_observation`). This is where the new tables should go.
+
+```bash
+grep -n "CREATE TABLE pricing.price_observation" src/automana/database/SQL/schemas/06_prices.sql
+```
+
+- [ ] **Step 4: Add table definitions in correct order**
+
+Add these tables after the existing pricing tables and before procedures:
+
+```sql
+-- Daily price hypertable with 7-day chunks, compression every 30 days
+CREATE TABLE IF NOT EXISTS pricing.print_price_daily (
+    price_date DATE NOT NULL,
+    card_version_id UUID,
+    source_id SMALLINT,
+    transaction_type_id SMALLINT,
+    finish_id SMALLINT,
+    condition_id SMALLINT,
+    language_id INT,
+    list_low_cents INT,
+    list_avg_cents INT,
+    sold_avg_cents INT,
+    n_providers SMALLINT
+);
+SELECT create_hypertable('pricing.print_price_daily', 'price_date', if_not_exists => TRUE, chunk_time_interval => '7 days'::interval);
+ALTER TABLE pricing.print_price_daily SET (timescaledb.compress, timescaledb.compress_orderby='card_version_id, source_id, finish_id');
+SELECT add_compression_policy('pricing.print_price_daily', INTERVAL '30 days', if_not_exists => TRUE);
+CREATE INDEX IF NOT EXISTS idx_ppd_card_source_date ON pricing.print_price_daily (card_version_id, source_id, price_date DESC);
+CREATE INDEX IF NOT EXISTS idx_ppd_date_dims ON pricing.print_price_daily (price_date DESC, transaction_type_id, condition_id);
+
+-- Weekly price hypertable with 28-day chunks, compression every 7 days
+CREATE TABLE IF NOT EXISTS pricing.print_price_weekly (
+    price_week DATE NOT NULL,
+    card_version_id UUID,
+    source_id SMALLINT,
+    transaction_type_id SMALLINT,
+    finish_id SMALLINT,
+    condition_id SMALLINT,
+    language_id INT,
+    list_low_cents INT,
+    list_avg_cents INT,
+    sold_avg_cents INT,
+    n_providers SMALLINT,
+    n_days SMALLINT
+);
+SELECT create_hypertable('pricing.print_price_weekly', 'price_week', if_not_exists => TRUE, chunk_time_interval => '28 days'::interval);
+ALTER TABLE pricing.print_price_weekly SET (timescaledb.compress, timescaledb.compress_orderby='card_version_id, source_id, finish_id');
+SELECT add_compression_policy('pricing.print_price_weekly', INTERVAL '7 days', if_not_exists => TRUE);
+CREATE INDEX IF NOT EXISTS idx_ppw_card_source_week ON pricing.print_price_weekly (card_version_id, source_id, price_week DESC);
+CREATE INDEX IF NOT EXISTS idx_ppw_week_dims ON pricing.print_price_weekly (price_week DESC, transaction_type_id, condition_id);
+ALTER TABLE pricing.print_price_weekly ADD CONSTRAINT uk_ppw_weekly_dims UNIQUE (price_week, card_version_id, source_id, transaction_type_id, finish_id, condition_id, language_id);
+
+-- Latest daily snapshot
+CREATE TABLE IF NOT EXISTS pricing.print_price_latest (
+    card_version_id UUID PRIMARY KEY,
+    source_id SMALLINT,
+    transaction_type_id SMALLINT,
+    finish_id SMALLINT,
+    condition_id SMALLINT,
+    language_id INT,
+    price_cents INT,
+    price_date DATE,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Watermark for tier refresh state
+CREATE TABLE IF NOT EXISTS pricing.tier_watermark (
+    tier_name TEXT PRIMARY KEY,
+    last_processed_date DATE,
+    updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+- [ ] **Step 5: Add procedures from migration_18 and migration_19**
+
+Add `refresh_daily_prices()` from migration_18 and `archive_to_weekly()` from migration_19 (using the mission_19 body with decompress_chunk loop):
+
+```sql
+CREATE OR REPLACE PROCEDURE pricing.refresh_daily_prices(p_from DATE, p_to DATE)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_date DATE;
+BEGIN
+    FOR v_date IN SELECT DISTINCT price_date FROM pricing.price_observation 
+                  WHERE price_date BETWEEN p_from AND p_to
+                  ORDER BY price_date
+    LOOP
+        INSERT INTO pricing.print_price_daily (...)
+        SELECT ... FROM pricing.price_observation WHERE price_date = v_date
+        ON CONFLICT DO NOTHING;
+    END LOOP;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE pricing.archive_to_weekly(p_older_than INTERVAL)
+LANGUAGE plpgsql
+SET work_mem = '256MB'
+SET maintenance_work_mem = '512MB'
+SET timescaledb.max_tuples_decompressed_per_dml_transaction = 0
+AS $$
+DECLARE
+    v_chunk RECORD;
+BEGIN
+    FOR v_chunk IN
+        SELECT chunk_name FROM timescaledb_information.chunks
+        WHERE hypertable_name = 'print_price_daily'
+          AND range_start < (CURRENT_DATE - p_older_than)::bigint
+        ORDER BY range_start DESC
+    LOOP
+        EXECUTE format('SELECT decompress_chunk(%L)', v_chunk.chunk_name);
+        -- Archive logic with 7-day batching
+        INSERT INTO pricing.print_price_weekly (...)
+        SELECT price_week, ... FROM pricing.print_price_daily
+        WHERE price_date < CURRENT_DATE - p_older_than
+        ON CONFLICT DO NOTHING;
+        EXECUTE format('SELECT compress_chunk(%L)', v_chunk.chunk_name);
+    END LOOP;
+END;
+$$;
+```
+
+(Use the exact procedure bodies from migration_19_archive_to_weekly_fix.sql — this summary shows structure only)
+
+- [ ] **Step 6: Add data seed for tier_watermark**
+
+After procedures, add:
+
+```sql
+INSERT INTO pricing.tier_watermark (tier_name, last_processed_date)
+VALUES ('daily', '1970-01-01'), ('weekly', '1970-01-01')
+ON CONFLICT DO NOTHING;
+```
+
+- [ ] **Step 7: Add grants for all roles**
+
+```sql
+-- Grants for pricing tier tables
+GRANT SELECT, INSERT, UPDATE, DELETE ON pricing.print_price_daily TO app_celery, app_rw, app_admin;
+GRANT SELECT ON pricing.print_price_daily TO app_readonly;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON pricing.print_price_weekly TO app_celery, app_rw, app_admin;
+GRANT SELECT ON pricing.print_price_weekly TO app_readonly;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON pricing.print_price_latest TO app_celery, app_rw, app_admin;
+GRANT SELECT ON pricing.print_price_latest TO app_readonly;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON pricing.tier_watermark TO app_celery, app_rw, app_admin;
+GRANT SELECT ON pricing.tier_watermark TO app_readonly;
+
+GRANT EXECUTE ON PROCEDURE pricing.refresh_daily_prices(DATE, DATE) TO app_celery, app_rw, app_admin;
+GRANT EXECUTE ON PROCEDURE pricing.archive_to_weekly(INTERVAL) TO app_celery, app_rw, app_admin;
+```
+
+- [ ] **Step 8: Verify syntax**
+
+```bash
+docker compose --env-file config/env/.env.dev -f deploy/docker-compose.dev.yml exec postgres psql -d automana -f src/automana/database/SQL/schemas/06_prices.sql -v ON_ERROR_STOP=1
+```
+
+Expected: No syntax errors
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/automana/database/SQL/schemas/06_prices.sql
+git commit -m "feat: consolidate migration_18 and migration_19 pricing tiers into 06_prices.sql"
+```
+
+---
+
+## Task 4: Create 13_reporting_schema.sql from migration_24_reporting_schema.sql
+
+**Files:**
+- Create: `src/automana/database/SQL/schemas/13_reporting_schema.sql`
+- Source: `migration_24_reporting_schema.sql`
+
+- [ ] **Step 1: Read migration_24_reporting_schema.sql**
+
+```bash
+cat src/automana/database/SQL/migrations/migration_24_reporting_schema.sql
+```
+
+Expected: Contains schema creation and hourly_metrics table definition
+
+- [ ] **Step 2: Create new schema file with proper header**
+
+```bash
+cat > src/automana/database/SQL/schemas/13_reporting_schema.sql << 'EOF'
+-- Reporting schema for API and pipeline metrics aggregation
+-- Used by metrics collection services to store hourly summaries
+
+CREATE SCHEMA IF NOT EXISTS reporting;
+
+-- Hourly metrics aggregation table
+CREATE TABLE IF NOT EXISTS reporting.hourly_metrics (
+    id SERIAL PRIMARY KEY,
+    hour BIGINT NOT NULL,
+    metric_type VARCHAR(50) NOT NULL,
+    endpoint VARCHAR(255),
+    task_name VARCHAR(255),
+    status_code SMALLINT,
+    request_count INT DEFAULT 0,
+    error_count INT DEFAULT 0,
+    cache_hit_count INT DEFAULT 0,
+    response_time_p95 FLOAT,
+    response_time_median FLOAT,
+    response_time_max FLOAT,
+    celery_success_count INT DEFAULT 0,
+    celery_failure_count INT DEFAULT 0,
+    error_rate FLOAT,
+    cache_hit_rate FLOAT,
+    celery_success_rate FLOAT,
+    created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (hour, metric_type, endpoint, task_name, status_code)
+);
+
+CREATE INDEX IF NOT EXISTS idx_hourly_metrics_hour ON reporting.hourly_metrics (hour DESC);
+CREATE INDEX IF NOT EXISTS idx_hourly_metrics_metric_type ON reporting.hourly_metrics (metric_type);
+CREATE INDEX IF NOT EXISTS idx_hourly_metrics_endpoint ON reporting.hourly_metrics (endpoint);
+CREATE INDEX IF NOT EXISTS idx_hourly_metrics_task_name ON reporting.hourly_metrics (task_name);
+CREATE INDEX IF NOT EXISTS idx_hourly_metrics_created_at ON reporting.hourly_metrics (created_at DESC);
+
+-- Grants: SELECT to app_readonly, INSERT+UPDATE to app_celery, full DML to app_rw and app_admin
+GRANT USAGE ON SCHEMA reporting TO app_readonly, app_celery, app_rw, app_admin;
+GRANT SELECT ON reporting.hourly_metrics TO app_readonly;
+GRANT SELECT, INSERT, UPDATE ON reporting.hourly_metrics TO app_celery;
+GRANT SELECT, INSERT, UPDATE, DELETE ON reporting.hourly_metrics TO app_rw, app_admin;
+EOF
+```
+
+- [ ] **Step 3: Verify the file was created**
+
+```bash
+wc -l src/automana/database/SQL/schemas/13_reporting_schema.sql
+```
+
+Expected: 40+ lines
+
+- [ ] **Step 4: Test syntax**
+
+```bash
+docker compose --env-file config/env/.env.dev -f deploy/docker-compose.dev.yml exec postgres psql -d automana -f src/automana/database/SQL/schemas/13_reporting_schema.sql -v ON_ERROR_STOP=1
+```
+
+Expected: No syntax errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/automana/database/SQL/schemas/13_reporting_schema.sql
+git commit -m "feat: create 13_reporting_schema.sql from migration_24_reporting_schema.sql"
+```
+
+---
+
+## Task 5: Delete Absorbed Migrations (Bucket 1)
+
+**Files to delete:**
+- `migration_16_fix_staging_lower_set_code.sql` (absorbed in 06_prices.sql)
+- `migration_17_foil_finish_suffix.sql` (absorbed in 06_prices.sql)
+- `migration_18_fix_mtgjson_price_cents_overflow.sql` (absorbed in 11_mtgjson_schema.sql)
+- `migration_19_widen_redirect_uri.sql` (absorbed in 05_ebay.sql)
+- `migration_20_sandbox_scopes.sql` (absorbed in 05_ebay.sql)
+
+- [ ] **Step 1: Verify each migration has been consolidated**
+
+For each migration file, search its content in the corresponding schema file:
+
+```bash
+# 16: search for "staging_lower_set_code" or similar in 06_prices.sql
+grep -i "staging_lower_set_code\|fix_lower" src/automana/database/SQL/schemas/06_prices.sql
+
+# 17: search for "foil_finish_suffix" in 06_prices.sql
+grep -i "foil.*finish" src/automana/database/SQL/schemas/06_prices.sql
+
+# 18: search for "price_cents" or "LEAST.*2147483647" in 11_mtgjson_schema.sql
+grep -i "price_cents\|2147483647" src/automana/database/SQL/schemas/11_mtgjson_schema.sql
+
+# 19: search for "redirect_uri" in 05_ebay.sql
+grep -i "redirect_uri" src/automana/database/SQL/schemas/05_ebay.sql
+
+# 20: search for "sandbox" or "scopes" in 05_ebay.sql
+grep -i "sandbox\|SANDBOX_SCOPES" src/automana/database/SQL/schemas/05_ebay.sql
+```
+
+Expected: All searches find the consolidated DDL in the respective schema files
+
+- [ ] **Step 2: Delete the absorbed migration files**
+
+```bash
+rm src/automana/database/SQL/migrations/migration_16_fix_staging_lower_set_code.sql \
+   src/automana/database/SQL/migrations/migration_17_foil_finish_suffix.sql \
+   src/automana/database/SQL/migrations/migration_18_fix_mtgjson_price_cents_overflow.sql \
+   src/automana/database/SQL/migrations/migration_19_widen_redirect_uri.sql \
+   src/automana/database/SQL/migrations/migration_20_sandbox_scopes.sql
+```
+
+- [ ] **Step 3: Verify deletions with git status**
+
+```bash
+git status src/automana/database/SQL/migrations/
+```
+
+Expected: 5 deletions shown as `deleted: migration_XX_...`
+
+- [ ] **Step 4: Commit deletions**
+
+```bash
+git add -u src/automana/database/SQL/migrations/
+git commit -m "refactor: remove absorbed migrations (16, 17, 18, 19, 20)"
+```
+
+---
+
+## Task 6: Delete Consolidated Pricing Migrations (Bucket 2 — after consolidation)
+
+**Files to delete:**
+- `migration_18_pricing_tiers.sql` (consolidated into 06_prices.sql in Task 3)
+- `migration_19_archive_to_weekly_fix.sql` (consolidated into 06_prices.sql in Task 3)
+- `migration_19_refresh_views_security_definer.sql` (consolidated into 02_card_schema.sql in Task 2)
+
+- [ ] **Step 1: Verify consolidation is complete**
+
+Confirm Tasks 2 and 3 are committed and the schema files contain the necessary DDL:
+
+```bash
+git log --oneline -3
+```
+
+Expected: Recent commits for Tasks 2 and 3
+
+- [ ] **Step 2: Delete the three migration files**
+
+```bash
+rm src/automana/database/SQL/migrations/migration_18_pricing_tiers.sql \
+   src/automana/database/SQL/migrations/migration_19_archive_to_weekly_fix.sql \
+   src/automana/database/SQL/migrations/migration_19_refresh_views_security_definer.sql
+```
+
+- [ ] **Step 3: Verify with git status**
+
+```bash
+git status src/automana/database/SQL/migrations/
+```
+
+Expected: 3 deletions shown
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -u src/automana/database/SQL/migrations/
+git commit -m "refactor: remove consolidated pricing migrations (18, 19 archive, 19 refresh)"
+```
+
+---
+
+## Task 7: Verify No Migrations Remain in Unwanted Locations
+
+**Files:**
+- Inspect: `src/automana/database/SQL/migrations/`
+
+- [ ] **Step 1: List all remaining migration files**
+
+```bash
+ls -la src/automana/database/SQL/migrations/*.sql
+```
+
+Expected: Only these files remain:
+- `migration_21_*.sql` (if it exists)
+- `migration_22_ebay_refresh_tokens.sql` (dev-only TRUNCATE)
+- `migration_23_scopes_user_subset_constraint.sql` (dev-only DELETE)
+- `migration_24_prod_scopes_sync.sql` (prod-specific scope app linkage)
+- `migration_25_fix2_fix3.sql` (already consolidated in previous session)
+
+- [ ] **Step 2: Verify no "fix2_fix3" or numbering gaps**
+
+```bash
+ls -1 src/automana/database/SQL/migrations/ | sort
+```
+
+Expected: Consistent numbering; no duplicate migration_25; only dev/env-specific migrations left
+
+- [ ] **Step 3: Document which migrations were kept and why**
+
+Create a summary showing:
+- Migration 22: `TRUNCATE app_integration.ebay_tokens` — dev-only cleanup, must not run in production
+- Migration 23: `DELETE FROM app_integration.scopes_user` — dev-only cleanup, must not run in production
+- Migration 24: `scope_app` linkage — prod-specific, references production app row
+
+```bash
+cat > /tmp/REMAINING_MIGRATIONS.txt << 'EOF'
+# Remaining Migrations (Dev/Env-Specific Only)
+
+## migration_22_ebay_refresh_tokens.sql
+- Purpose: Dev-only truncation of ebay_tokens table
+- Reason Kept: TRUNCATE RESTART IDENTITY is destructive; only appropriate for dev rebuilds
+- Production: Must never run in production
+
+## migration_23_scopes_user_subset_constraint.sql
+- Purpose: Dev-only deletion of stale scopes_user records
+- Reason Kept: DELETE is destructive; only appropriate for dev rebuilds
+- Production: Must never run in production
+
+## migration_24_prod_scopes_sync.sql
+- Purpose: Prod-specific scope app linkage for 'automana-production-v1' app
+- Reason Kept: References production-specific app row not seeded by schema files
+- Production: Must be run only in production environment
+
+All other migrations (16-21, 25) have been consolidated into schema files.
+EOF
+cat /tmp/REMAINING_MIGRATIONS.txt
+```
+
+- [ ] **Step 4: Commit the summary as documentation**
+
+```bash
+git add PIPELINE_TECHNICAL_DEBT.md # if this file exists and needs updating
+git commit -m "docs: record consolidated migrations and dev-only migration retention"
+```
+
+---
+
+## Task 8: Full Integration Test — Rebuild Database from Schema Files
+
+**Files:**
+- Execute: `src/automana/database/SQL/maintenance/rebuild_dev_db.sh`
+
+- [ ] **Step 1: Create a backup of the current database**
+
+```bash
+docker exec automana-postgres-dev pg_dump -U automana_admin automana | gzip > backups/automana-pre-consolidation-$(date -u +%Y%m%d-%H%M%S).sql.gz
+ls -lh backups/automana-pre-consolidation-*.sql.gz
+```
+
+Expected: Backup file created with non-zero size (100MB+ expected)
+
+- [ ] **Step 2: Run full rebuild with two-phase startup**
+
+```bash
+dcdev-automana down
+dcdev-automana up -d --build postgres redis
+# Wait for postgres to be healthy
+sleep 30
+docker compose --env-file config/env/.env.dev -f deploy/docker-compose.dev.yml exec postgres pg_isready -U automana_admin
+```
+
+Expected: `postgres is accepting connections` message
+
+- [ ] **Step 3: Run rebuild with --only rebuild**
+
+```bash
+bash ./src/automana/database/SQL/maintenance/rebuild_dev_db.sh --only rebuild
+```
+
+Expected: Schema files applied, migrations applied, grants set, no errors
+
+- [ ] **Step 4: Bring up celery and run pipeline skip-rebuild**
+
+```bash
+dcdev-automana up -d --build celery-worker celery-beat
+sleep 10
+bash ./src/automana/database/SQL/maintenance/rebuild_dev_db.sh --skip-rebuild
+```
+
+Expected: Pipelines run and complete without errors; `ops.ingestion_runs` shows terminal status for each pipeline
+
+- [ ] **Step 5: Verify no data loss or constraint violations**
+
+```bash
+docker compose --env-file config/env/.env.dev -f deploy/docker-compose.dev.yml exec postgres psql -U app_agent -d automana << 'EOF'
+SELECT COUNT(*) as card_count FROM card_catalog.cards;
+SELECT COUNT(*) as set_count FROM card_catalog.sets;
+SELECT COUNT(*) as price_count FROM pricing.price_observation;
+SELECT COUNT(*) as tier_count FROM pricing.tier_watermark;
+SELECT COUNT(*) as metrics_count FROM reporting.hourly_metrics;
+SELECT COUNT(*) as ebay_scopes FROM app_integration.scopes WHERE app_id IS NOT NULL;
+EOF
+```
+
+Expected: Non-zero counts for card_catalog, pricing, and reporting tables; ebay_scopes > 0
+
+- [ ] **Step 6: Verify printing schema exists and is populated (if recovered)**
+
+```bash
+docker compose --env-file config/env/.env.dev -f deploy/docker-compose.dev.yml exec postgres psql -U app_agent -d automana << 'EOF'
+\dt staging.*
+SELECT COUNT(*) FROM staging.* LIMIT 10;
+EOF
+```
+
+Expected: Staging schema tables exist and have data
+
+- [ ] **Step 7: Commit successful rebuild**
+
+```bash
+git add -A
+git commit -m "test: verify database rebuild succeeds with consolidated schema files"
+```
+
+---
+
+## Summary
+
+✅ **Consolidation Complete**
+
+All migrations have been consolidated or categorized:
+
+| Bucket | Migrations | Action |
+|--------|-----------|--------|
+| 1 — Already absorbed | 16, 17, 18, 19, 20 | ✅ Deleted |
+| 2 — Newly consolidated | 18 (pricing), 19 (archive), 19 (refresh), 24 (reporting) | ✅ Added to schemas 02, 06, 13 |
+| 3 — Keep as-is | 22, 23, 24 (prod) | ✅ Retained (dev/env-specific) |
+| Special case | 25 (fix2_fix3) | ✅ Already consolidated (previous session) |
+| Recovery | 12_staging_schema.sql | ✅ Recovered from git history |
+
+**Files modified:** 02_card_schema.sql, 06_prices.sql, 12_staging_schema.sql (recovered), 13_reporting_schema.sql (new)
+
+**Files deleted:** 8 migration files
+
+**Migrations remaining:** 4 (dev-only and prod-specific, as documented)
+
+**Data loss:** None — all operations use `IF NOT EXISTS`, `ON CONFLICT DO NOTHING`, or dev-only markers
+
+---
+
+## Execution Options
+
+Plan complete and saved to `/home/arthur/projects/AutoMana/docs/superpowers/plans/2026-05-07-consolidate-remaining-migrations.md`.
+
+**Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach would you prefer?

--- a/docs/superpowers/plans/2026-05-08-ebay-setup-wizard-wiring.md
+++ b/docs/superpowers/plans/2026-05-08-ebay-setup-wizard-wiring.md
@@ -1,0 +1,1337 @@
+# eBay Setup Wizard Wiring Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the `/ebay/setup` 4-step wizard to `POST /api/integrations/ebay/auth/admin/apps`, replacing all mock data with real API calls and adding the missing form fields the backend requires.
+
+**Architecture:** Three frontend layers change: (1) `mockEbayApp.ts` gains full eBay scope URLs and a `RegistrationResult` type; (2) a new `features/ebay/api.ts` owns the `registerEbayApp()` call; (3) `setup.tsx` wires the wizard — adds `app_name`, `description`, and environment fields to Step 2, calls the API on Step 3 "Next", and replaces the fake verify step with a registration result screen. No backend changes needed.
+
+**Tech Stack:** React 18, TypeScript, TanStack Router, Vitest + Testing Library, existing `apiClient` wrapper, CSS Modules.
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `src/frontend/src/features/ebay/mockEbayApp.ts` | Modify | Add `scopeUrl` to `OAuthScope`, full eBay scope URLs, `RegistrationResult` type; remove `devId` from `EbayCredentials` |
+| `src/frontend/src/features/ebay/api.ts` | **Create** | `registerEbayApp()` — single POST to backend |
+| `src/frontend/src/routes/ebay/Setup.module.css` | Modify | Add `.envToggle`, `.envOption`, `.envOptionActive` for environment segmented control |
+| `src/frontend/src/routes/ebay/setup.tsx` | Modify | New fields on Step 2, async submit on Step 3, result screen on Step 4 |
+| `src/frontend/src/routes/ebay/__tests__/setup.test.tsx` | Modify | Remove Dev ID assertions, add new field assertions, mock API, test submit flow |
+
+---
+
+## Task 1: Update mockEbayApp.ts types and scope URLs
+
+**Files:**
+- Modify: `src/frontend/src/features/ebay/mockEbayApp.ts`
+
+- [ ] **Step 1: Update `mockEbayApp.ts`**
+
+Replace the entire file with:
+
+```typescript
+// src/frontend/src/features/ebay/mockEbayApp.ts
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+export interface EbayCredentials {
+  appId: string       // Client ID (ebay_app_id)
+  certId: string      // Client Secret
+  ruName: string      // Redirect URI — read-only, provided by backend config
+}
+
+export interface OAuthScope {
+  id: string
+  name: string
+  description: string
+  scopeUrl: string    // Full eBay scope URL sent to the backend
+  required: boolean
+  enabled: boolean
+}
+
+export type RegistrationResult =
+  | { success: true; appCode: string }
+  | { success: false; error: string }
+
+export interface ConnectionStatus {
+  connected: boolean
+  environment: 'sandbox' | 'production'
+  lastVerified: string | null
+  tokenExpires: string | null
+  dailyQuota: number
+  usedToday: number
+}
+
+export type SetupStep = 0 | 1 | 2 | 3
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+export const REDIRECT_URI = 'https://auth.automana.app/oauth/callback/ebay'
+
+export const MOCK_OAUTH_SCOPES: OAuthScope[] = [
+  {
+    id: 'sell.inventory',
+    name: 'sell.inventory',
+    description: 'Read and manage your eBay inventory listings',
+    scopeUrl: 'https://api.ebay.com/oauth/api_scope/sell.inventory',
+    required: true,
+    enabled: true,
+  },
+  {
+    id: 'sell.account',
+    name: 'sell.account',
+    description: 'Access your eBay seller account settings',
+    scopeUrl: 'https://api.ebay.com/oauth/api_scope/sell.account',
+    required: true,
+    enabled: true,
+  },
+  {
+    id: 'sell.marketing',
+    name: 'sell.marketing',
+    description: 'Create and manage eBay marketing promotions',
+    scopeUrl: 'https://api.ebay.com/oauth/api_scope/sell.marketing',
+    required: false,
+    enabled: false,
+  },
+  {
+    id: 'sell.fulfillment',
+    name: 'sell.fulfillment',
+    description: 'Manage order fulfillment and shipping details',
+    scopeUrl: 'https://api.ebay.com/oauth/api_scope/sell.fulfillment',
+    required: true,
+    enabled: true,
+  },
+  {
+    id: 'buy.browse',
+    name: 'buy.browse',
+    description: 'Search and browse eBay item catalog for pricing',
+    scopeUrl: 'https://api.ebay.com/oauth/api_scope/buy.browse',
+    required: true,
+    enabled: true,
+  },
+  {
+    id: 'commerce.identity',
+    name: 'commerce.identity',
+    description: 'Access verified identity for user authorization',
+    scopeUrl: 'https://api.ebay.com/oauth/api_scope/commerce.identity.readonly',
+    required: true,
+    enabled: true,
+  },
+]
+
+export const MOCK_CONNECTION_STATUS: ConnectionStatus = {
+  connected: false,
+  environment: 'production',
+  lastVerified: null,
+  tokenExpires: null,
+  dailyQuota: 5000,
+  usedToday: 0,
+}
+
+export const MOCK_CONNECTED_STATUS: ConnectionStatus = {
+  connected: true,
+  environment: 'production',
+  lastVerified: '2026-05-06T10:32:00Z',
+  tokenExpires: '2026-06-06T10:32:00Z',
+  dailyQuota: 5000,
+  usedToday: 247,
+}
+
+export const SETUP_STEPS = [
+  { label: 'Create app' },
+  { label: 'Paste keys' },
+  { label: 'OAuth scopes' },
+  { label: 'Done' },
+]
+
+// ── Help links ─────────────────────────────────────────────────────────────
+
+export const HELP_LINKS = [
+  { label: 'eBay Developer Portal', href: 'https://developer.ebay.com' },
+  { label: 'Create an application', href: 'https://developer.ebay.com/my/keys' },
+  { label: 'Configure RuName', href: 'https://developer.ebay.com/my/auth' },
+  { label: 'OAuth scope reference', href: 'https://developer.ebay.com/api-docs/static/oauth-scopes.html' },
+]
+
+export const BYOA_BENEFITS = [
+  'Your API quota is never shared with other AutoMana users',
+  'Credentials stay in your eBay account — we only store tokens',
+  'Revoke access instantly from the eBay developer portal',
+  'Sandbox support for testing without live listings',
+]
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/mockEbayApp.ts
+git commit -m "feat(ebay): add scopeUrl to OAuthScope and RegistrationResult type"
+```
+
+---
+
+## Task 2: Create features/ebay/api.ts
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/api.ts`
+
+- [ ] **Step 1: Write a failing test for `registerEbayApp`**
+
+Create `src/frontend/src/features/ebay/__tests__/api.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { registerEbayApp } from '../api'
+
+// Mock apiClient at the module level
+vi.mock('../../../lib/apiClient', () => ({
+  apiClient: vi.fn(),
+}))
+
+import { apiClient } from '../../../lib/apiClient'
+
+const mockApiClient = vi.mocked(apiClient)
+
+describe('registerEbayApp', () => {
+  beforeEach(() => {
+    mockApiClient.mockReset()
+  })
+
+  it('calls POST /integrations/ebay/auth/admin/apps with correct body', async () => {
+    mockApiClient.mockResolvedValue({ message: 'eBay app registered successfully', app_code: 'cool_app_123' })
+
+    const result = await registerEbayApp({
+      app_name: 'My Store',
+      description: 'Test app',
+      environment: 'SANDBOX',
+      ebay_app_id: 'MyApp-1234',
+      client_secret: 'SBX-secret',
+      redirect_uri: 'https://auth.automana.app/oauth/callback/ebay',
+      allowed_scopes: ['https://api.ebay.com/oauth/api_scope/sell.inventory'],
+    })
+
+    expect(mockApiClient).toHaveBeenCalledWith(
+      '/integrations/ebay/auth/admin/apps',
+      expect.objectContaining({
+        method: 'POST',
+        body: expect.stringContaining('"app_name":"My Store"'),
+      })
+    )
+    expect(result.app_code).toBe('cool_app_123')
+  })
+
+  it('defaults app_code to empty string', async () => {
+    mockApiClient.mockResolvedValue({ message: 'ok', app_code: 'auto_123' })
+
+    await registerEbayApp({
+      app_name: 'X',
+      description: '',
+      environment: 'PRODUCTION',
+      ebay_app_id: 'id',
+      client_secret: 'secret',
+      redirect_uri: 'https://example.com',
+      allowed_scopes: [],
+    })
+
+    const body = JSON.parse((mockApiClient.mock.calls[0][1] as RequestInit).body as string)
+    expect(body.app_code).toBe('')
+  })
+
+  it('propagates errors from apiClient', async () => {
+    mockApiClient.mockRejectedValue(new Error('API 403: forbidden'))
+    await expect(
+      registerEbayApp({
+        app_name: 'X',
+        description: '',
+        environment: 'SANDBOX',
+        ebay_app_id: 'id',
+        client_secret: 'secret',
+        redirect_uri: 'https://example.com',
+        allowed_scopes: [],
+      })
+    ).rejects.toThrow('API 403: forbidden')
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd src/frontend && npx vitest run src/frontend/src/features/ebay/__tests__/api.test.ts
+```
+
+Expected: FAIL with "Cannot find module '../api'"
+
+- [ ] **Step 3: Create `features/ebay/api.ts`**
+
+```typescript
+// src/frontend/src/features/ebay/api.ts
+import { apiClient } from '../../lib/apiClient'
+
+export interface RegisterEbayAppRequest {
+  app_name: string
+  description: string
+  environment: 'SANDBOX' | 'PRODUCTION'
+  ebay_app_id: string
+  client_secret: string
+  redirect_uri: string
+  allowed_scopes: string[]
+}
+
+export interface RegisterEbayAppResponse {
+  message: string
+  app_code: string
+}
+
+export async function registerEbayApp(data: RegisterEbayAppRequest): Promise<RegisterEbayAppResponse> {
+  return apiClient<RegisterEbayAppResponse>('/integrations/ebay/auth/admin/apps', {
+    method: 'POST',
+    body: JSON.stringify({
+      app_name: data.app_name,
+      description: data.description,
+      environment: data.environment,
+      ebay_app_id: data.ebay_app_id,
+      client_secret: data.client_secret,
+      redirect_uri: data.redirect_uri,
+      allowed_scopes: data.allowed_scopes,
+      app_code: '',
+      response_type: 'code',
+      user_requirements: ['premium'],
+    }),
+  })
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+cd src/frontend && npx vitest run src/frontend/src/features/ebay/__tests__/api.test.ts
+```
+
+Expected: 3 passing
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/api.ts src/frontend/src/features/ebay/__tests__/api.test.ts
+git commit -m "feat(ebay): add registerEbayApp API function"
+```
+
+---
+
+## Task 3: Add new fields to Step 2 (credentials)
+
+**Files:**
+- Modify: `src/frontend/src/routes/ebay/Setup.module.css`
+- Modify: `src/frontend/src/routes/ebay/setup.tsx`
+- Modify: `src/frontend/src/routes/ebay/__tests__/setup.test.tsx`
+
+- [ ] **Step 1: Add CSS for environment segmented control**
+
+Append to the end of `src/frontend/src/routes/ebay/Setup.module.css`:
+
+```css
+/* ── Environment segmented control ───────────────────────── */
+.envToggle {
+  display: flex;
+  border: 1px solid var(--hd-border);
+  border-radius: 6px;
+  overflow: hidden;
+  width: fit-content;
+}
+
+.envOption {
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  background: transparent;
+  border: none;
+  color: var(--hd-sub);
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.envOption + .envOption {
+  border-left: 1px solid var(--hd-border);
+}
+
+.envOptionActive {
+  background: var(--hd-accent);
+  color: var(--hd-bg);
+}
+```
+
+- [ ] **Step 2: Update the failing tests first**
+
+Replace the full content of `src/frontend/src/routes/ebay/__tests__/setup.test.tsx` with:
+
+```typescript
+// src/frontend/src/routes/ebay/__tests__/setup.test.tsx
+import React from 'react'
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>()
+  return {
+    ...actual,
+    createFileRoute: (_path: string) => (opts: unknown) => opts,
+    useNavigate: () => vi.fn(),
+  }
+})
+
+vi.mock('../../../components/layout/AppShell', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div data-testid="app-shell">{children}</div>,
+}))
+vi.mock('../../../components/layout/TopBar', () => ({
+  TopBar: ({ title, subtitle, breadcrumb }: { title: string; subtitle?: string; breadcrumb?: string }) => (
+    <div data-testid="topbar">
+      {breadcrumb && <span>{breadcrumb}</span>}
+      {subtitle && <span>{subtitle}</span>}
+      <h1>{title}</h1>
+    </div>
+  ),
+}))
+
+vi.mock('../../../features/ebay/api', () => ({
+  registerEbayApp: vi.fn().mockResolvedValue({
+    message: 'eBay app registered successfully',
+    app_code: 'cool_app_123',
+  }),
+}))
+
+import { registerEbayApp } from '../../../features/ebay/api'
+const mockRegisterEbayApp = vi.mocked(registerEbayApp)
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined)
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: writeTextMock },
+  writable: true,
+})
+
+import { EbaySetupPage } from '../setup'
+
+// Helper: navigate to Step 2 (credentials)
+function goToStep2() {
+  render(<EbaySetupPage />)
+  fireEvent.click(screen.getByRole('button', { name: /next/i }))
+}
+
+// Helper: fill credentials and advance to Step 3 (scopes)
+function goToStep3() {
+  goToStep2()
+  fireEvent.change(screen.getByLabelText('App Name'), { target: { value: 'My Store' } })
+  fireEvent.change(screen.getByLabelText('App ID (Client ID)'), { target: { value: 'test-app-id' } })
+  fireEvent.change(screen.getByLabelText('Cert ID (Client Secret)'), { target: { value: 'test-cert-id' } })
+  fireEvent.click(screen.getByRole('button', { name: /next/i }))
+}
+
+describe('EbaySetupPage', () => {
+  beforeEach(() => {
+    writeTextMock.mockClear()
+    mockRegisterEbayApp.mockReset()
+    mockRegisterEbayApp.mockResolvedValue({
+      message: 'eBay app registered successfully',
+      app_code: 'cool_app_123',
+    })
+  })
+
+  it('renders page title', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText('Connect your eBay app')).toBeTruthy()
+  })
+
+  it('renders breadcrumb and subtitle', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText('Settings / Integrations')).toBeTruthy()
+    expect(screen.getByText('eBay Developer')).toBeTruthy()
+  })
+
+  it('renders all 4 stepper steps', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText('Create app')).toBeTruthy()
+    expect(screen.getByText('Paste keys')).toBeTruthy()
+    expect(screen.getByText('OAuth scopes')).toBeTruthy()
+    expect(screen.getByText('Done')).toBeTruthy()
+  })
+
+  it('shows Step 1 (Create app) content by default', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText('Create your eBay app')).toBeTruthy()
+    expect(screen.getByText(/developer.ebay.com/)).toBeTruthy()
+  })
+
+  it('advances to Step 2 (credentials) when Next is clicked', () => {
+    goToStep2()
+    expect(screen.getByLabelText('App Name')).toBeTruthy()
+    expect(screen.getByLabelText('App ID (Client ID)')).toBeTruthy()
+    expect(screen.getByLabelText('Cert ID (Client Secret)')).toBeTruthy()
+  })
+
+  it('does not show Dev ID field', () => {
+    goToStep2()
+    expect(screen.queryByLabelText('Dev ID')).toBeNull()
+  })
+
+  it('shows environment toggle with Sandbox and Production options', () => {
+    goToStep2()
+    expect(screen.getByRole('button', { name: /sandbox/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /production/i })).toBeTruthy()
+  })
+
+  it('shows validation errors on Step 2 when Next clicked with empty fields', () => {
+    goToStep2()
+    fireEvent.click(screen.getByRole('button', { name: /next/i }))
+    expect(screen.getByText('App name is required')).toBeTruthy()
+    expect(screen.getByText('App ID is required')).toBeTruthy()
+    expect(screen.getByText('Cert ID is required')).toBeTruthy()
+  })
+
+  it('allows navigating back from Step 2', () => {
+    goToStep2()
+    fireEvent.click(screen.getByRole('button', { name: /back/i }))
+    expect(screen.getByText('Create your eBay app')).toBeTruthy()
+  })
+
+  it('copies Redirect URI to clipboard when copy button clicked', async () => {
+    goToStep2()
+    const copyBtn = screen.getByRole('button', { name: /copy redirect uri/i })
+    fireEvent.click(copyBtn)
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledWith(expect.stringContaining('automana.app'))
+    })
+  })
+
+  it('shows Redirect URI as read-only input', () => {
+    goToStep2()
+    const ruNameInput = screen.getByLabelText(/redirect uri/i) as HTMLInputElement
+    expect(ruNameInput.readOnly).toBe(true)
+    expect(ruNameInput.value).toContain('automana.app')
+  })
+
+  it('shows Cert ID input as password (masked) by default', () => {
+    goToStep2()
+    const certInput = screen.getByLabelText('Cert ID (Client Secret)') as HTMLInputElement
+    expect(certInput.type).toBe('password')
+  })
+
+  it('reveals Cert ID when eye button is clicked', () => {
+    goToStep2()
+    const certInput = screen.getByLabelText('Cert ID (Client Secret)') as HTMLInputElement
+    const revealBtn = screen.getByRole('button', { name: /show cert id/i })
+    fireEvent.click(revealBtn)
+    expect(certInput.type).toBe('text')
+  })
+
+  it('advances to Step 3 (scopes) when required credentials are filled', () => {
+    goToStep3()
+    expect(screen.getByText('Configure OAuth scopes')).toBeTruthy()
+  })
+
+  it('renders all OAuth scopes in Step 3', () => {
+    goToStep3()
+    expect(screen.getByText('sell.inventory')).toBeTruthy()
+    expect(screen.getByText('sell.account')).toBeTruthy()
+    expect(screen.getByText('sell.marketing')).toBeTruthy()
+    expect(screen.getByText('sell.fulfillment')).toBeTruthy()
+    expect(screen.getByText('buy.browse')).toBeTruthy()
+    expect(screen.getByText('commerce.identity')).toBeTruthy()
+  })
+
+  it('shows REQUIRED badges on required scopes', () => {
+    goToStep3()
+    const badges = screen.getAllByText('REQUIRED')
+    expect(badges.length).toBeGreaterThanOrEqual(5)
+  })
+
+  it('toggles non-required scope (sell.marketing)', () => {
+    goToStep3()
+    const marketingToggle = screen.getByRole('switch', { name: /toggle sell\.marketing/i })
+    expect(marketingToggle.getAttribute('aria-checked')).toBe('false')
+    fireEvent.click(marketingToggle)
+    expect(marketingToggle.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('does not toggle required scopes (sell.inventory stays on)', () => {
+    goToStep3()
+    const inventoryToggle = screen.getByRole('switch', { name: /toggle sell\.inventory/i })
+    expect(inventoryToggle.getAttribute('aria-checked')).toBe('true')
+    fireEvent.click(inventoryToggle)
+    expect(inventoryToggle.getAttribute('aria-checked')).toBe('true')
+  })
+
+  it('calls registerEbayApp with correct payload when Register App clicked', async () => {
+    goToStep3()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /register app/i }))
+    })
+    expect(mockRegisterEbayApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        app_name: 'My Store',
+        ebay_app_id: 'test-app-id',
+        client_secret: 'test-cert-id',
+        environment: 'SANDBOX',
+        redirect_uri: expect.stringContaining('automana.app'),
+        allowed_scopes: expect.arrayContaining([
+          'https://api.ebay.com/oauth/api_scope/sell.inventory',
+        ]),
+      })
+    )
+  })
+
+  it('shows success screen on Step 4 after successful registration', async () => {
+    goToStep3()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /register app/i }))
+    })
+    await waitFor(() => {
+      expect(screen.getByText('App registered successfully')).toBeTruthy()
+      expect(screen.getByText('cool_app_123')).toBeTruthy()
+    })
+  })
+
+  it('shows error screen on Step 4 when registration fails', async () => {
+    mockRegisterEbayApp.mockRejectedValue(new Error('API 400: conflict'))
+    goToStep3()
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /register app/i }))
+    })
+    await waitFor(() => {
+      expect(screen.getByText('Registration failed')).toBeTruthy()
+      expect(screen.getByText('API 400: conflict')).toBeTruthy()
+    })
+  })
+
+  it('renders sidebar with not connected status', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText('Connection status')).toBeTruthy()
+    expect(screen.getByText('Not connected')).toBeTruthy()
+  })
+
+  it('renders sidebar connection metrics', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText('Environment')).toBeTruthy()
+    expect(screen.getByText('Last verified')).toBeTruthy()
+    expect(screen.getByText('Token expires')).toBeTruthy()
+    expect(screen.getByText('Daily quota')).toBeTruthy()
+    expect(screen.getByText('5,000')).toBeTruthy()
+  })
+
+  it('renders "Why bring your own app?" section', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText("Why bring your own app?")).toBeTruthy()
+    expect(screen.getByText(/api quota/i)).toBeTruthy()
+  })
+
+  it('renders "Need help?" section with eBay developer portal link', () => {
+    render(<EbaySetupPage />)
+    expect(screen.getByText('Need help?')).toBeTruthy()
+    const link = screen.getByText('eBay Developer Portal')
+    expect(link.closest('a')?.getAttribute('href')).toContain('developer.ebay.com')
+  })
+})
+```
+
+- [ ] **Step 3: Run updated tests — expect FAIL**
+
+```bash
+cd src/frontend && npx vitest run src/frontend/src/routes/ebay/__tests__/setup.test.tsx
+```
+
+Expected: multiple failures (new labels not rendered yet, registerEbayApp not wired, Step 4 content different)
+
+- [ ] **Step 4: Update `setup.tsx` — replace full file**
+
+```typescript
+// src/frontend/src/routes/ebay/setup.tsx
+import React, { useState } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { AppShell } from '../../components/layout/AppShell'
+import { TopBar } from '../../components/layout/TopBar'
+import { Button } from '../../components/ui/Button'
+import { Toggle } from '../../components/ui/Toggle'
+import { Icon } from '../../components/design-system/Icon'
+import {
+  MOCK_OAUTH_SCOPES,
+  REDIRECT_URI,
+  SETUP_STEPS,
+  HELP_LINKS,
+  BYOA_BENEFITS,
+  MOCK_CONNECTION_STATUS,
+  type OAuthScope,
+  type ConnectionStatus,
+  type RegistrationResult,
+} from '../../features/ebay/mockEbayApp'
+import { registerEbayApp } from '../../features/ebay/api'
+import styles from './Setup.module.css'
+
+export const Route = createFileRoute('/ebay/setup')({
+  component: EbaySetupPage,
+})
+
+export { EbaySetupPage }
+
+// ── Step 1: Create app instructions ───────────────────────────────────────
+
+function StepCreateApp() {
+  return (
+    <div className={styles.stepContent}>
+      <h2 className={styles.stepHeading}>Create your eBay app</h2>
+      <p className={styles.stepDesc}>
+        You'll need a free eBay developer account to generate API credentials for AutoMana.
+      </p>
+      <ol className={styles.instructionList}>
+        <li>
+          Go to{' '}
+          <a
+            href="https://developer.ebay.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.externalLink}
+          >
+            developer.ebay.com
+          </a>{' '}
+          and sign in (or create a free account).
+        </li>
+        <li>
+          Navigate to <strong>Application Keys</strong> in the top navigation.
+        </li>
+        <li>
+          Click <strong>Create a keyset</strong>, choose <em>Production</em>, and name your app
+          (e.g., "AutoMana").
+        </li>
+        <li>
+          Copy the <strong>App ID (Client ID)</strong> and <strong>Cert ID</strong> — you'll
+          paste them in the next step.
+        </li>
+      </ol>
+      <div className={styles.infoBox}>
+        <Icon kind="shield" size={14} color="var(--hd-blue)" />
+        <span>
+          eBay developer accounts are free. Your credentials are encrypted at rest and never
+          shared with other AutoMana users.
+        </span>
+      </div>
+    </div>
+  )
+}
+
+// ── Step 2: Paste credentials ──────────────────────────────────────────────
+
+type Environment = 'SANDBOX' | 'PRODUCTION'
+
+interface StepCredentialsProps {
+  appName: string
+  description: string
+  environment: Environment
+  appId: string
+  certId: string
+  onAppNameChange: (v: string) => void
+  onDescriptionChange: (v: string) => void
+  onEnvironmentChange: (v: Environment) => void
+  onAppIdChange: (v: string) => void
+  onCertIdChange: (v: string) => void
+  errors: Record<string, string>
+}
+
+function StepCredentials({
+  appName,
+  description,
+  environment,
+  appId,
+  certId,
+  onAppNameChange,
+  onDescriptionChange,
+  onEnvironmentChange,
+  onAppIdChange,
+  onCertIdChange,
+  errors,
+}: StepCredentialsProps) {
+  const [certRevealed, setCertRevealed] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  function copyRuName() {
+    navigator.clipboard.writeText(REDIRECT_URI).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
+  return (
+    <div className={styles.stepContent}>
+      <h2 className={styles.stepHeading}>Paste your eBay credentials</h2>
+      <p className={styles.stepDesc}>
+        Find these in the eBay Developer Portal under <strong>Application Keys</strong>.
+      </p>
+
+      <div className={styles.formGrid}>
+        {/* App Name */}
+        <div className={styles.field}>
+          <label className={styles.fieldLabel} htmlFor="ebay-app-name">
+            App Name
+          </label>
+          <div className={styles.inputWrapper}>
+            <Icon kind="tag" size={14} color="var(--hd-muted)" />
+            <input
+              id="ebay-app-name"
+              className={[styles.input, errors.appName ? styles.inputError : ''].filter(Boolean).join(' ')}
+              type="text"
+              placeholder="My AutoMana Store"
+              value={appName}
+              onChange={(e) => onAppNameChange(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+          {errors.appName && <span className={styles.errorMsg}>{errors.appName}</span>}
+        </div>
+
+        {/* Description */}
+        <div className={styles.field}>
+          <label className={styles.fieldLabel} htmlFor="ebay-description">
+            Description
+            <span className={styles.readOnlyTag}>optional</span>
+          </label>
+          <div className={styles.inputWrapper}>
+            <input
+              id="ebay-description"
+              className={styles.input}
+              type="text"
+              placeholder="e.g. My main eBay seller account"
+              value={description}
+              onChange={(e) => onDescriptionChange(e.target.value)}
+              autoComplete="off"
+            />
+          </div>
+        </div>
+
+        {/* Environment */}
+        <div className={styles.field}>
+          <label className={styles.fieldLabel}>
+            Environment
+          </label>
+          <div className={styles.envToggle}>
+            <button
+              type="button"
+              className={[styles.envOption, environment === 'SANDBOX' ? styles.envOptionActive : ''].filter(Boolean).join(' ')}
+              onClick={() => onEnvironmentChange('SANDBOX')}
+              aria-pressed={environment === 'SANDBOX'}
+            >
+              Sandbox
+            </button>
+            <button
+              type="button"
+              className={[styles.envOption, environment === 'PRODUCTION' ? styles.envOptionActive : ''].filter(Boolean).join(' ')}
+              onClick={() => onEnvironmentChange('PRODUCTION')}
+              aria-pressed={environment === 'PRODUCTION'}
+            >
+              Production
+            </button>
+          </div>
+        </div>
+
+        {/* App ID */}
+        <div className={styles.field}>
+          <label className={styles.fieldLabel} htmlFor="ebay-app-id">
+            App ID (Client ID)
+          </label>
+          <div className={styles.inputWrapper}>
+            <Icon kind="key" size={14} color="var(--hd-muted)" />
+            <input
+              id="ebay-app-id"
+              className={[styles.input, errors.appId ? styles.inputError : ''].filter(Boolean).join(' ')}
+              type="text"
+              placeholder="YourApp-1234-5678-ABCD-efg12345"
+              value={appId}
+              onChange={(e) => onAppIdChange(e.target.value)}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+          {errors.appId && <span className={styles.errorMsg}>{errors.appId}</span>}
+        </div>
+
+        {/* Cert ID */}
+        <div className={styles.field}>
+          <label className={styles.fieldLabel} htmlFor="ebay-cert-id">
+            Cert ID (Client Secret)
+          </label>
+          <div className={styles.inputWrapper}>
+            <Icon kind="shield" size={14} color="var(--hd-muted)" />
+            <input
+              id="ebay-cert-id"
+              className={[styles.input, errors.certId ? styles.inputError : ''].filter(Boolean).join(' ')}
+              type={certRevealed ? 'text' : 'password'}
+              placeholder="SBX-1234abcd-efgh-5678"
+              value={certId}
+              onChange={(e) => onCertIdChange(e.target.value)}
+              autoComplete="new-password"
+              spellCheck={false}
+            />
+            <button
+              type="button"
+              className={styles.revealBtn}
+              onClick={() => setCertRevealed((v) => !v)}
+              aria-label={certRevealed ? 'Hide Cert ID' : 'Show Cert ID'}
+            >
+              <Icon kind="eye" size={13} color="var(--hd-muted)" />
+            </button>
+          </div>
+          {errors.certId && <span className={styles.errorMsg}>{errors.certId}</span>}
+        </div>
+
+        {/* Redirect URI (read-only) */}
+        <div className={styles.field}>
+          <label className={styles.fieldLabel} htmlFor="ebay-runame">
+            Redirect URI (RuName)
+            <span className={styles.readOnlyTag}>read-only</span>
+          </label>
+          <div className={styles.inputWrapper}>
+            <Icon kind="link" size={14} color="var(--hd-muted)" />
+            <input
+              id="ebay-runame"
+              className={[styles.input, styles.inputReadOnly].join(' ')}
+              type="text"
+              value={REDIRECT_URI}
+              readOnly
+              aria-readonly="true"
+            />
+            <button
+              type="button"
+              className={styles.copyBtn}
+              onClick={copyRuName}
+              aria-label="Copy Redirect URI"
+            >
+              {copied ? (
+                <Icon kind="check" size={13} color="var(--hd-accent)" />
+              ) : (
+                <Icon kind="copy" size={13} color="var(--hd-muted)" />
+              )}
+            </button>
+          </div>
+          <p className={styles.fieldHint}>
+            Paste this URL into your eBay app's <strong>Auth accepted URL</strong> field in the
+            developer portal, then add it as an allowed RuName.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Step 3: OAuth scopes ───────────────────────────────────────────────────
+
+interface StepScopesProps {
+  scopes: OAuthScope[]
+  onToggle: (id: string) => void
+}
+
+function StepScopes({ scopes, onToggle }: StepScopesProps) {
+  return (
+    <div className={styles.stepContent}>
+      <h2 className={styles.stepHeading}>Configure OAuth scopes</h2>
+      <p className={styles.stepDesc}>
+        These permissions determine what AutoMana can do on your eBay account. Required scopes
+        cannot be disabled.
+      </p>
+
+      <div className={styles.scopeList} role="list">
+        {scopes.map((scope) => (
+          <div key={scope.id} className={styles.scopeRow} role="listitem">
+            <div className={styles.scopeInfo}>
+              <div className={styles.scopeNameRow}>
+                <span className={styles.scopeName}>{scope.name}</span>
+                {scope.required && (
+                  <span className={styles.requiredBadge}>REQUIRED</span>
+                )}
+              </div>
+              <span className={styles.scopeDesc}>{scope.description}</span>
+            </div>
+            <Toggle
+              on={scope.enabled}
+              onToggle={scope.required ? undefined : () => onToggle(scope.id)}
+              label={`Toggle ${scope.name}`}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Step 4: Registration result ────────────────────────────────────────────
+
+interface StepResultProps {
+  result: RegistrationResult
+}
+
+function StepResult({ result }: StepResultProps) {
+  if (result.success) {
+    return (
+      <div className={styles.stepContent}>
+        <h2 className={styles.stepHeading}>App registered</h2>
+        <div className={styles.verifyBox}>
+          <div className={styles.verifySuccess}>
+            <div className={styles.verifyIcon}>
+              <Icon kind="check" size={24} color="var(--hd-accent)" />
+            </div>
+            <div>
+              <div className={styles.verifyTitle}>App registered successfully</div>
+              <div className={styles.verifySubtitle}>
+                App code: <code>{result.appCode}</code>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p className={styles.verifyNote}>
+          Your eBay app is registered. Use the app code above to start the OAuth flow and
+          connect your eBay account.
+        </p>
+      </div>
+    )
+  }
+  return (
+    <div className={styles.stepContent}>
+      <h2 className={styles.stepHeading}>Registration failed</h2>
+      <div className={styles.verifyBox}>
+        <div className={styles.verifyIdle}>
+          <div className={styles.verifyIcon}>
+            <Icon kind="shield" size={24} color="var(--hd-red)" />
+          </div>
+          <div>
+            <div className={styles.verifyTitle}>Could not register app</div>
+            <div className={styles.verifySubtitle}>{result.error}</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Stepper indicator ──────────────────────────────────────────────────────
+
+interface StepperProps {
+  steps: { label: string }[]
+  current: number
+  completed: Set<number>
+}
+
+function Stepper({ steps, current, completed }: StepperProps) {
+  return (
+    <div className={styles.stepper} role="list" aria-label="Setup steps">
+      {steps.map((step, i) => {
+        const isDone = completed.has(i)
+        const isActive = i === current
+        return (
+          <div
+            key={i}
+            className={[
+              styles.stepItem,
+              isActive ? styles.stepItemActive : '',
+              isDone ? styles.stepItemDone : '',
+            ].filter(Boolean).join(' ')}
+            role="listitem"
+          >
+            <div className={styles.stepNumber} aria-hidden="true">
+              {isDone ? <Icon kind="check" size={11} color="var(--hd-bg)" /> : i + 1}
+            </div>
+            <span className={styles.stepLabel}>{step.label}</span>
+            {i < steps.length - 1 && <div className={styles.stepConnector} aria-hidden="true" />}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── Connection status sidebar panel ───────────────────────────────────────
+
+interface StatusPanelProps {
+  status: ConnectionStatus
+}
+
+function StatusPanel({ status }: StatusPanelProps) {
+  const quotaPct = status.dailyQuota > 0
+    ? Math.round((status.usedToday / status.dailyQuota) * 100)
+    : 0
+
+  return (
+    <div className={styles.sidePanel}>
+      <div className={styles.sidePanelTitle}>Connection status</div>
+      <div className={styles.statusDot}>
+        <span
+          className={styles.statusIndicator}
+          style={{ background: status.connected ? 'var(--hd-accent)' : 'var(--hd-sub)' }}
+          aria-hidden="true"
+        />
+        <span className={styles.statusLabel}>
+          {status.connected ? 'Connected' : 'Not connected'}
+        </span>
+      </div>
+
+      <div className={styles.metricList}>
+        <div className={styles.metricRow}>
+          <span className={styles.metricKey}>Environment</span>
+          <span className={styles.metricVal}>{status.environment}</span>
+        </div>
+        <div className={styles.metricRow}>
+          <span className={styles.metricKey}>Last verified</span>
+          <span className={styles.metricVal}>
+            {status.lastVerified
+              ? new Date(status.lastVerified).toLocaleDateString()
+              : '—'}
+          </span>
+        </div>
+        <div className={styles.metricRow}>
+          <span className={styles.metricKey}>Token expires</span>
+          <span className={styles.metricVal}>
+            {status.tokenExpires
+              ? new Date(status.tokenExpires).toLocaleDateString()
+              : '—'}
+          </span>
+        </div>
+        <div className={styles.metricRow}>
+          <span className={styles.metricKey}>Daily quota</span>
+          <span className={styles.metricVal}>{status.dailyQuota.toLocaleString()}</span>
+        </div>
+        <div className={styles.metricRow}>
+          <span className={styles.metricKey}>Used today</span>
+          <span className={styles.metricVal}>{status.usedToday}</span>
+        </div>
+      </div>
+
+      {status.connected && (
+        <div className={styles.quotaBarWrapper}>
+          <div
+            className={styles.quotaBar}
+            role="progressbar"
+            aria-valuenow={status.usedToday}
+            aria-valuemax={status.dailyQuota}
+            aria-label="Daily quota usage"
+          >
+            <div
+              className={styles.quotaFill}
+              style={{
+                width: `${quotaPct}%`,
+                background: quotaPct > 80 ? 'var(--hd-red)' : 'var(--hd-accent)',
+              }}
+            />
+          </div>
+          <span className={styles.quotaPct}>{quotaPct}%</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main page ──────────────────────────────────────────────────────────────
+
+function EbaySetupPage() {
+  const [step, setStep] = useState<number>(0)
+  const [completed, setCompleted] = useState<Set<number>>(new Set())
+
+  // Step 2 form state
+  const [appName, setAppName] = useState('')
+  const [description, setDescription] = useState('')
+  const [environment, setEnvironment] = useState<Environment>('SANDBOX')
+  const [appId, setAppId] = useState('')
+  const [certId, setCertId] = useState('')
+  const [formErrors, setFormErrors] = useState<Record<string, string>>({})
+
+  // Step 3 state
+  const [scopes, setScopes] = useState(MOCK_OAUTH_SCOPES)
+
+  // Step 4 state
+  const [submitting, setSubmitting] = useState(false)
+  const [registrationResult, setRegistrationResult] = useState<RegistrationResult | null>(null)
+
+  function validateCredentials(): boolean {
+    const errors: Record<string, string> = {}
+    if (!appName.trim()) errors.appName = 'App name is required'
+    if (!appId.trim()) errors.appId = 'App ID is required'
+    if (!certId.trim()) errors.certId = 'Cert ID is required'
+    setFormErrors(errors)
+    return Object.keys(errors).length === 0
+  }
+
+  function toggleScope(id: string) {
+    setScopes((prev) =>
+      prev.map((s) => (s.id === id && !s.required ? { ...s, enabled: !s.enabled } : s))
+    )
+  }
+
+  async function handleNext() {
+    if (step === 1 && !validateCredentials()) return
+
+    if (step === 2) {
+      setSubmitting(true)
+      try {
+        const enabledScopeUrls = scopes.filter((s) => s.enabled).map((s) => s.scopeUrl)
+        const result = await registerEbayApp({
+          app_name: appName,
+          description,
+          environment,
+          ebay_app_id: appId,
+          client_secret: certId,
+          redirect_uri: REDIRECT_URI,
+          allowed_scopes: enabledScopeUrls,
+        })
+        setRegistrationResult({ success: true, appCode: result.app_code })
+      } catch (err) {
+        setRegistrationResult({
+          success: false,
+          error: err instanceof Error ? err.message : 'Registration failed',
+        })
+      } finally {
+        setSubmitting(false)
+        setCompleted((prev) => new Set(prev).add(step))
+        setStep((s) => s + 1)
+      }
+      return
+    }
+
+    setCompleted((prev) => new Set(prev).add(step))
+    setStep((s) => Math.min(s + 1, SETUP_STEPS.length - 1))
+  }
+
+  function handleBack() {
+    setStep((s) => Math.max(s - 1, 0))
+  }
+
+  return (
+    <AppShell active="settings">
+      <TopBar
+        title="Connect your eBay app"
+        subtitle="eBay Developer"
+        breadcrumb="Settings / Integrations"
+      />
+
+      <div className={styles.page}>
+        <Stepper steps={SETUP_STEPS} current={step} completed={completed} />
+
+        <div className={styles.contentGrid}>
+          <div className={styles.mainPanel}>
+            {step === 0 && <StepCreateApp />}
+            {step === 1 && (
+              <StepCredentials
+                appName={appName}
+                description={description}
+                environment={environment}
+                appId={appId}
+                certId={certId}
+                onAppNameChange={(v) => { setAppName(v); setFormErrors((e) => ({ ...e, appName: '' })) }}
+                onDescriptionChange={setDescription}
+                onEnvironmentChange={setEnvironment}
+                onAppIdChange={(v) => { setAppId(v); setFormErrors((e) => ({ ...e, appId: '' })) }}
+                onCertIdChange={(v) => { setCertId(v); setFormErrors((e) => ({ ...e, certId: '' })) }}
+                errors={formErrors}
+              />
+            )}
+            {step === 2 && <StepScopes scopes={scopes} onToggle={toggleScope} />}
+            {step === 3 && registrationResult && <StepResult result={registrationResult} />}
+
+            <div className={styles.navButtons}>
+              {step > 0 && step < SETUP_STEPS.length - 1 && (
+                <Button variant="ghost" size="md" onClick={handleBack}>
+                  Back
+                </Button>
+              )}
+              {step < SETUP_STEPS.length - 1 && (
+                <Button
+                  variant="accent"
+                  size="md"
+                  onClick={handleNext}
+                  disabled={submitting}
+                  icon={step === 2 ? undefined : <Icon kind="arrowRight" size={13} color="currentColor" />}
+                >
+                  {step === 2
+                    ? submitting ? 'Registering…' : 'Register App'
+                    : 'Next'}
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <aside className={styles.sidebar} aria-label="eBay setup sidebar">
+            <StatusPanel status={MOCK_CONNECTION_STATUS} />
+
+            <div className={styles.sidePanel}>
+              <div className={styles.sidePanelTitle}>Why bring your own app?</div>
+              <ul className={styles.benefitList}>
+                {BYOA_BENEFITS.map((benefit) => (
+                  <li key={benefit} className={styles.benefitItem}>
+                    <Icon kind="check" size={12} color="var(--hd-accent)" />
+                    <span>{benefit}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className={styles.sidePanel}>
+              <div className={styles.sidePanelTitle}>Need help?</div>
+              <div className={styles.helpLinks}>
+                {HELP_LINKS.map((link) => (
+                  <a
+                    key={link.href}
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={styles.helpLink}
+                  >
+                    <Icon kind="link" size={11} color="var(--hd-muted)" />
+                    {link.label}
+                  </a>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </AppShell>
+  )
+}
+```
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+```bash
+cd src/frontend && npx vitest run src/frontend/src/routes/ebay/__tests__/setup.test.tsx
+```
+
+Expected: all tests passing. If `Icon kind="tag"` doesn't exist in the Icon component, replace with `kind="key"` as a fallback (check `src/frontend/src/components/design-system/Icon.tsx` for available kinds).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  src/frontend/src/routes/ebay/Setup.module.css \
+  src/frontend/src/routes/ebay/setup.tsx \
+  src/frontend/src/routes/ebay/__tests__/setup.test.tsx
+git commit -m "feat(ebay): wire setup wizard to POST /admin/apps with new credential fields"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- ✅ Wire to `POST /api/integrations/ebay/auth/admin/apps` — Task 2 + 3
+- ✅ Add `app_name`, `description`, environment toggle to Step 2 — Task 3
+- ✅ Remove Dev ID — Task 3
+- ✅ Submission triggered by "Next" on Step 3 (scopes) — Task 3
+- ✅ Step 4 shows success with `app_code` or error with message — Task 3
+- ✅ `app_code` sent as `""` for backend auto-generation — Task 2
+- ✅ `redirect_uri` hardcoded as constant — Task 1
+
+**Placeholder scan:** None found. All code is complete.
+
+**Type consistency:**
+- `OAuthScope.scopeUrl` defined in Task 1, used in Task 3 (`s.scopeUrl`)
+- `RegistrationResult` defined in Task 1, used as `StepResultProps.result` in Task 3
+- `RegisterEbayAppRequest` / `RegisterEbayAppResponse` defined in Task 2, consumed in Task 3
+- `REDIRECT_URI` (renamed from `MOCK_REDIRECT_URI`) defined in Task 1, used in Task 3 and tests
+- `Environment` type defined locally in `setup.tsx` — consistent with backend enum values `'SANDBOX' | 'PRODUCTION'`

--- a/docs/superpowers/plans/2026-05-09-ebay-listings-page.md
+++ b/docs/superpowers/plans/2026-05-09-ebay-listings-page.md
@@ -1,0 +1,1577 @@
+# eBay Listings Page — Live Data Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the Active tab of `/listings` to real eBay API data — fetched in parallel from all production apps — adding thumbnail, app badge, finish column, and inline card-name filter.
+
+**Architecture:** Add `EbayLiveListing` type and `parseCardTitle` utility to `mockListings.ts`; add `fetchActiveListings` to `api.ts` with a raw-to-typed mapper; rewrite `ListingsTable` to consume `EbayLiveListing[]`; update `listings.tsx` to fetch apps then listings in parallel and pass live data to the table.
+
+**Tech Stack:** React 18, TypeScript, Vitest, @testing-library/react, CSS Modules, TanStack Router
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/frontend/src/features/ebay/mockListings.ts` | Add `EbayLiveListing` interface + `parseCardTitle` helper |
+| `src/frontend/src/features/ebay/__tests__/mockListings.test.ts` | **Create** — tests for `parseCardTitle` |
+| `src/frontend/src/features/ebay/api.ts` | Add `fetchActiveListings` + internal `mapToLiveListing` |
+| `src/frontend/src/features/ebay/__tests__/api.test.ts` | Extend — tests for `fetchActiveListings` |
+| `src/frontend/src/features/ebay/components/ListingsTable.tsx` | Rewrite — new props/columns/filter |
+| `src/frontend/src/features/ebay/components/ListingsTable.module.css` | Add new CSS classes |
+| `src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx` | Rewrite — tests for new component |
+| `src/frontend/src/routes/listings.tsx` | Wire Active tab to live data |
+| `src/frontend/src/routes/__tests__/listings.test.tsx` | **Create** — tests for route fetch/render |
+
+---
+
+## Task 1: `EbayLiveListing` interface and `parseCardTitle` helper
+
+**Files:**
+- Modify: `src/frontend/src/features/ebay/mockListings.ts`
+- Create: `src/frontend/src/features/ebay/__tests__/mockListings.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/frontend/src/features/ebay/__tests__/mockListings.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { parseCardTitle } from '../mockListings'
+
+describe('parseCardTitle', () => {
+  it('strips set code, collector number, condition, MTG suffix', () => {
+    const { cardName, setInfo } = parseCardTitle('Ragavan, Nimble Pilferer MH2 #138 NM MTG')
+    expect(cardName).toBe('Ragavan, Nimble Pilferer')
+    expect(setInfo).toBe('MH2 #138')
+  })
+
+  it('strips FOIL suffix', () => {
+    const { cardName, setInfo } = parseCardTitle('Mox Diamond STH NM FOIL MTG')
+    expect(cardName).toBe('Mox Diamond')
+    expect(setInfo).toBe('STH')
+  })
+
+  it('strips 3-letter set code without collector number', () => {
+    const { cardName, setInfo } = parseCardTitle('Force of Will ALL LP MTG')
+    expect(cardName).toBe('Force of Will')
+    expect(setInfo).toBe('ALL')
+  })
+
+  it('handles set code with digits (e.g. MH2)', () => {
+    const { cardName, setInfo } = parseCardTitle('Sheoldred, the Apocalypse DMU NM MTG')
+    expect(cardName).toBe('Sheoldred, the Apocalypse')
+    expect(setInfo).toBe('DMU')
+  })
+
+  it('falls back to full title when no suffix tokens match', () => {
+    const { cardName, setInfo } = parseCardTitle('Some weird title')
+    expect(cardName).toBe('Some weird title')
+    expect(setInfo).toBe('')
+  })
+
+  it('does not strip mixed-case words like card names', () => {
+    const { cardName } = parseCardTitle('Wrenn and Six MH1 NM MTG')
+    expect(cardName).toBe('Wrenn and Six')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/mockListings.test.ts
+```
+
+Expected: FAIL with "parseCardTitle is not a function" or similar.
+
+- [ ] **Step 3: Add `EbayLiveListing` interface and `parseCardTitle` to `mockListings.ts`**
+
+Append to the end of `src/frontend/src/features/ebay/mockListings.ts`:
+
+```typescript
+// ── Live listing types ─────────────────────────────────────────────────────
+
+export interface EbayLiveListing {
+  itemId: string
+  title: string
+  cardName: string
+  setInfo: string
+  price: number
+  currency: string
+  conditionLabel: string
+  finish: 'Foil' | 'Regular'
+  watchCount: number
+  viewItemUrl: string
+  imageUrl: string | null
+  appCode: string
+  appName: string
+}
+
+// ── Title parsing ──────────────────────────────────────────────────────────
+
+const NOISE_TOKEN_RE = /^(MTG|FOIL|NM\+?|LP|MP|HP|PLD|EX|VG|GD|PR)$/i
+const SET_CODE_RE = /^[A-Z0-9]{2,5}$/
+
+export function parseCardTitle(title: string): { cardName: string; setInfo: string } {
+  const tokens = title.trim().split(/\s+/)
+  let i = tokens.length - 1
+  const setTokens: string[] = []
+
+  while (i >= 0) {
+    const tok = tokens[i]
+    if (NOISE_TOKEN_RE.test(tok)) {
+      i--
+      continue
+    }
+    if (/^#\d+$/.test(tok)) {
+      setTokens.unshift(tok)
+      i--
+      continue
+    }
+    if (SET_CODE_RE.test(tok)) {
+      setTokens.unshift(tok)
+      i--
+      continue
+    }
+    break
+  }
+
+  const cardName = i >= 0 ? tokens.slice(0, i + 1).join(' ') : title
+  return { cardName, setInfo: setTokens.join(' ') }
+}
+```
+
+`SET_CODE_RE` matches only tokens that are entirely uppercase letters/digits (2–5 chars), which excludes mixed-case card name words like "Will" or "Six".
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/mockListings.test.ts
+```
+
+Expected: PASS — 6 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/mockListings.ts \
+        src/frontend/src/features/ebay/__tests__/mockListings.test.ts
+git commit -m "feat(ebay): add EbayLiveListing interface and parseCardTitle helper"
+```
+
+---
+
+## Task 2: `fetchActiveListings` API function
+
+**Files:**
+- Modify: `src/frontend/src/features/ebay/api.ts`
+- Modify: `src/frontend/src/features/ebay/__tests__/api.test.ts`
+
+The backend `GET /listing/active?app_code=…` returns a `PaginatedResponse` with `data` = array of `ItemModel` objects. The `apiClient` unwraps `{ data, success }` shaped responses automatically, so the resolved value is the item array directly.
+
+Backend Pydantic serialises with Python field names (not aliases), so items arrive as:
+- `ItemID`, `Title`, `WatchCount`, `ConditionDisplayName`, `ConditionDescription`, `SKU`
+- `StartPrice: { currencyID: string, text: number }`  (`BaseCostType` fields)
+- `ListingDetails: { ViewItemURL: string | null }`
+- `PictureDetails: { GalleryURL: string | string[] } | null`  (raw dict)
+- `ItemSpecifics: { NameValueList: ... } | null`  (raw dict)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append a new `describe` block to `src/frontend/src/features/ebay/__tests__/api.test.ts`:
+
+```typescript
+import { fetchActiveListings } from '../api'
+
+// (add these imports at the top alongside the existing ones)
+// import { fetchActiveListings } from '../api'
+// import type { EbayLiveListing } from '../mockListings'
+
+describe('fetchActiveListings', () => {
+  beforeEach(() => {
+    mockApiClient.mockReset()
+  })
+
+  it('calls GET /listing/active with correct query params', async () => {
+    mockApiClient.mockResolvedValue([])
+    await fetchActiveListings('my_app', 50, 0)
+    expect(mockApiClient).toHaveBeenCalledWith(
+      '/listing/active?app_code=my_app&limit=50&offset=0'
+    )
+  })
+
+  it('uses default limit=50 and offset=0', async () => {
+    mockApiClient.mockResolvedValue([])
+    await fetchActiveListings('my_app')
+    expect(mockApiClient).toHaveBeenCalledWith(
+      '/listing/active?app_code=my_app&limit=50&offset=0'
+    )
+  })
+
+  it('maps StartPrice to price and currency', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '123',
+        Title: 'Ragavan, Nimble Pilferer MH2 NM MTG',
+        StartPrice: { currencyID: 'AUD', text: 62.0 },
+        WatchCount: 5,
+        ConditionDisplayName: 'Near Mint or Better',
+        ConditionDescription: null,
+        ItemSpecifics: null,
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/123' },
+        PictureDetails: { GalleryURL: 'https://img.ebay.com/1.jpg' },
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].price).toBe(62)
+    expect(result[0].currency).toBe('AUD')
+    expect(result[0].itemId).toBe('123')
+    expect(result[0].conditionLabel).toBe('Near Mint or Better')
+  })
+
+  it('falls back to ConditionDescription when ConditionDisplayName is absent', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '124',
+        Title: 'Force of Will ALL LP MTG',
+        StartPrice: { currencyID: 'AUD', text: 100 },
+        WatchCount: 0,
+        ConditionDescription: 'Light Play',
+        ConditionDisplayName: null,
+        ItemSpecifics: null,
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/124' },
+        PictureDetails: null,
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].conditionLabel).toBe('Light Play')
+  })
+
+  it('uses fallback eBay URL when ViewItemURL is null', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '456',
+        Title: 'Force of Will ALL MTG',
+        StartPrice: { currencyID: 'AUD', text: 10 },
+        WatchCount: 0,
+        ConditionDisplayName: null,
+        ConditionDescription: null,
+        ItemSpecifics: null,
+        ListingDetails: null,
+        PictureDetails: null,
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].viewItemUrl).toBe('https://www.ebay.com.au/itm/456')
+  })
+
+  it('extracts Finish from ItemSpecifics NameValueList (array)', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '789',
+        Title: 'Ragavan, Nimble Pilferer MH2 NM FOIL MTG',
+        StartPrice: { currencyID: 'AUD', text: 100 },
+        WatchCount: 3,
+        ConditionDisplayName: 'Near Mint',
+        ConditionDescription: null,
+        ItemSpecifics: {
+          NameValueList: [{ Name: 'Finish', Value: 'Foil' }],
+        },
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/789' },
+        PictureDetails: null,
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].finish).toBe('Foil')
+  })
+
+  it('extracts Finish from ItemSpecifics NameValueList (single object, not array)', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '790',
+        Title: 'Ragavan MH2 NM FOIL MTG',
+        StartPrice: { currencyID: 'AUD', text: 80 },
+        WatchCount: 0,
+        ConditionDisplayName: 'NM',
+        ConditionDescription: null,
+        ItemSpecifics: {
+          NameValueList: { Name: 'Finish', Value: 'Foil' },
+        },
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/790' },
+        PictureDetails: null,
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].finish).toBe('Foil')
+  })
+
+  it('defaults finish to Regular when ItemSpecifics is null', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '999',
+        Title: 'Ancient Tomb TMP NM MTG',
+        StartPrice: { currencyID: 'AUD', text: 58 },
+        WatchCount: 0,
+        ConditionDisplayName: 'NM',
+        ConditionDescription: null,
+        ItemSpecifics: null,
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/999' },
+        PictureDetails: null,
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].finish).toBe('Regular')
+  })
+
+  it('extracts GalleryURL when PictureDetails is present', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '111',
+        Title: 'Dark Confidant RAV NM MTG',
+        StartPrice: { currencyID: 'AUD', text: 30 },
+        WatchCount: 1,
+        ConditionDisplayName: 'NM',
+        ConditionDescription: null,
+        ItemSpecifics: null,
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/111' },
+        PictureDetails: { GalleryURL: 'https://img.ebay.com/card.jpg' },
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].imageUrl).toBe('https://img.ebay.com/card.jpg')
+  })
+
+  it('sets imageUrl to null when PictureDetails is null', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '222',
+        Title: 'Snapcaster Mage ISD LP MTG',
+        StartPrice: { currencyID: 'AUD', text: 20 },
+        WatchCount: 0,
+        ConditionDisplayName: 'LP',
+        ConditionDescription: null,
+        ItemSpecifics: null,
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/222' },
+        PictureDetails: null,
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].imageUrl).toBeNull()
+  })
+
+  it('parses cardName from title', async () => {
+    mockApiClient.mockResolvedValue([
+      {
+        ItemID: '333',
+        Title: 'Sheoldred, the Apocalypse DMU #107 NM MTG',
+        StartPrice: { currencyID: 'AUD', text: 44 },
+        WatchCount: 0,
+        ConditionDisplayName: 'NM',
+        ConditionDescription: null,
+        ItemSpecifics: null,
+        ListingDetails: { ViewItemURL: 'https://www.ebay.com.au/itm/333' },
+        PictureDetails: null,
+      },
+    ])
+    const result = await fetchActiveListings('my_app')
+    expect(result[0].cardName).toBe('Sheoldred, the Apocalypse')
+    expect(result[0].setInfo).toBe('DMU #107')
+  })
+
+  it('propagates errors from apiClient', async () => {
+    mockApiClient.mockRejectedValue(new Error('API 401: unauthorized'))
+    await expect(fetchActiveListings('my_app')).rejects.toThrow('API 401: unauthorized')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/api.test.ts
+```
+
+Expected: FAIL with "fetchActiveListings is not a function".
+
+- [ ] **Step 3: Implement `fetchActiveListings` and helpers in `api.ts`**
+
+Add these imports and implementations to `src/frontend/src/features/ebay/api.ts`:
+
+At the top of the file, add the import:
+```typescript
+import { parseCardTitle, type EbayLiveListing } from './mockListings'
+```
+
+Then add the following at the end of the file:
+
+```typescript
+// ── Active listings ────────────────────────────────────────────────────────
+
+interface RawEbayItem {
+  ItemID?: string | null
+  Title?: string | null
+  StartPrice?: { currencyID?: string | null; text?: string | number | null } | null
+  WatchCount?: number | null
+  ConditionDescription?: string | null
+  ConditionDisplayName?: string | null
+  PictureDetails?: { GalleryURL?: string | string[] } | null
+  ListingDetails?: { ViewItemURL?: string | null } | null
+  ItemSpecifics?: {
+    NameValueList?:
+      | Array<{ Name: string; Value: string | string[] }>
+      | { Name: string; Value: string | string[] }
+  } | null
+}
+
+function getFinish(itemSpecifics: RawEbayItem['ItemSpecifics']): 'Foil' | 'Regular' {
+  if (!itemSpecifics?.NameValueList) return 'Regular'
+  const list = Array.isArray(itemSpecifics.NameValueList)
+    ? itemSpecifics.NameValueList
+    : [itemSpecifics.NameValueList]
+  const finishSpec = list.find((nv) => nv.Name === 'Finish')
+  if (!finishSpec) return 'Regular'
+  const val = Array.isArray(finishSpec.Value) ? finishSpec.Value[0] : finishSpec.Value
+  return val === 'Foil' ? 'Foil' : 'Regular'
+}
+
+function getImageUrl(pictureDetails: RawEbayItem['PictureDetails']): string | null {
+  if (!pictureDetails?.GalleryURL) return null
+  return Array.isArray(pictureDetails.GalleryURL)
+    ? (pictureDetails.GalleryURL[0] ?? null)
+    : pictureDetails.GalleryURL
+}
+
+function mapToLiveListing(raw: RawEbayItem): Omit<EbayLiveListing, 'appCode' | 'appName'> {
+  const itemId = raw.ItemID ?? ''
+  const { cardName, setInfo } = parseCardTitle(raw.Title ?? '')
+  return {
+    itemId,
+    title: raw.Title ?? '',
+    cardName,
+    setInfo,
+    price: Number(raw.StartPrice?.text ?? 0),
+    currency: raw.StartPrice?.currencyID ?? 'AUD',
+    conditionLabel: raw.ConditionDisplayName ?? raw.ConditionDescription ?? '',
+    finish: getFinish(raw.ItemSpecifics),
+    watchCount: raw.WatchCount ?? 0,
+    viewItemUrl:
+      raw.ListingDetails?.ViewItemURL ?? `https://www.ebay.com.au/itm/${itemId}`,
+    imageUrl: getImageUrl(raw.PictureDetails),
+  }
+}
+
+export async function fetchActiveListings(
+  appCode: string,
+  limit = 50,
+  offset = 0,
+): Promise<EbayLiveListing[]> {
+  const items = await apiClient<RawEbayItem[]>(
+    `/listing/active?app_code=${encodeURIComponent(appCode)}&limit=${limit}&offset=${offset}`
+  )
+  return (items ?? []).map((raw) => ({ ...mapToLiveListing(raw), appCode, appName: '' }))
+}
+```
+
+Note: `appName` is set to `''` here; the caller (`listings.tsx`) overwrites it after the fact via `.map(item => ({ ...item, appName: app.app_name }))`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/api.test.ts
+```
+
+Expected: all tests in both describe blocks pass (existing `registerEbayApp` tests + new `fetchActiveListings` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/api.ts \
+        src/frontend/src/features/ebay/__tests__/api.test.ts
+git commit -m "feat(ebay): add fetchActiveListings API function with raw item mapper"
+```
+
+---
+
+## Task 3: Rewrite `ListingsTable` component
+
+**Files:**
+- Modify: `src/frontend/src/features/ebay/components/ListingsTable.tsx`
+- Modify: `src/frontend/src/features/ebay/components/ListingsTable.module.css`
+- Modify: `src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx`
+
+The component changes from `ActiveListing[]` to `EbayLiveListing[]`. The Actions, Market price, and Set columns are removed. New columns: Thumbnail, App badge, Finish. Card name becomes an external `<a>` to eBay. The CARD NAME header contains an inline underline `<input>` for client-side filtering.
+
+- [ ] **Step 1: Replace the test file with new tests**
+
+Replace the entire contents of `src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx`:
+
+```typescript
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { ListingsTable } from '../ListingsTable'
+import type { EbayLiveListing } from '../../mockListings'
+
+function makeListing(overrides: Partial<EbayLiveListing> = {}): EbayLiveListing {
+  return {
+    itemId: 'l1',
+    title: 'Ragavan, Nimble Pilferer MH2 NM MTG',
+    cardName: 'Ragavan, Nimble Pilferer',
+    setInfo: 'MH2',
+    price: 62,
+    currency: 'AUD',
+    conditionLabel: 'NM',
+    finish: 'Regular',
+    watchCount: 12,
+    viewItemUrl: 'https://www.ebay.com.au/itm/123',
+    imageUrl: null,
+    appCode: 'automana_au',
+    appName: 'AutoMana AU',
+    ...overrides,
+  }
+}
+
+describe('ListingsTable', () => {
+  it('renders column headers', () => {
+    render(<ListingsTable listings={[]} />)
+    expect(screen.getByText(/app/i)).toBeTruthy()
+    expect(screen.getByText(/cond/i)).toBeTruthy()
+    expect(screen.getByText(/finish/i)).toBeTruthy()
+    expect(screen.getByText(/price/i)).toBeTruthy()
+    expect(screen.getByText(/watch/i)).toBeTruthy()
+  })
+
+  it('shows empty state when no listings and not loading', () => {
+    render(<ListingsTable listings={[]} />)
+    expect(screen.getByText(/no listings found/i)).toBeTruthy()
+  })
+
+  it('renders card name as an external link to eBay', () => {
+    const listing = makeListing()
+    render(<ListingsTable listings={[listing]} />)
+    const link = screen.getByRole('link', { name: /ragavan/i })
+    expect(link.getAttribute('href')).toBe('https://www.ebay.com.au/itm/123')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('renders set info badge next to card name', () => {
+    render(<ListingsTable listings={[makeListing({ setInfo: 'MH2 #138' })]} />)
+    expect(screen.getByText('MH2 #138')).toBeTruthy()
+  })
+
+  it('renders app badge with app name', () => {
+    render(<ListingsTable listings={[makeListing()]} />)
+    expect(screen.getByText('AutoMana AU')).toBeTruthy()
+  })
+
+  it('shows Regular finish as plain text', () => {
+    render(<ListingsTable listings={[makeListing({ finish: 'Regular' })]} />)
+    expect(screen.getByText('Regular')).toBeTruthy()
+  })
+
+  it('shows Foil finish with badge styling', () => {
+    render(<ListingsTable listings={[makeListing({ finish: 'Foil' })]} />)
+    expect(screen.getByText('Foil')).toBeTruthy()
+  })
+
+  it('renders thumbnail img when imageUrl is provided', () => {
+    const listing = makeListing({ imageUrl: 'https://img.ebay.com/card.jpg' })
+    render(<ListingsTable listings={[listing]} />)
+    const img = screen.getByRole('img', { name: /ragavan/i })
+    expect(img.getAttribute('src')).toBe('https://img.ebay.com/card.jpg')
+  })
+
+  it('renders fallback placeholder when imageUrl is null', () => {
+    render(<ListingsTable listings={[makeListing({ imageUrl: null })]} />)
+    expect(screen.getByText('MTG')).toBeTruthy()
+  })
+
+  it('filters rows by card name input', () => {
+    const listings = [
+      makeListing({ itemId: 'l1', cardName: 'Ragavan, Nimble Pilferer' }),
+      makeListing({ itemId: 'l2', cardName: 'Force of Will', viewItemUrl: 'https://www.ebay.com.au/itm/2' }),
+    ]
+    render(<ListingsTable listings={listings} />)
+    const input = screen.getByPlaceholderText('card name')
+    fireEvent.change(input, { target: { value: 'Force' } })
+    expect(screen.queryByText('Ragavan, Nimble Pilferer')).toBeNull()
+    expect(screen.getByText('Force of Will')).toBeTruthy()
+  })
+
+  it('filter is case-insensitive', () => {
+    const listings = [makeListing({ cardName: 'Ragavan, Nimble Pilferer' })]
+    render(<ListingsTable listings={listings} />)
+    const input = screen.getByPlaceholderText('card name')
+    fireEvent.change(input, { target: { value: 'ragavan' } })
+    expect(screen.getByText('Ragavan, Nimble Pilferer')).toBeTruthy()
+  })
+
+  it('shows skeleton rows when isLoading is true', () => {
+    render(<ListingsTable listings={[]} isLoading />)
+    expect(screen.queryByText(/no listings found/i)).toBeNull()
+    const skeletonRows = document.querySelectorAll('[data-testid="skeleton-row"]')
+    expect(skeletonRows.length).toBe(3)
+  })
+
+  it('renders price with currency', () => {
+    render(<ListingsTable listings={[makeListing({ price: 62, currency: 'AUD' })]} />)
+    expect(screen.getByText(/62/)).toBeTruthy()
+  })
+
+  it('renders watch count', () => {
+    render(<ListingsTable listings={[makeListing({ watchCount: 7 })]} />)
+    expect(screen.getByText('7')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/ListingsTable.test.tsx
+```
+
+Expected: many failures — old component has wrong props, missing elements.
+
+- [ ] **Step 3: Rewrite `ListingsTable.tsx`**
+
+Replace the entire content of `src/frontend/src/features/ebay/components/ListingsTable.tsx`:
+
+```typescript
+import React, { useState, useMemo } from 'react'
+import { AIBadge } from '../../../components/design-system/AIBadge'
+import { Icon } from '../../../components/design-system/Icon'
+import type { EbayLiveListing } from '../mockListings'
+import styles from './ListingsTable.module.css'
+
+interface ListingsTableProps {
+  listings: EbayLiveListing[]
+  isLoading?: boolean
+}
+
+const APP_PALETTE = ['var(--hd-blue)', '#a78bfa', '#34d399', '#f59e0b']
+
+export function ListingsTable({ listings, isLoading = false }: ListingsTableProps) {
+  const [filter, setFilter] = useState('')
+
+  const appColors = useMemo<Record<string, string>>(() => {
+    const codes = [...new Set(listings.map((l) => l.appCode))]
+    return Object.fromEntries(codes.map((code, i) => [code, APP_PALETTE[i % APP_PALETTE.length]]))
+  }, [listings])
+
+  const visible = useMemo(
+    () =>
+      filter.trim()
+        ? listings.filter((l) =>
+            l.cardName.toLowerCase().includes(filter.toLowerCase())
+          )
+        : listings,
+    [listings, filter]
+  )
+
+  return (
+    <div className={styles.wrapper} role="region" aria-label="Listings table">
+      <table className={styles.table}>
+        <thead className={styles.thead}>
+          <tr>
+            <th scope="col" style={{ width: 36 }} aria-label="Thumbnail" />
+            <th scope="col">
+              <div className={styles.filterInputWrapper}>
+                <input
+                  className={styles.filterInput}
+                  type="text"
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value)}
+                  placeholder="card name"
+                  aria-label="Filter by card name"
+                />
+              </div>
+            </th>
+            <th scope="col">App</th>
+            <th scope="col">Cond</th>
+            <th scope="col">Finish</th>
+            <th scope="col" className={styles.right}>Price</th>
+            <th scope="col" className={styles.center}>Watchers</th>
+            <th scope="col" className={styles.center}>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {isLoading && (
+            <>
+              {[0, 1, 2].map((i) => (
+                <tr key={i} data-testid="skeleton-row" className={styles.skeletonRow}>
+                  <td><div className={styles.skeletonThumb} /></td>
+                  <td><div className={styles.skeletonText} style={{ width: '60%' }} /></td>
+                  <td><div className={styles.skeletonText} style={{ width: '70%' }} /></td>
+                  <td><div className={styles.skeletonText} style={{ width: '40%' }} /></td>
+                  <td><div className={styles.skeletonText} style={{ width: '50%' }} /></td>
+                  <td><div className={styles.skeletonText} style={{ width: '50%', marginLeft: 'auto' }} /></td>
+                  <td><div className={styles.skeletonText} style={{ width: '30%', margin: '0 auto' }} /></td>
+                  <td><div className={styles.skeletonText} style={{ width: '50%', margin: '0 auto' }} /></td>
+                </tr>
+              ))}
+            </>
+          )}
+          {!isLoading && visible.length === 0 && (
+            <tr>
+              <td colSpan={8} className={styles.empty}>No listings found</td>
+            </tr>
+          )}
+          {!isLoading && visible.map((listing) => {
+            const isFoil = listing.finish === 'Foil'
+            const appColor = appColors[listing.appCode] ?? APP_PALETTE[0]
+            return (
+              <tr
+                key={listing.itemId}
+                className={[styles.row, isFoil ? styles.rowFoil : ''].filter(Boolean).join(' ')}
+              >
+                {/* Thumbnail */}
+                <td className={styles.thumbCell}>
+                  {listing.imageUrl ? (
+                    <img
+                      src={listing.imageUrl}
+                      alt={listing.cardName}
+                      className={[styles.thumb, isFoil ? styles.thumbFoil : ''].filter(Boolean).join(' ')}
+                    />
+                  ) : (
+                    <div className={styles.thumbPlaceholder}>MTG</div>
+                  )}
+                </td>
+
+                {/* Card name + set info */}
+                <td>
+                  <div className={styles.nameCell}>
+                    <a
+                      href={listing.viewItemUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={styles.cardName}
+                    >
+                      {listing.cardName}
+                    </a>
+                    {listing.setInfo && (
+                      <span className={styles.setInfo}>{listing.setInfo}</span>
+                    )}
+                  </div>
+                </td>
+
+                {/* App badge */}
+                <td>
+                  <span
+                    className={styles.appBadge}
+                    style={{
+                      color: appColor,
+                      background: `${appColor}1a`,
+                      border: `1px solid ${appColor}44`,
+                    }}
+                  >
+                    {listing.appName.length > 10
+                      ? listing.appName.slice(0, 10)
+                      : listing.appName}
+                  </span>
+                </td>
+
+                {/* Condition */}
+                <td>
+                  <span className={styles.condition}>{listing.conditionLabel}</span>
+                </td>
+
+                {/* Finish */}
+                <td>
+                  {isFoil ? (
+                    <span className={styles.foilBadge}>Foil</span>
+                  ) : (
+                    <span className={styles.regularFinish}>Regular</span>
+                  )}
+                </td>
+
+                {/* Price */}
+                <td className={styles.right}>
+                  <span className={styles.price}>
+                    {listing.currency}&nbsp;{listing.price.toFixed(2)}
+                  </span>
+                </td>
+
+                {/* Watchers */}
+                <td className={styles.center}>
+                  <span className={styles.watchers}>
+                    <Icon kind="eye" size={11} color="var(--hd-muted)" />
+                    {listing.watchCount}
+                  </span>
+                </td>
+
+                {/* AI status (static badge, real signal TBD) */}
+                <td className={styles.center}>
+                  <AIBadge status="ok" showLabel size="sm" />
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Add new CSS classes to `ListingsTable.module.css`**
+
+Append to the end of `src/frontend/src/features/ebay/components/ListingsTable.module.css`:
+
+```css
+/* Filter input in header */
+.filterInputWrapper {
+  display: flex;
+  align-items: center;
+}
+
+.filterInput {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--hd-border);
+  color: var(--hd-sub);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  padding: 2px 0;
+  width: 140px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+.filterInput::placeholder {
+  color: var(--hd-sub);
+  text-transform: uppercase;
+  letter-spacing: 1.2px;
+}
+
+.filterInput:focus {
+  border-bottom-color: var(--hd-accent);
+}
+
+/* Thumbnail column */
+.thumbCell {
+  padding: 6px 10px;
+  width: 36px;
+}
+
+.thumb {
+  width: 28px;
+  height: 39px;
+  border-radius: 3px;
+  object-fit: cover;
+  display: block;
+}
+
+.thumbFoil {
+  border: 1px solid #a78bfa44;
+  box-shadow: 0 0 6px #a78bfa33;
+}
+
+.thumbPlaceholder {
+  width: 28px;
+  height: 39px;
+  border-radius: 3px;
+  background: var(--hd-surface-alt);
+  border: 1px solid var(--hd-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 8px;
+  color: var(--hd-sub);
+  letter-spacing: 0.5px;
+}
+
+/* App badge */
+.appBadge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 90px;
+}
+
+/* Finish badges */
+.foilBadge {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: linear-gradient(90deg, #a78bfa22, #60a5fa22);
+  border: 1px solid #a78bfa44;
+  color: #a78bfa;
+}
+
+.regularFinish {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+}
+
+/* Foil row tint */
+.rowFoil {
+  background: #a78bfa05;
+}
+
+.rowFoil:hover {
+  background: #a78bfa0d;
+}
+
+/* Price */
+.price {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--hd-text);
+}
+
+/* Skeleton loading */
+.skeletonRow td {
+  padding: 10px 14px;
+}
+
+.skeletonThumb {
+  width: 28px;
+  height: 39px;
+  border-radius: 3px;
+  background: var(--hd-surface-alt);
+  animation: shimmer 1.4s infinite linear;
+}
+
+.skeletonText {
+  height: 10px;
+  border-radius: 3px;
+  background: var(--hd-surface-alt);
+  animation: shimmer 1.4s infinite linear;
+}
+
+@keyframes shimmer {
+  0%   { opacity: 0.6; }
+  50%  { opacity: 0.3; }
+  100% { opacity: 0.6; }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/ListingsTable.test.tsx
+```
+
+Expected: all 14 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/ListingsTable.tsx \
+        src/frontend/src/features/ebay/components/ListingsTable.module.css \
+        src/frontend/src/features/ebay/components/__tests__/ListingsTable.test.tsx
+git commit -m "feat(ebay): rewrite ListingsTable with live data columns, thumbnail, app badge, filter"
+```
+
+---
+
+## Task 4: Wire `listings.tsx` route to live data
+
+**Files:**
+- Modify: `src/frontend/src/routes/listings.tsx`
+- Create: `src/frontend/src/routes/__tests__/listings.test.tsx`
+
+The route currently imports `MOCK_ACTIVE_LISTINGS` and passes it to `<ListingsTable>`. After this task it will fetch production apps, fetch their active listings in parallel, and pass the merged result to the table with `isLoading` and per-app error banners.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/frontend/src/routes/__tests__/listings.test.tsx`:
+
+```typescript
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+
+vi.mock('../../features/ebay/api', () => ({
+  fetchUserApps: vi.fn(),
+  fetchActiveListings: vi.fn(),
+}))
+
+vi.mock('../../components/layout/AppShell', () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('../../components/layout/TopBar', () => ({
+  TopBar: ({ title }: { title: string }) => <div>{title}</div>,
+}))
+
+vi.mock('../../features/ebay/components/ListingsTable', () => ({
+  ListingsTable: ({ listings, isLoading }: { listings: { appName: string }[]; isLoading?: boolean }) => (
+    <div
+      data-testid="listings-table"
+      data-loading={String(isLoading)}
+      data-count={listings.length}
+      data-app-names={listings.map((l) => l.appName).join(',')}
+    />
+  ),
+}))
+
+import { fetchUserApps, fetchActiveListings } from '../../features/ebay/api'
+import type { EbayAppSummary } from '../../features/ebay/api'
+import type { EbayLiveListing } from '../../features/ebay/mockListings'
+import { ListingsPage } from '../listings'
+
+const mockFetchUserApps = vi.mocked(fetchUserApps)
+const mockFetchActiveListings = vi.mocked(fetchActiveListings)
+
+function makeApp(overrides: Partial<EbayAppSummary> = {}): EbayAppSummary {
+  return {
+    app_id: 'app-1',
+    app_name: 'AutoMana AU',
+    app_code: 'automana_au',
+    environment: 'PRODUCTION',
+    description: null,
+    is_active: true,
+    is_connected: true,
+    token_expires_at: null,
+    other_user_count: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeListing(overrides: Partial<EbayLiveListing> = {}): EbayLiveListing {
+  return {
+    itemId: 'l1',
+    title: 'Ragavan MH2 NM MTG',
+    cardName: 'Ragavan',
+    setInfo: 'MH2',
+    price: 62,
+    currency: 'AUD',
+    conditionLabel: 'NM',
+    finish: 'Regular',
+    watchCount: 5,
+    viewItemUrl: 'https://www.ebay.com.au/itm/123',
+    imageUrl: null,
+    appCode: 'automana_au',
+    appName: 'AutoMana AU',
+    ...overrides,
+  }
+}
+
+function renderListingsPage() {
+  return render(<ListingsPage />)
+}
+
+describe('ListingsPage Active tab', () => {
+  beforeEach(() => {
+    mockFetchUserApps.mockReset()
+    mockFetchActiveListings.mockReset()
+  })
+
+  it('shows loading skeleton while fetching', async () => {
+    mockFetchUserApps.mockReturnValue(new Promise(() => {}))
+    await renderListingsPage()
+    const table = screen.getByTestId('listings-table')
+    expect(table.getAttribute('data-loading')).toBe('true')
+  })
+
+  it('passes merged live listings to ListingsTable after fetch', async () => {
+    const listing = makeListing()
+    mockFetchUserApps.mockResolvedValue([makeApp()])
+    mockFetchActiveListings.mockResolvedValue([listing])
+    await renderListingsPage()
+    await waitFor(() => {
+      const table = screen.getByTestId('listings-table')
+      expect(table.getAttribute('data-count')).toBe('1')
+      expect(table.getAttribute('data-loading')).toBe('false')
+    })
+  })
+
+  it('only fetches PRODUCTION apps, ignores SANDBOX', async () => {
+    mockFetchUserApps.mockResolvedValue([
+      makeApp({ environment: 'PRODUCTION', app_code: 'prod_app' }),
+      makeApp({ environment: 'SANDBOX', app_code: 'sandbox_app' }),
+    ])
+    mockFetchActiveListings.mockResolvedValue([])
+    await renderListingsPage()
+    await waitFor(() => {
+      expect(mockFetchActiveListings).toHaveBeenCalledTimes(1)
+      expect(mockFetchActiveListings).toHaveBeenCalledWith('prod_app', 50, 0)
+    })
+  })
+
+  it('merges listings from multiple apps', async () => {
+    mockFetchUserApps.mockResolvedValue([
+      makeApp({ app_code: 'app_1', app_name: 'App 1' }),
+      makeApp({ app_code: 'app_2', app_name: 'App 2', app_id: 'app-2' }),
+    ])
+    mockFetchActiveListings
+      .mockResolvedValueOnce([makeListing({ itemId: 'l1', appCode: 'app_1' })])
+      .mockResolvedValueOnce([makeListing({ itemId: 'l2', appCode: 'app_2' })])
+    await renderListingsPage()
+    await waitFor(() => {
+      const table = screen.getByTestId('listings-table')
+      expect(table.getAttribute('data-count')).toBe('2')
+    })
+  })
+
+  it('injects appName onto each listing', async () => {
+    mockFetchUserApps.mockResolvedValue([makeApp({ app_code: 'automana_au', app_name: 'AutoMana AU' })])
+    mockFetchActiveListings.mockResolvedValue([makeListing({ appCode: 'automana_au', appName: '' })])
+    renderListingsPage()
+    await waitFor(() => {
+      const table = screen.getByTestId('listings-table')
+      expect(table.getAttribute('data-app-names')).toBe('AutoMana AU')
+    })
+  })
+
+  it('shows error banner when one app fetch fails', async () => {
+    mockFetchUserApps.mockResolvedValue([
+      makeApp({ app_code: 'app_ok', app_name: 'Good App' }),
+      makeApp({ app_code: 'app_fail', app_name: 'Bad App', app_id: 'app-2' }),
+    ])
+    mockFetchActiveListings
+      .mockResolvedValueOnce([makeListing()])
+      .mockRejectedValueOnce(new Error('Network error'))
+    await renderListingsPage()
+    await waitFor(() => {
+      expect(screen.getByText(/could not load listings for bad app/i)).toBeTruthy()
+    })
+  })
+
+  it('renders listings from successful apps even when one fails', async () => {
+    mockFetchUserApps.mockResolvedValue([
+      makeApp({ app_code: 'app_ok', app_name: 'Good App' }),
+      makeApp({ app_code: 'app_fail', app_name: 'Bad App', app_id: 'app-2' }),
+    ])
+    mockFetchActiveListings
+      .mockResolvedValueOnce([makeListing({ itemId: 'l1' })])
+      .mockRejectedValueOnce(new Error('fail'))
+    await renderListingsPage()
+    await waitFor(() => {
+      const table = screen.getByTestId('listings-table')
+      expect(table.getAttribute('data-count')).toBe('1')
+    })
+  })
+
+  it('dismisses error banner on close click', async () => {
+    const user = userEvent.setup()
+    mockFetchUserApps.mockResolvedValue([makeApp({ app_code: 'app_fail', app_name: 'Bad App' })])
+    mockFetchActiveListings.mockRejectedValue(new Error('fail'))
+    await renderListingsPage()
+    await waitFor(() => {
+      expect(screen.getByText(/could not load listings for bad app/i)).toBeTruthy()
+    })
+    const closeBtn = screen.getByRole('button', { name: /dismiss/i })
+    await user.click(closeBtn)
+    expect(screen.queryByText(/could not load listings for bad app/i)).toBeNull()
+  })
+
+  it('does not fetch listings when there are no production apps', async () => {
+    mockFetchUserApps.mockResolvedValue([
+      makeApp({ environment: 'SANDBOX' }),
+    ])
+    await renderListingsPage()
+    await waitFor(() => {
+      expect(mockFetchActiveListings).not.toHaveBeenCalled()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd src/frontend && npx vitest run src/routes/__tests__/listings.test.tsx
+```
+
+Expected: FAIL — component does not import `fetchUserApps` or `fetchActiveListings` yet.
+
+- [ ] **Step 3: Rewrite `listings.tsx`**
+
+Replace the entire content of `src/frontend/src/routes/listings.tsx`:
+
+```typescript
+import React, { useState, useMemo, useEffect } from 'react'
+import { createFileRoute } from '@tanstack/react-router'
+import { AppShell } from '../components/layout/AppShell'
+import { TopBar } from '../components/layout/TopBar'
+import { Button } from '../components/ui/Button'
+import { Icon } from '../components/design-system/Icon'
+import { ListingsTable } from '../features/ebay/components/ListingsTable'
+import { fetchUserApps, fetchActiveListings } from '../features/ebay/api'
+import {
+  MOCK_SOLD_LISTINGS,
+  MOCK_ATTENTION_ALERTS,
+  MOCK_STRATEGY_MIX,
+  formatUSD,
+  priceDeltaPct,
+  type EbayLiveListing,
+} from '../features/ebay/mockListings'
+import styles from './Listings.module.css'
+
+export const Route = createFileRoute('/listings')({
+  component: ListingsPage,
+})
+
+type Tab = 'active' | 'sold' | 'saved'
+
+const ALERT_COLORS: Record<string, string> = {
+  overpriced:  'var(--hd-red)',
+  stale:       'var(--hd-amber)',
+  underpriced: 'var(--hd-blue)',
+}
+
+const ALERT_ICONS: Record<string, 'arrowDown' | 'flag' | 'arrowUp'> = {
+  overpriced:  'arrowDown',
+  stale:       'flag',
+  underpriced: 'arrowUp',
+}
+
+export function ListingsPage() {
+  const [tab, setTab] = useState<Tab>('active')
+  const [listings, setListings] = useState<EbayLiveListing[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [failedApps, setFailedApps] = useState<string[]>([])
+  const [dismissedApps, setDismissedApps] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setIsLoading(true)
+      try {
+        const apps = await fetchUserApps()
+        const productionApps = apps.filter((a) => a.environment === 'PRODUCTION')
+
+        const results = await Promise.allSettled(
+          productionApps.map((app) =>
+            fetchActiveListings(app.app_code, 50, 0).then((items) =>
+              items.map((item) => ({ ...item, appName: app.app_name }))
+            )
+          )
+        )
+
+        if (cancelled) return
+
+        const merged: EbayLiveListing[] = []
+        const failed: string[] = []
+        results.forEach((result, i) => {
+          if (result.status === 'fulfilled') {
+            merged.push(...result.value)
+          } else {
+            failed.push(productionApps[i].app_name)
+          }
+        })
+
+        setListings(merged)
+        setFailedApps(failed)
+      } catch {
+        // fetchUserApps itself failed — leave listings empty, no per-app banners
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [])
+
+  const strategyTotal = useMemo(
+    () => MOCK_STRATEGY_MIX.reduce((a, b) => a + b.count, 0) || 1,
+    []
+  )
+
+  const visibleBanners = failedApps.filter((name) => !dismissedApps.has(name))
+
+  return (
+    <AppShell active="listings">
+      <TopBar
+        title="Your listings"
+        actions={
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Button variant="ghost" size="sm">Import</Button>
+            <Button
+              variant="accent"
+              size="sm"
+              icon={<Icon kind="plus" size={12} color="currentColor" />}
+            >
+              New listing
+            </Button>
+          </div>
+        }
+      />
+
+      <div className={styles.page}>
+        {/* ── Error banners ────────────────────────────────────── */}
+        {visibleBanners.map((appName) => (
+          <div key={appName} className={styles.errorBanner} role="alert">
+            <span>Could not load listings for {appName}.</span>
+            <button
+              className={styles.errorBannerDismiss}
+              aria-label="Dismiss"
+              onClick={() => setDismissedApps((prev) => new Set([...prev, appName]))}
+            >
+              <Icon kind="close" size={12} color="currentColor" />
+            </button>
+          </div>
+        ))}
+
+        {/* ── Tabs ─────────────────────────────────────────────── */}
+        <div className={styles.tabRow} role="tablist" aria-label="Listing tabs">
+          {(['active', 'sold', 'saved'] as Tab[]).map((t) => (
+            <button
+              key={t}
+              role="tab"
+              aria-selected={tab === t}
+              className={[styles.tab, tab === t ? styles.tabActive : ''].filter(Boolean).join(' ')}
+              onClick={() => setTab(t)}
+            >
+              {t.charAt(0).toUpperCase() + t.slice(1)}
+              {t === 'active' && (
+                <span className={styles.tabCount}>{listings.length}</span>
+              )}
+            </button>
+          ))}
+        </div>
+
+        {/* ── Main grid ─────────────────────────────────────────── */}
+        <div className={styles.contentGrid}>
+          <div>
+            {tab === 'active' && (
+              <ListingsTable listings={listings} isLoading={isLoading} />
+            )}
+            {tab === 'sold' && (
+              <div className={styles.soldTable} role="region" aria-label="Sold listings">
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>Card name</th>
+                      <th>Set</th>
+                      <th>Condition</th>
+                      <th className={styles.right}>Sale price</th>
+                      <th className={styles.right}>Market at sale</th>
+                      <th className={styles.right}>Days listed</th>
+                      <th>Sold date</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {MOCK_SOLD_LISTINGS.map((s) => {
+                      const delta = priceDeltaPct(s.salePrice, s.marketPriceAtSale)
+                      return (
+                        <tr key={s.id} className={styles.soldRow}>
+                          <td>
+                            <span className={styles.soldCardName}>{s.cardName}</span>
+                            {s.foil && <span className={styles.foilBadge}>foil</span>}
+                          </td>
+                          <td><span className={styles.setCode}>{s.setCode}</span></td>
+                          <td className={styles.condition}>{s.condition}</td>
+                          <td className={[styles.right, styles.mono].join(' ')}>
+                            <span className={delta >= 0 ? styles.positive : styles.negative}>
+                              {formatUSD(s.salePrice)}
+                            </span>
+                          </td>
+                          <td className={[styles.right, styles.mono, styles.muted].join(' ')}>
+                            {formatUSD(s.marketPriceAtSale)}
+                          </td>
+                          <td className={[styles.right, styles.mono, styles.muted].join(' ')}>
+                            {s.daysListed}d
+                          </td>
+                          <td className={[styles.mono, styles.muted].join(' ')}>{s.soldDate}</td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+            {tab === 'saved' && (
+              <div className={styles.emptyState}>
+                <Icon kind="tag" size={32} color="var(--hd-sub)" />
+                <p>No saved drafts</p>
+              </div>
+            )}
+          </div>
+
+          {/* Right: sidebar panels */}
+          <aside className={styles.sidebar} aria-label="Listings sidebar">
+            <div className={styles.sidePanel}>
+              <div className={styles.sidePanelTitle}>Needs your attention</div>
+              <div className={styles.alertList}>
+                {MOCK_ATTENTION_ALERTS.map((alert) => {
+                  const color = ALERT_COLORS[alert.type]
+                  const iconKind = ALERT_ICONS[alert.type]
+                  return (
+                    <div key={alert.id} className={styles.alertRow}>
+                      <div className={styles.alertDot} style={{ background: color }} aria-hidden="true" />
+                      <div className={styles.alertContent}>
+                        <div className={styles.alertIcon} style={{ color }}>
+                          <Icon kind={iconKind} size={11} color={color} />
+                        </div>
+                        <div>
+                          <div className={styles.alertCard}>{alert.cardName}</div>
+                          <div className={styles.alertMessage}>{alert.message}</div>
+                        </div>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            </div>
+
+            <div className={styles.sidePanel}>
+              <div className={styles.sidePanelTitle}>Recent sales</div>
+              {MOCK_SOLD_LISTINGS.slice(0, 3).map((sale) => {
+                const delta = priceDeltaPct(sale.salePrice, sale.marketPriceAtSale)
+                return (
+                  <div key={sale.id} className={styles.recentSaleRow}>
+                    <div className={styles.recentSaleName}>{sale.cardName}</div>
+                    <div className={styles.recentSaleRight}>
+                      <span className={styles.recentSalePrice}>{formatUSD(sale.salePrice)}</span>
+                      <span className={[styles.recentSaleDelta, delta >= 0 ? styles.positive : styles.negative].join(' ')}>
+                        {delta > 0 ? '+' : ''}{delta}%
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+
+            <div className={styles.sidePanel}>
+              <div className={styles.sidePanelTitle}>Strategy mix</div>
+              <div className={styles.strategyBarWrapper}>
+                <div className={styles.strategyBar} role="img" aria-label="Strategy distribution bar">
+                  {MOCK_STRATEGY_MIX.map((item) => (
+                    <div
+                      key={item.label}
+                      className={styles.strategyBarSegment}
+                      style={{ flex: item.count, background: item.color }}
+                      title={`${item.label}: ${item.count}`}
+                    />
+                  ))}
+                </div>
+              </div>
+              <div className={styles.strategyLegend}>
+                {MOCK_STRATEGY_MIX.map((item) => (
+                  <div key={item.label} className={styles.strategyLegendRow}>
+                    <div className={styles.strategyLegendDot} style={{ background: item.color }} aria-hidden="true" />
+                    <span className={styles.strategyLegendLabel}>{item.label}</span>
+                    <span className={styles.strategyLegendCount}>
+                      {item.count} ({Math.round((item.count / strategyTotal) * 100)}%)
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </AppShell>
+  )
+}
+```
+
+Note: `ListingsPage` is exported as a named export so the test can import it directly without a router context.
+
+- [ ] **Step 4: Add error banner CSS to `Listings.module.css`**
+
+Check if `src/frontend/src/routes/Listings.module.css` exists:
+
+```bash
+ls src/frontend/src/routes/Listings.module.css
+```
+
+Append to the end of that file:
+
+```css
+/* Error banner */
+.errorBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 8px 0;
+  padding: 8px 12px;
+  background: rgba(227, 94, 108, 0.08);
+  border: 1px solid rgba(227, 94, 108, 0.25);
+  border-radius: 6px;
+  font-size: 12px;
+  color: var(--hd-red);
+}
+
+.errorBannerDismiss {
+  background: transparent;
+  border: none;
+  color: var(--hd-muted);
+  cursor: pointer;
+  padding: 2px;
+  display: flex;
+  align-items: center;
+  border-radius: 3px;
+  transition: color 0.1s;
+}
+
+.errorBannerDismiss:hover {
+  color: var(--hd-text);
+}
+```
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+cd src/frontend && npx vitest run
+```
+
+Expected: all tests in the suite pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/routes/listings.tsx \
+        src/frontend/src/routes/__tests__/listings.test.tsx
+git commit -m "feat(ebay): wire listings Active tab to live API data with parallel fetch and error banners"
+```
+
+---
+
+## Self-Review Checklist
+
+Run this mentally after all tasks complete:
+
+1. **Spec coverage:**
+   - ✓ Thumbnail column (Task 3) — 28×39px, `object-fit: cover`, placeholder div
+   - ✓ Card name as external link (Task 3) — `target="_blank" rel="noopener noreferrer"`
+   - ✓ App badge with colour cycling (Task 3)
+   - ✓ Finish badge — Foil gradient, Regular muted (Task 3 + CSS)
+   - ✓ Foil row tint (Task 3 + CSS)
+   - ✓ Inline filter in card name header (Task 3) — 140px underline input, placeholder "card name"
+   - ✓ Data flow — production apps only, parallel fetch, flatten, error skip (Task 4)
+   - ✓ Skeleton rows while loading (Task 3, Task 4)
+   - ✓ Error banner dismissible (Task 4)
+   - ✓ AI status badge kept static (Task 3)
+   - ✓ Sold + Saved tabs remain mock (Task 4)
+
+2. **Type consistency:**
+   - `EbayLiveListing` defined in Task 1, imported in Tasks 2, 3, 4 — check spellings match exactly.
+   - `fetchActiveListings` signature: `(appCode: string, limit?: number, offset?: number): Promise<EbayLiveListing[]>` — used in Task 4 as `fetchActiveListings(app.app_code, 50, 0)`.
+
+3. **No placeholders:** All code blocks are complete and runnable.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-09-ebay-listings-page.md`.
+
+**Two execution options:**
+
+**1. Subagent-Driven (recommended)** — dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/plans/2026-05-09-sold-orders-dashboard.md
+++ b/docs/superpowers/plans/2026-05-09-sold-orders-dashboard.md
@@ -1,0 +1,2464 @@
+# Sold Orders Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface sold eBay orders in the Listings page Sold tab with lifecycle badges (Sold → Sent → In Transit → Complete) and inline "Mark as sent" / "Add tracking" actions that call eBay's Fulfillment API.
+
+**Architecture:** eBay's `orderFulfillmentStatus` drives Sold/Sent/Complete; a new local table `app_integration.ebay_order_status` stores the In Transit override and tracking metadata. Two new backend endpoints handle fulfillment writes; the existing history endpoint is augmented to merge local status. Three new frontend components (LifecycleBadge, SoldOrdersTable, SoldOrderDetailPanel) wire into the existing Sold tab stub.
+
+**Tech Stack:** Python/FastAPI, asyncpg, Pydantic v2, pytest-asyncio; React 18, TypeScript, CSS Modules, Vitest, @testing-library/react.
+
+---
+
+## Task 1: DB Migration
+
+**Files:**
+- Create: `src/automana/database/SQL/migrations/migration_26_ebay_order_status.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- migration_26_ebay_order_status.sql
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS app_integration.ebay_order_status (
+    order_id        TEXT         NOT NULL,
+    app_code        VARCHAR(50)  NOT NULL
+        REFERENCES app_integration.app_info(app_code) ON DELETE CASCADE,
+    local_status    TEXT         NOT NULL
+        CHECK (local_status IN ('sold', 'sent', 'in_transit', 'complete')),
+    tracking_number TEXT,
+    carrier_code    TEXT,
+    shipped_at      TIMESTAMPTZ,
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    PRIMARY KEY (order_id, app_code)
+);
+
+GRANT SELECT, INSERT, UPDATE ON app_integration.ebay_order_status TO app_backend;
+GRANT SELECT, INSERT, UPDATE ON app_integration.ebay_order_status TO app_celery;
+
+COMMIT;
+```
+
+- [ ] **Step 2: Apply the migration**
+
+```bash
+docker exec -i automana-postgres-dev psql -U automana_admin automana \
+  < src/automana/database/SQL/migrations/migration_26_ebay_order_status.sql
+```
+
+Expected: `CREATE TABLE` then `GRANT`.
+
+- [ ] **Step 3: Verify**
+
+```bash
+docker exec automana-postgres-dev psql -U automana_admin automana \
+  -c "\d app_integration.ebay_order_status"
+```
+
+Expected: table with columns `order_id`, `app_code`, `local_status`, `tracking_number`, `carrier_code`, `shipped_at`, `updated_at`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/automana/database/SQL/migrations/migration_26_ebay_order_status.sql
+git commit -m "feat(ebay): add ebay_order_status migration for sold orders lifecycle"
+```
+
+---
+
+## Task 2: App Repository — Order Status CRUD
+
+**Files:**
+- Modify: `src/automana/core/repositories/app_integration/ebay/app_queries.py`
+- Modify: `src/automana/core/repositories/app_integration/ebay/app_repository.py`
+- Create: `src/automana/tests/unit/repositories/ebay/test_order_status_repository.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/automana/tests/unit/repositories/ebay/test_order_status_repository.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from automana.core.repositories.app_integration.ebay.app_repository import EbayAppRepository
+
+
+def make_repo():
+    conn = MagicMock()
+    repo = EbayAppRepository.__new__(EbayAppRepository)
+    repo.connection = conn
+    repo.executor = None
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_get_order_statuses_returns_dict_keyed_by_order_id(monkeypatch):
+    repo = make_repo()
+    fake_rows = [
+        {"order_id": "ord-1", "local_status": "sent", "tracking_number": None,
+         "carrier_code": None, "shipped_at": None},
+    ]
+    repo.execute_query = AsyncMock(return_value=fake_rows)
+
+    result = await repo.get_order_statuses(app_code="myapp", order_ids=["ord-1", "ord-2"])
+
+    assert result == {
+        "ord-1": {"order_id": "ord-1", "local_status": "sent", "tracking_number": None,
+                  "carrier_code": None, "shipped_at": None}
+    }
+    repo.execute_query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_get_order_statuses_empty_returns_empty_dict(monkeypatch):
+    repo = make_repo()
+    repo.execute_query = AsyncMock(return_value=[])
+    result = await repo.get_order_statuses(app_code="myapp", order_ids=[])
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_upsert_order_status_calls_execute_command():
+    repo = make_repo()
+    repo.execute_command = AsyncMock(return_value=None)
+
+    await repo.upsert_order_status(
+        order_id="ord-1",
+        app_code="myapp",
+        local_status="sent",
+        tracking_number="TRK123",
+        carrier_code="AusPost",
+        shipped_at=None,
+    )
+
+    repo.execute_command.assert_awaited_once()
+    args = repo.execute_command.call_args[0]
+    assert args[1] == ("ord-1", "myapp", "sent", "TRK123", "AusPost", None)
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+cd src && python -m pytest automana/tests/unit/repositories/ebay/test_order_status_repository.py -v
+```
+
+Expected: `ImportError` or `AttributeError` — methods don't exist yet.
+
+- [ ] **Step 3: Add SQL queries to app_queries.py**
+
+Append to `src/automana/core/repositories/app_integration/ebay/app_queries.py`:
+
+```python
+get_order_statuses_query = """
+SELECT order_id, local_status, tracking_number, carrier_code, shipped_at
+FROM app_integration.ebay_order_status
+WHERE app_code = $1
+  AND order_id = ANY($2::TEXT[])
+"""
+
+upsert_order_status_query = """
+INSERT INTO app_integration.ebay_order_status
+    (order_id, app_code, local_status, tracking_number, carrier_code, shipped_at, updated_at)
+VALUES ($1, $2, $3, $4, $5, $6, now())
+ON CONFLICT (order_id, app_code) DO UPDATE SET
+    local_status    = EXCLUDED.local_status,
+    tracking_number = COALESCE(EXCLUDED.tracking_number,
+                               app_integration.ebay_order_status.tracking_number),
+    carrier_code    = COALESCE(EXCLUDED.carrier_code,
+                               app_integration.ebay_order_status.carrier_code),
+    shipped_at      = COALESCE(EXCLUDED.shipped_at,
+                               app_integration.ebay_order_status.shipped_at),
+    updated_at      = now()
+"""
+```
+
+- [ ] **Step 4: Add repository methods to app_repository.py**
+
+Append inside the `EbayAppRepository` class in `src/automana/core/repositories/app_integration/ebay/app_repository.py`:
+
+```python
+    async def get_order_statuses(
+        self, app_code: str, order_ids: list[str]
+    ) -> dict[str, dict]:
+        rows = await self.execute_query(
+            app_queries.get_order_statuses_query, (app_code, order_ids)
+        )
+        return {row["order_id"]: dict(row) for row in (rows or [])}
+
+    async def upsert_order_status(
+        self,
+        order_id: str,
+        app_code: str,
+        local_status: str,
+        tracking_number: str | None = None,
+        carrier_code: str | None = None,
+        shipped_at=None,
+    ) -> None:
+        await self.execute_command(
+            app_queries.upsert_order_status_query,
+            (order_id, app_code, local_status, tracking_number, carrier_code, shipped_at),
+        )
+```
+
+- [ ] **Step 5: Run tests — expect green**
+
+```bash
+cd src && python -m pytest automana/tests/unit/repositories/ebay/test_order_status_repository.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/automana/core/repositories/app_integration/ebay/app_queries.py \
+        src/automana/core/repositories/app_integration/ebay/app_repository.py \
+        src/automana/tests/unit/repositories/ebay/test_order_status_repository.py
+git commit -m "feat(ebay): add get_order_statuses and upsert_order_status to app repository"
+```
+
+---
+
+## Task 3: ApiSelling Repository — create_shipping_fulfillment
+
+**Files:**
+- Modify: `src/automana/core/repositories/app_integration/ebay/ApiSelling_repository.py`
+- Create: `src/automana/tests/unit/repositories/ebay/test_api_selling_fulfill.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/automana/tests/unit/repositories/ebay/test_api_selling_fulfill.py
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from automana.core.repositories.app_integration.ebay.ApiSelling_repository import EbaySellingRepository
+
+
+def make_repo(environment="sandbox"):
+    repo = EbaySellingRepository.__new__(EbaySellingRepository)
+    repo.environment = environment
+    repo.timeout = 30
+    repo.http2 = True
+    repo.base_url = "https://api.sandbox.ebay.com/ws/api.dll"
+    repo._client = None
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_create_shipping_fulfillment_posts_correct_url():
+    repo = make_repo()
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    repo.send = AsyncMock(return_value=mock_response)
+
+    result = await repo.create_shipping_fulfillment({
+        "token": "tok123",
+        "order_id": "12-34567-89012",
+        "line_item_ids": ["9876543210"],
+    })
+
+    assert result == {"success": True, "order_id": "12-34567-89012"}
+    call_args = repo.send.call_args
+    assert call_args[0][0] == "POST"
+    assert "12-34567-89012/shippingFulfillment" in call_args[0][1]
+    body = call_args[1]["json"]
+    assert body["lineItems"] == [{"lineItemId": "9876543210", "quantity": 1}]
+    assert "shippedDate" in body
+
+
+@pytest.mark.asyncio
+async def test_create_shipping_fulfillment_includes_tracking_when_provided():
+    repo = make_repo()
+    mock_response = MagicMock()
+    mock_response.status_code = 201
+    repo.send = AsyncMock(return_value=mock_response)
+
+    await repo.create_shipping_fulfillment({
+        "token": "tok123",
+        "order_id": "ord-1",
+        "line_item_ids": ["111"],
+        "tracking_number": "TRK999",
+        "carrier_code": "AusPost",
+    })
+
+    body = repo.send.call_args[1]["json"]
+    assert body["trackingNumber"] == "TRK999"
+    assert body["shippingCarrierCode"] == "AusPost"
+
+
+@pytest.mark.asyncio
+async def test_create_shipping_fulfillment_raises_on_missing_token():
+    repo = make_repo()
+    with pytest.raises(ValueError, match="Token is required"):
+        await repo.create_shipping_fulfillment({"order_id": "ord-1", "line_item_ids": []})
+
+
+@pytest.mark.asyncio
+async def test_create_shipping_fulfillment_raises_on_missing_order_id():
+    repo = make_repo()
+    with pytest.raises(ValueError, match="order_id is required"):
+        await repo.create_shipping_fulfillment({"token": "tok", "line_item_ids": []})
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src && python -m pytest automana/tests/unit/repositories/ebay/test_api_selling_fulfill.py -v
+```
+
+Expected: `AttributeError: 'EbaySellingRepository' object has no attribute 'create_shipping_fulfillment'`.
+
+- [ ] **Step 3: Add the method to ApiSelling_repository.py**
+
+Append inside the `EbaySellingRepository` class, after `upload_picture`:
+
+```python
+    async def create_shipping_fulfillment(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Mark an eBay order as shipped via the Fulfillment REST API.
+
+        POST /sell/fulfillment/v1/order/{orderId}/shippingFulfillment
+        Returns {"success": True, "order_id": ...} on 200/201/204.
+        """
+        token = payload.get("token")
+        order_id = payload.get("order_id")
+        if not token:
+            raise ValueError("Token is required")
+        if not order_id:
+            raise ValueError("order_id is required")
+
+        base = (
+            "https://api.sandbox.ebay.com"
+            if self.environment == "sandbox"
+            else "https://api.ebay.com"
+        )
+        url = f"{base}/sell/fulfillment/v1/order/{order_id}/shippingFulfillment"
+
+        from datetime import datetime, timezone
+        body: Dict[str, Any] = {
+            "lineItems": [
+                {"lineItemId": lid, "quantity": 1}
+                for lid in payload.get("line_item_ids", [])
+            ],
+            "shippedDate": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+        }
+        if payload.get("tracking_number"):
+            body["trackingNumber"] = payload["tracking_number"]
+        if payload.get("carrier_code"):
+            body["shippingCarrierCode"] = payload["carrier_code"]
+
+        headers = {**self.auth_header(token), "Content-Type": "application/json"}
+        logger.info(
+            "ebay_create_shipping_fulfillment",
+            extra={"order_id": order_id},
+        )
+        response = await self.send("POST", url, json=body, headers=headers)
+        if response.status_code in (200, 201, 204):
+            return {"success": True, "order_id": order_id}
+        return self._parse_response(response)
+```
+
+- [ ] **Step 4: Run tests — expect green**
+
+```bash
+cd src && python -m pytest automana/tests/unit/repositories/ebay/test_api_selling_fulfill.py -v
+```
+
+Expected: 4 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/automana/core/repositories/app_integration/ebay/ApiSelling_repository.py \
+        src/automana/tests/unit/repositories/ebay/test_api_selling_fulfill.py
+git commit -m "feat(ebay): add create_shipping_fulfillment to ApiSelling repository"
+```
+
+---
+
+## Task 4: FulfillmentResponse Model — local_status field
+
+**Files:**
+- Modify: `src/automana/core/models/ebay/listings.py`
+
+- [ ] **Step 1: Add `local_status` to `FulfillmentResponse`**
+
+In `src/automana/core/models/ebay/listings.py`, add `local_status` to the `FulfillmentResponse` class:
+
+```python
+class FulfillmentResponse(BaseModel):
+    orderId: Optional[str]
+    legacyOrderId: Optional[str]
+    creationDate: Optional[str]
+    lastModifiedDate: Optional[str]
+    orderFulfillmentStatus: Optional[str]
+    orderPaymentStatus: Optional[str]
+    sellerId: Optional[str]
+    buyer: Optional[BuyerType]
+    pricingSummary: Optional[PricingSummaryType]
+    cancelStatus: Optional[CancelStatusType]
+    paymentSummary: Optional[PaymentSummaryType]
+    fulfillmentStartInstructions: Optional[List[FulfillmentStartInstructionsType]]
+    fulfillmentHrefs: Optional[List[str]]
+    lineItems: Optional[List[LineItemType]]
+    salesRecordReference: Optional[str]
+    totalFeeBasisAmount: Optional[BaseCostType]
+    totalMarketplaceFee: Optional[BaseCostType]
+    local_status: Optional[str] = None   # AutoMana override — not from eBay
+```
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+```bash
+cd src && python -m pytest automana/tests/ -q --tb=short 2>&1 | tail -10
+```
+
+Expected: same pass count as before (adding an optional field with a default cannot break existing behaviour).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/automana/core/models/ebay/listings.py
+git commit -m "feat(ebay): add local_status field to FulfillmentResponse model"
+```
+
+---
+
+## Task 5: fulfillment_write_service — Mark Order Shipped
+
+**Files:**
+- Create: `src/automana/core/services/app_integration/ebay/fulfillment_write_service.py`
+- Create: `src/automana/tests/unit/services/ebay/test_fulfillment_write_service.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/automana/tests/unit/services/ebay/test_fulfillment_write_service.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+from automana.core.services.app_integration.ebay.fulfillment_write_service import mark_order_shipped
+
+USER_ID = UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture
+def auth_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def app_repo():
+    repo = AsyncMock()
+    repo.upsert_order_status = AsyncMock(return_value=None)
+    return repo
+
+
+@pytest.fixture
+def selling_repo():
+    repo = AsyncMock()
+    repo.create_shipping_fulfillment = AsyncMock(
+        return_value={"success": True, "order_id": "ord-1"}
+    )
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_mark_order_shipped_calls_ebay_and_upserts_local(auth_repo, app_repo, selling_repo):
+    with patch(
+        "automana.core.services.app_integration.ebay.fulfillment_write_service.resolve_token",
+        new=AsyncMock(return_value="tok123"),
+    ):
+        result = await mark_order_shipped(
+            auth_repository=auth_repo,
+            app_repository=app_repo,
+            selling_repository=selling_repo,
+            user_id=USER_ID,
+            app_code="myapp",
+            order_id="ord-1",
+            line_item_ids=["line-111"],
+        )
+
+    assert result == {"success": True, "order_id": "ord-1"}
+    selling_repo.create_shipping_fulfillment.assert_awaited_once()
+    payload = selling_repo.create_shipping_fulfillment.call_args[0][0]
+    assert payload["token"] == "tok123"
+    assert payload["order_id"] == "ord-1"
+    assert payload["line_item_ids"] == ["line-111"]
+    assert payload.get("tracking_number") is None
+
+    app_repo.upsert_order_status.assert_awaited_once()
+    upsert_kwargs = app_repo.upsert_order_status.call_args[1]
+    assert upsert_kwargs["order_id"] == "ord-1"
+    assert upsert_kwargs["local_status"] == "sent"
+
+
+@pytest.mark.asyncio
+async def test_mark_order_shipped_passes_tracking_when_provided(auth_repo, app_repo, selling_repo):
+    with patch(
+        "automana.core.services.app_integration.ebay.fulfillment_write_service.resolve_token",
+        new=AsyncMock(return_value="tok"),
+    ):
+        await mark_order_shipped(
+            auth_repository=auth_repo,
+            app_repository=app_repo,
+            selling_repository=selling_repo,
+            user_id=USER_ID,
+            app_code="myapp",
+            order_id="ord-2",
+            line_item_ids=["l2"],
+            tracking_number="TRK999",
+            carrier_code="AusPost",
+        )
+
+    payload = selling_repo.create_shipping_fulfillment.call_args[0][0]
+    assert payload["tracking_number"] == "TRK999"
+    assert payload["carrier_code"] == "AusPost"
+    upsert_kwargs = app_repo.upsert_order_status.call_args[1]
+    assert upsert_kwargs["tracking_number"] == "TRK999"
+    assert upsert_kwargs["carrier_code"] == "AusPost"
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src && python -m pytest automana/tests/unit/services/ebay/test_fulfillment_write_service.py -v
+```
+
+Expected: `ImportError` — module doesn't exist yet.
+
+- [ ] **Step 3: Create fulfillment_write_service.py**
+
+```python
+# src/automana/core/services/app_integration/ebay/fulfillment_write_service.py
+"""eBay fulfillment writes — marking orders as shipped.
+
+Design patterns
+───────────────
+- CQS: this module owns fulfillment writes. Reads live in ``fulfillment_service``.
+- Guard clause via ``_auth_context.resolve_token``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from automana.core.repositories.app_integration.ebay.auth_repository import EbayAuthRepository
+from automana.core.repositories.app_integration.ebay.app_repository import EbayAppRepository
+from automana.core.repositories.app_integration.ebay.ApiSelling_repository import EbaySellingRepository
+from automana.core.service_registry import ServiceRegistry
+from automana.core.services.app_integration.ebay._auth_context import resolve_token
+
+logger = logging.getLogger(__name__)
+
+
+@ServiceRegistry.register(
+    path="integrations.ebay.selling.fulfillment.ship",
+    db_repositories=["auth", "app"],
+    api_repositories=["selling"],
+)
+async def mark_order_shipped(
+    auth_repository: EbayAuthRepository,
+    app_repository: EbayAppRepository,
+    selling_repository: EbaySellingRepository,
+    user_id: UUID,
+    app_code: str,
+    order_id: str,
+    line_item_ids: List[str],
+    tracking_number: Optional[str] = None,
+    carrier_code: Optional[str] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Call eBay's Fulfillment API to mark an order shipped, then persist locally."""
+    logger.info(
+        "ebay_mark_order_shipped_requested",
+        extra={
+            "action": "mark_order_shipped",
+            "user_id": str(user_id),
+            "app_code": app_code,
+            "order_id": order_id,
+        },
+    )
+
+    token = await resolve_token(auth_repository, user_id=user_id, app_code=app_code)
+
+    result = await selling_repository.create_shipping_fulfillment({
+        "token": token,
+        "order_id": order_id,
+        "line_item_ids": line_item_ids,
+        "tracking_number": tracking_number,
+        "carrier_code": carrier_code,
+    })
+
+    await app_repository.upsert_order_status(
+        order_id=order_id,
+        app_code=app_code,
+        local_status="sent",
+        tracking_number=tracking_number,
+        carrier_code=carrier_code,
+        shipped_at=datetime.now(timezone.utc),
+    )
+
+    logger.info(
+        "ebay_mark_order_shipped_success",
+        extra={"action": "mark_order_shipped", "order_id": order_id},
+    )
+    return result
+```
+
+- [ ] **Step 4: Run tests — expect green**
+
+```bash
+cd src && python -m pytest automana/tests/unit/services/ebay/test_fulfillment_write_service.py -v
+```
+
+Expected: 2 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/automana/core/services/app_integration/ebay/fulfillment_write_service.py \
+        src/automana/tests/unit/services/ebay/test_fulfillment_write_service.py
+git commit -m "feat(ebay): add fulfillment_write_service for marking orders shipped"
+```
+
+---
+
+## Task 6: Augment get_order_history + local PATCH status
+
+**Files:**
+- Modify: `src/automana/core/services/app_integration/ebay/fulfillment_service.py`
+- Create: `src/automana/tests/unit/services/ebay/test_fulfillment_service_augmented.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/automana/tests/unit/services/ebay/test_fulfillment_service_augmented.py
+import pytest
+from unittest.mock import AsyncMock, patch
+from uuid import UUID
+from automana.core.services.app_integration.ebay.fulfillment_service import (
+    get_order_history,
+    update_order_local_status,
+)
+
+USER_ID = UUID("00000000-0000-0000-0000-000000000002")
+
+RAW_ORDERS = {
+    "orders": [
+        {
+            "orderId": "ord-1",
+            "orderFulfillmentStatus": "NOT_STARTED",
+            "orderPaymentStatus": "FULLY_PAID",
+            "buyer": None,
+            "pricingSummary": None,
+            "cancelStatus": None,
+            "paymentSummary": None,
+            "fulfillmentStartInstructions": None,
+            "fulfillmentHrefs": None,
+            "lineItems": [{"lineItemId": "line-1", "legacyItemId": None, "title": "Ragavan",
+                           "lineItemCost": None, "quantity": 1, "soldFormat": None,
+                           "listingMarketplaceId": None, "purchaseMarketplaceId": None,
+                           "lineItemFulfillmentStatus": None, "total": None,
+                           "deliveryCost": None, "appliedPromotions": None,
+                           "taxes": None, "properties": None,
+                           "lineItemFulfillmentInstructions": None, "itemLocation": None}],
+        }
+    ],
+    "total": 1,
+}
+
+
+@pytest.fixture
+def auth_repo():
+    return AsyncMock()
+
+
+@pytest.fixture
+def app_repo():
+    repo = AsyncMock()
+    repo.get_order_statuses = AsyncMock(return_value={})
+    repo.upsert_order_status = AsyncMock(return_value=None)
+    return repo
+
+
+@pytest.fixture
+def selling_repo():
+    repo = AsyncMock()
+    repo.get_history = AsyncMock(return_value=RAW_ORDERS)
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_get_order_history_merges_local_status(auth_repo, app_repo, selling_repo):
+    app_repo.get_order_statuses = AsyncMock(
+        return_value={"ord-1": {"local_status": "in_transit"}}
+    )
+    with patch(
+        "automana.core.services.app_integration.ebay.fulfillment_service.resolve_token",
+        new=AsyncMock(return_value="tok"),
+    ):
+        result = await get_order_history(
+            auth_repository=auth_repo,
+            app_repository=app_repo,
+            selling_repository=selling_repo,
+            user_id=USER_ID,
+            app_code="myapp",
+        )
+
+    assert result.items[0].local_status == "in_transit"
+
+
+@pytest.mark.asyncio
+async def test_get_order_history_local_status_none_when_no_row(auth_repo, app_repo, selling_repo):
+    with patch(
+        "automana.core.services.app_integration.ebay.fulfillment_service.resolve_token",
+        new=AsyncMock(return_value="tok"),
+    ):
+        result = await get_order_history(
+            auth_repository=auth_repo,
+            app_repository=app_repo,
+            selling_repository=selling_repo,
+            user_id=USER_ID,
+            app_code="myapp",
+        )
+
+    assert result.items[0].local_status is None
+
+
+@pytest.mark.asyncio
+async def test_update_order_local_status_upserts(auth_repo, app_repo):
+    await update_order_local_status(
+        app_repository=app_repo,
+        order_id="ord-1",
+        app_code="myapp",
+        local_status="in_transit",
+    )
+    app_repo.upsert_order_status.assert_awaited_once_with(
+        order_id="ord-1",
+        app_code="myapp",
+        local_status="in_transit",
+    )
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src && python -m pytest automana/tests/unit/services/ebay/test_fulfillment_service_augmented.py -v
+```
+
+Expected: `ImportError` for `update_order_local_status`, and attribute errors for the `app_repository` parameter.
+
+- [ ] **Step 3: Rewrite fulfillment_service.py**
+
+Replace the entire content of `src/automana/core/services/app_integration/ebay/fulfillment_service.py`:
+
+```python
+"""eBay fulfillment — order history query and local status transitions.
+
+Design patterns
+───────────────
+- CQS: reads and simple local writes share this module; heavyweight writes
+  (eBay API calls) live in ``fulfillment_write_service``.
+- Guard Clause via ``_auth_context.resolve_token``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from automana.core.models.ebay import listings as listings_model
+from automana.core.repositories.app_integration.ebay.auth_repository import EbayAuthRepository
+from automana.core.repositories.app_integration.ebay.app_repository import EbayAppRepository
+from automana.core.repositories.app_integration.ebay.ApiSelling_repository import EbaySellingRepository
+from automana.core.service_registry import ServiceRegistry
+from automana.core.services.app_integration.ebay._auth_context import resolve_token
+
+logger = logging.getLogger(__name__)
+
+
+@ServiceRegistry.register(
+    path="integrations.ebay.selling.fulfillment.history",
+    db_repositories=["auth", "app"],
+    api_repositories=["selling"],
+)
+async def get_order_history(
+    auth_repository: EbayAuthRepository,
+    app_repository: EbayAppRepository,
+    selling_repository: EbaySellingRepository,
+    user_id: UUID,
+    app_code: str,
+    limit: int = 10,
+    offset: int = 0,
+    **kwargs: Any,
+) -> listings_model.PaginatedOrders:
+    """Fetch order history from the eBay Fulfillment API, merged with local status."""
+    logger.info(
+        "ebay_get_order_history_requested",
+        extra={
+            "action": "get_order_history",
+            "user_id": str(user_id),
+            "app_code": app_code,
+            "limit": limit,
+            "offset": offset,
+        },
+    )
+
+    token = await resolve_token(auth_repository, user_id=user_id, app_code=app_code)
+    payload: Dict[str, Any] = {"token": token, "limit": limit, "offset": offset}
+    raw = await selling_repository.get_history(payload)
+
+    raw_orders = raw.get("orders") or []
+    items: List[listings_model.FulfillmentResponse] = []
+    for order in raw_orders:
+        if isinstance(order, dict):
+            items.append(listings_model.FulfillmentResponse.model_validate(order))
+
+    # Merge local status overrides.
+    if items:
+        order_ids = [o.orderId for o in items if o.orderId]
+        local_map = await app_repository.get_order_statuses(
+            app_code=app_code, order_ids=order_ids
+        )
+        for item in items:
+            if item.orderId and item.orderId in local_map:
+                item.local_status = local_map[item.orderId].get("local_status")
+
+    raw_total: Optional[Any] = raw.get("total")
+    total: Optional[int] = None
+    if raw_total is not None:
+        try:
+            total = int(raw_total)
+        except (ValueError, TypeError):
+            logger.warning(
+                "ebay_order_history_total_parse_failed",
+                extra={"action": "get_order_history", "raw_total": str(raw_total)},
+            )
+
+    return listings_model.PaginatedOrders.from_parts(
+        items=items, total=total, offset=offset, limit=limit,
+    )
+
+
+@ServiceRegistry.register(
+    path="integrations.ebay.selling.fulfillment.local_status",
+    db_repositories=["app"],
+    api_repositories=[],
+)
+async def update_order_local_status(
+    app_repository: EbayAppRepository,
+    order_id: str,
+    app_code: str,
+    local_status: str,
+    **kwargs: Any,
+) -> Dict[str, str]:
+    """Update the AutoMana-local lifecycle status for an order (no eBay call)."""
+    logger.info(
+        "ebay_update_order_local_status",
+        extra={"action": "update_order_local_status", "order_id": order_id, "local_status": local_status},
+    )
+    await app_repository.upsert_order_status(
+        order_id=order_id,
+        app_code=app_code,
+        local_status=local_status,
+    )
+    return {"order_id": order_id, "local_status": local_status}
+```
+
+- [ ] **Step 4: Run tests — expect green**
+
+```bash
+cd src && python -m pytest automana/tests/unit/services/ebay/test_fulfillment_service_augmented.py -v
+```
+
+Expected: 3 PASSED.
+
+- [ ] **Step 5: Run full suite to check nothing regressed**
+
+```bash
+cd src && python -m pytest automana/tests/ -q --tb=short 2>&1 | tail -15
+```
+
+Expected: all previously passing tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/automana/core/services/app_integration/ebay/fulfillment_service.py \
+        src/automana/tests/unit/services/ebay/test_fulfillment_service_augmented.py
+git commit -m "feat(ebay): augment get_order_history with local status merge; add update_order_local_status"
+```
+
+---
+
+## Task 7: Router — POST /orders/{order_id}/fulfill and PATCH /orders/{order_id}/status
+
+**Files:**
+- Modify: `src/automana/api/routers/integrations/ebay/ebay_selling.py`
+
+- [ ] **Step 1: Add request models and endpoints**
+
+Append to `src/automana/api/routers/integrations/ebay/ebay_selling.py`, after the existing imports and before the final upload endpoint. First add two new request body models at the top of the file alongside `BuildListingRequest`:
+
+```python
+class FulfillOrderRequest(BaseModel):
+    app_code: str
+    line_item_ids: List[str]
+    tracking_number: Optional[str] = None
+    carrier_code: Optional[str] = None
+
+class UpdateOrderStatusRequest(BaseModel):
+    app_code: str
+    local_status: str
+```
+
+Then add `List` to the existing `from typing import` line — it already has `Optional`, add `List`:
+
+```python
+from typing import Annotated, Any, Dict, List, Optional
+```
+
+Then append the two new endpoints at the end of the file:
+
+```python
+@ebay_listing_router.post("/orders/{order_id}/fulfill", description="Mark an order as shipped on eBay")
+async def fulfill_order(
+    order_id: str,
+    body: FulfillOrderRequest,
+    user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    if body.local_status_validate := body.local_status if hasattr(body, "local_status") else None:
+        pass  # unused branch — kept for symmetry
+    try:
+        result = await service_manager.execute_service(
+            "integrations.ebay.selling.fulfillment.ship",
+            user_id=user.unique_id,
+            app_code=body.app_code,
+            order_id=order_id,
+            line_item_ids=body.line_item_ids,
+            tracking_number=body.tracking_number,
+            carrier_code=body.carrier_code,
+        )
+        return ApiResponse(data=result, message="Order marked as shipped")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@ebay_listing_router.patch("/orders/{order_id}/status", description="Update local order lifecycle status")
+async def patch_order_status(
+    order_id: str,
+    body: UpdateOrderStatusRequest,
+    user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    allowed = {"in_transit", "complete"}
+    if body.local_status not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=f"local_status must be one of {sorted(allowed)}",
+        )
+    try:
+        result = await service_manager.execute_service(
+            "integrations.ebay.selling.fulfillment.local_status",
+            order_id=order_id,
+            app_code=body.app_code,
+            local_status=body.local_status,
+        )
+        return ApiResponse(data=result, message="Order status updated")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+```
+
+Note: remove the dead walrus-operator line above — it was a placeholder. The clean version:
+
+```python
+@ebay_listing_router.post("/orders/{order_id}/fulfill", description="Mark an order as shipped on eBay")
+async def fulfill_order(
+    order_id: str,
+    body: FulfillOrderRequest,
+    user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    try:
+        result = await service_manager.execute_service(
+            "integrations.ebay.selling.fulfillment.ship",
+            user_id=user.unique_id,
+            app_code=body.app_code,
+            order_id=order_id,
+            line_item_ids=body.line_item_ids,
+            tracking_number=body.tracking_number,
+            carrier_code=body.carrier_code,
+        )
+        return ApiResponse(data=result, message="Order marked as shipped")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@ebay_listing_router.patch("/orders/{order_id}/status", description="Update local order lifecycle status")
+async def patch_order_status(
+    order_id: str,
+    body: UpdateOrderStatusRequest,
+    user: CurrentUserDep,
+    service_manager: ServiceManagerDep,
+):
+    if body.local_status not in {"in_transit", "complete"}:
+        raise HTTPException(
+            status_code=400,
+            detail="local_status must be one of ['complete', 'in_transit']",
+        )
+    try:
+        result = await service_manager.execute_service(
+            "integrations.ebay.selling.fulfillment.local_status",
+            order_id=order_id,
+            app_code=body.app_code,
+            local_status=body.local_status,
+        )
+        return ApiResponse(data=result, message="Order status updated")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+```
+
+- [ ] **Step 2: Verify the app starts**
+
+```bash
+cd src && python -c "from automana.api.routers.integrations.ebay.ebay_selling import ebay_listing_router; print('OK')"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+cd src && python -m pytest automana/tests/ -q --tb=short 2>&1 | tail -10
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/automana/api/routers/integrations/ebay/ebay_selling.py
+git commit -m "feat(ebay): add POST fulfill and PATCH status endpoints for sold orders"
+```
+
+---
+
+## Task 8: Frontend — soldOrders.ts types and helpers
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/soldOrders.ts`
+- Create: `src/frontend/src/features/ebay/__tests__/soldOrders.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/frontend/src/features/ebay/__tests__/soldOrders.test.ts
+import { describe, it, expect } from 'vitest'
+import { deriveDisplayStatus } from '../soldOrders'
+
+describe('deriveDisplayStatus', () => {
+  it('returns complete when eBay status is FULFILLED regardless of local', () => {
+    expect(deriveDisplayStatus('FULFILLED', 'in_transit')).toBe('complete')
+    expect(deriveDisplayStatus('FULFILLED', null)).toBe('complete')
+  })
+
+  it('returns in_transit when local_status is in_transit and eBay is not FULFILLED', () => {
+    expect(deriveDisplayStatus('NOT_STARTED', 'in_transit')).toBe('in_transit')
+    expect(deriveDisplayStatus('IN_PROGRESS', 'in_transit')).toBe('in_transit')
+  })
+
+  it('returns sold when eBay status is NOT_STARTED and no in_transit override', () => {
+    expect(deriveDisplayStatus('NOT_STARTED', null)).toBe('sold')
+    expect(deriveDisplayStatus('NOT_STARTED', 'sent')).toBe('sold')
+  })
+
+  it('returns sent when eBay status is IN_PROGRESS and not in_transit', () => {
+    expect(deriveDisplayStatus('IN_PROGRESS', null)).toBe('sent')
+    expect(deriveDisplayStatus('IN_PROGRESS', 'sent')).toBe('sent')
+  })
+
+  it('returns sold for unknown eBay status', () => {
+    expect(deriveDisplayStatus(null, null)).toBe('sold')
+    expect(deriveDisplayStatus(undefined, null)).toBe('sold')
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/soldOrders.test.ts 2>&1 | tail -10
+```
+
+Expected: `Error: Cannot find module '../soldOrders'`.
+
+- [ ] **Step 3: Create soldOrders.ts**
+
+```typescript
+// src/frontend/src/features/ebay/soldOrders.ts
+
+export type DisplayStatus = 'sold' | 'sent' | 'in_transit' | 'complete'
+
+export interface SoldOrderLineItem {
+  lineItemId: string | null
+  legacyItemId: string | null
+  title: string | null
+  quantity: number | null
+  lineItemFulfillmentStatus: string | null
+}
+
+export interface SoldOrder {
+  orderId: string
+  legacyOrderId: string | null
+  creationDate: string | null
+  orderFulfillmentStatus: string | null
+  orderPaymentStatus: string | null
+  buyerUsername: string | null
+  totalAmount: number | null
+  currency: string | null
+  lineItems: SoldOrderLineItem[]
+  local_status: string | null
+  displayStatus: DisplayStatus
+  appCode: string
+  appName: string
+}
+
+/**
+ * Derives the display lifecycle stage from eBay's fulfillment status and the
+ * AutoMana-local override. Priority:
+ * 1. eBay FULFILLED → complete (terminal, eBay always wins)
+ * 2. local_status = in_transit → in_transit
+ * 3. eBay IN_PROGRESS → sent
+ * 4. Everything else → sold
+ */
+export function deriveDisplayStatus(
+  ebayStatus: string | null | undefined,
+  localStatus: string | null | undefined,
+): DisplayStatus {
+  if (ebayStatus === 'FULFILLED') return 'complete'
+  if (localStatus === 'in_transit') return 'in_transit'
+  if (ebayStatus === 'IN_PROGRESS') return 'sent'
+  return 'sold'
+}
+
+export function mapRawToSoldOrder(
+  raw: Record<string, unknown>,
+  appCode: string,
+  appName: string,
+): SoldOrder {
+  const buyer = raw.buyer as Record<string, unknown> | null
+  const pricing = raw.pricingSummary as Record<string, unknown> | null
+  const total = pricing?.total as Record<string, unknown> | null
+  const lineItems = (raw.lineItems as Record<string, unknown>[] | null) ?? []
+  const ebayStatus = (raw.orderFulfillmentStatus as string | null) ?? null
+  const localStatus = (raw.local_status as string | null) ?? null
+
+  return {
+    orderId: (raw.orderId as string) ?? '',
+    legacyOrderId: (raw.legacyOrderId as string | null) ?? null,
+    creationDate: (raw.creationDate as string | null) ?? null,
+    orderFulfillmentStatus: ebayStatus,
+    orderPaymentStatus: (raw.orderPaymentStatus as string | null) ?? null,
+    buyerUsername: (buyer?.username as string | null) ?? null,
+    totalAmount: total?.value != null ? Number(total.value) : null,
+    currency: (total?.currency as string | null) ?? null,
+    lineItems: lineItems.map((li) => ({
+      lineItemId: (li.lineItemId as string | null) ?? null,
+      legacyItemId: (li.legacyItemId as string | null) ?? null,
+      title: (li.title as string | null) ?? null,
+      quantity: (li.quantity as number | null) ?? null,
+      lineItemFulfillmentStatus: (li.lineItemFulfillmentStatus as string | null) ?? null,
+    })),
+    local_status: localStatus,
+    displayStatus: deriveDisplayStatus(ebayStatus, localStatus),
+    appCode,
+    appName,
+  }
+}
+```
+
+- [ ] **Step 4: Run tests — expect green**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/soldOrders.test.ts
+```
+
+Expected: 5 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/soldOrders.ts \
+        src/frontend/src/features/ebay/__tests__/soldOrders.test.ts
+git commit -m "feat(ebay): add SoldOrder types, deriveDisplayStatus, and mapRawToSoldOrder"
+```
+
+---
+
+## Task 9: Frontend API — fetchSoldOrders and order action functions
+
+**Files:**
+- Modify: `src/frontend/src/features/ebay/api.ts`
+- Create: `src/frontend/src/features/ebay/__tests__/api.sold.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/frontend/src/features/ebay/__tests__/api.sold.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchSoldOrders, markOrderSent, markOrderSentWithTracking, updateOrderLocalStatus } from '../api'
+
+vi.mock('../../../lib/apiClient', () => ({
+  apiClient: vi.fn(),
+  ApiError: class ApiError extends Error {
+    constructor(msg: string, public status: number) { super(msg) }
+  },
+}))
+
+import { apiClient } from '../../../lib/apiClient'
+const mockApiClient = vi.mocked(apiClient)
+
+beforeEach(() => { mockApiClient.mockReset() })
+
+describe('fetchSoldOrders', () => {
+  it('maps raw orders to SoldOrder array', async () => {
+    mockApiClient.mockResolvedValue({
+      data: [
+        {
+          orderId: 'ord-1',
+          orderFulfillmentStatus: 'NOT_STARTED',
+          orderPaymentStatus: 'FULLY_PAID',
+          creationDate: '2026-05-09T00:00:00Z',
+          buyer: { username: 'buyer_xyz', taxAddress: null, buyerRegistrationAddress: null },
+          pricingSummary: { total: { value: '42.00', currency: 'AUD' } },
+          lineItems: [],
+          local_status: null,
+        },
+      ],
+      pagination: { has_next: false },
+    })
+
+    const result = await fetchSoldOrders('myapp', 25, 0)
+    expect(result.orders).toHaveLength(1)
+    expect(result.orders[0].orderId).toBe('ord-1')
+    expect(result.orders[0].displayStatus).toBe('sold')
+    expect(result.orders[0].buyerUsername).toBe('buyer_xyz')
+    expect(result.orders[0].totalAmount).toBe(42)
+    expect(result.hasMore).toBe(false)
+  })
+})
+
+describe('markOrderSent', () => {
+  it('posts to the fulfill endpoint without tracking', async () => {
+    mockApiClient.mockResolvedValue({ data: { success: true } })
+    await markOrderSent('myapp', 'ord-1', ['line-1'])
+    expect(mockApiClient).toHaveBeenCalledWith(
+      '/integrations/ebay/listing/orders/ord-1/fulfill',
+      expect.objectContaining({ method: 'POST' }),
+    )
+    const body = JSON.parse(mockApiClient.mock.calls[0][1].body)
+    expect(body.app_code).toBe('myapp')
+    expect(body.line_item_ids).toEqual(['line-1'])
+    expect(body.tracking_number).toBeUndefined()
+  })
+})
+
+describe('markOrderSentWithTracking', () => {
+  it('posts with tracking fields', async () => {
+    mockApiClient.mockResolvedValue({ data: { success: true } })
+    await markOrderSentWithTracking('myapp', 'ord-1', ['line-1'], 'AusPost', 'TRK999')
+    const body = JSON.parse(mockApiClient.mock.calls[0][1].body)
+    expect(body.tracking_number).toBe('TRK999')
+    expect(body.carrier_code).toBe('AusPost')
+  })
+})
+
+describe('updateOrderLocalStatus', () => {
+  it('patches the status endpoint', async () => {
+    mockApiClient.mockResolvedValue({ data: { local_status: 'in_transit' } })
+    await updateOrderLocalStatus('myapp', 'ord-1', 'in_transit')
+    expect(mockApiClient).toHaveBeenCalledWith(
+      '/integrations/ebay/listing/orders/ord-1/status',
+      expect.objectContaining({ method: 'PATCH' }),
+    )
+    const body = JSON.parse(mockApiClient.mock.calls[0][1].body)
+    expect(body.local_status).toBe('in_transit')
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/api.sold.test.ts 2>&1 | tail -10
+```
+
+Expected: import errors for the new functions.
+
+- [ ] **Step 3: Add the four new functions to api.ts**
+
+Append to the bottom of `src/frontend/src/features/ebay/api.ts`:
+
+```typescript
+// ── Sold orders ────────────────────────────────────────────────────────────
+
+import { mapRawToSoldOrder, type SoldOrder } from './soldOrders'
+
+export async function fetchSoldOrders(
+  appCode: string,
+  limit = 25,
+  offset = 0,
+): Promise<{ orders: SoldOrder[]; hasMore: boolean }> {
+  const raw = await apiClient<unknown>(
+    `/integrations/ebay/listing/history?app_code=${encodeURIComponent(appCode)}&limit=${limit}&offset=${offset}`
+  )
+  const paged = raw as { data?: unknown; pagination?: { has_next?: boolean } }
+  const items = Array.isArray(paged.data) ? (paged.data as Record<string, unknown>[]) : []
+  const hasMore = paged.pagination?.has_next ?? false
+  return {
+    orders: items.map((item) => mapRawToSoldOrder(item, appCode, '')),
+    hasMore,
+  }
+}
+
+export async function markOrderSent(
+  appCode: string,
+  orderId: string,
+  lineItemIds: string[],
+): Promise<void> {
+  await apiClient<unknown>(
+    `/integrations/ebay/listing/orders/${encodeURIComponent(orderId)}/fulfill`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ app_code: appCode, line_item_ids: lineItemIds }),
+    },
+  )
+}
+
+export async function markOrderSentWithTracking(
+  appCode: string,
+  orderId: string,
+  lineItemIds: string[],
+  carrierCode: string,
+  trackingNumber: string,
+): Promise<void> {
+  await apiClient<unknown>(
+    `/integrations/ebay/listing/orders/${encodeURIComponent(orderId)}/fulfill`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        app_code: appCode,
+        line_item_ids: lineItemIds,
+        carrier_code: carrierCode,
+        tracking_number: trackingNumber,
+      }),
+    },
+  )
+}
+
+export async function updateOrderLocalStatus(
+  appCode: string,
+  orderId: string,
+  localStatus: 'in_transit' | 'complete',
+): Promise<void> {
+  await apiClient<unknown>(
+    `/integrations/ebay/listing/orders/${encodeURIComponent(orderId)}/status`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ app_code: appCode, local_status: localStatus }),
+    },
+  )
+}
+```
+
+- [ ] **Step 4: Run tests — expect green**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/__tests__/api.sold.test.ts
+```
+
+Expected: 4 PASSED.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/api.ts \
+        src/frontend/src/features/ebay/__tests__/api.sold.test.ts
+git commit -m "feat(ebay): add fetchSoldOrders, markOrderSent, markOrderSentWithTracking, updateOrderLocalStatus to api.ts"
+```
+
+---
+
+## Task 10: LifecycleBadge component
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/components/LifecycleBadge.tsx`
+- Create: `src/frontend/src/features/ebay/components/LifecycleBadge.module.css`
+- Create: `src/frontend/src/features/ebay/components/__tests__/LifecycleBadge.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/frontend/src/features/ebay/components/__tests__/LifecycleBadge.test.tsx
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { LifecycleBadge } from '../LifecycleBadge'
+
+describe('LifecycleBadge', () => {
+  it('renders Sold for sold status', () => {
+    render(<LifecycleBadge status="sold" />)
+    expect(screen.getByText(/Sold/i)).toBeTruthy()
+  })
+
+  it('renders Sent for sent status', () => {
+    render(<LifecycleBadge status="sent" />)
+    expect(screen.getByText(/Sent/i)).toBeTruthy()
+  })
+
+  it('renders Transit for in_transit status', () => {
+    render(<LifecycleBadge status="in_transit" />)
+    expect(screen.getByText(/Transit/i)).toBeTruthy()
+  })
+
+  it('renders Done for complete status', () => {
+    render(<LifecycleBadge status="complete" />)
+    expect(screen.getByText(/Done/i)).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/LifecycleBadge.test.tsx 2>&1 | tail -5
+```
+
+Expected: `Cannot find module '../LifecycleBadge'`.
+
+- [ ] **Step 3: Create LifecycleBadge.tsx**
+
+```tsx
+// src/frontend/src/features/ebay/components/LifecycleBadge.tsx
+import type { DisplayStatus } from '../soldOrders'
+import styles from './LifecycleBadge.module.css'
+
+interface LifecycleBadgeProps {
+  status: DisplayStatus
+}
+
+const CONFIG: Record<DisplayStatus, { icon: string; label: string; mod: string }> = {
+  sold:       { icon: '💰', label: 'Sold',    mod: 'sold' },
+  sent:       { icon: '📦', label: 'Sent',    mod: 'sent' },
+  in_transit: { icon: '🚚', label: 'Transit', mod: 'transit' },
+  complete:   { icon: '✅', label: 'Done',    mod: 'complete' },
+}
+
+export function LifecycleBadge({ status }: LifecycleBadgeProps) {
+  const { icon, label, mod } = CONFIG[status]
+  return (
+    <span className={`${styles.badge} ${styles[mod]}`}>
+      {icon} {label}
+    </span>
+  )
+}
+```
+
+- [ ] **Step 4: Create LifecycleBadge.module.css**
+
+```css
+/* src/frontend/src/features/ebay/components/LifecycleBadge.module.css */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 12px;
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.sold     { color: var(--hd-red,    #e05252); background: color-mix(in srgb, var(--hd-red,    #e05252) 10%, transparent); border-color: color-mix(in srgb, var(--hd-red,    #e05252) 30%, transparent); }
+.sent     { color: var(--hd-accent, #7c6af7); background: color-mix(in srgb, var(--hd-accent, #7c6af7) 10%, transparent); border-color: color-mix(in srgb, var(--hd-accent, #7c6af7) 30%, transparent); }
+.transit  { color: var(--hd-amber,  #f7a535); background: color-mix(in srgb, var(--hd-amber,  #f7a535) 10%, transparent); border-color: color-mix(in srgb, var(--hd-amber,  #f7a535) 30%, transparent); }
+.complete { color: var(--hd-green,  #3fc870); background: color-mix(in srgb, var(--hd-green,  #3fc870) 10%, transparent); border-color: color-mix(in srgb, var(--hd-green,  #3fc870) 30%, transparent); }
+```
+
+- [ ] **Step 5: Run tests — expect green**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/LifecycleBadge.test.tsx
+```
+
+Expected: 4 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/LifecycleBadge.tsx \
+        src/frontend/src/features/ebay/components/LifecycleBadge.module.css \
+        src/frontend/src/features/ebay/components/__tests__/LifecycleBadge.test.tsx
+git commit -m "feat(ebay): add LifecycleBadge component"
+```
+
+---
+
+## Task 11: SoldOrdersTable component
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/components/SoldOrdersTable.tsx`
+- Create: `src/frontend/src/features/ebay/components/SoldOrdersTable.module.css`
+- Create: `src/frontend/src/features/ebay/components/__tests__/SoldOrdersTable.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/frontend/src/features/ebay/components/__tests__/SoldOrdersTable.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { SoldOrdersTable } from '../SoldOrdersTable'
+import type { SoldOrder } from '../../soldOrders'
+
+function makeOrder(overrides: Partial<SoldOrder> = {}): SoldOrder {
+  return {
+    orderId: 'ord-1',
+    legacyOrderId: null,
+    creationDate: '2026-05-09T00:00:00Z',
+    orderFulfillmentStatus: 'NOT_STARTED',
+    orderPaymentStatus: 'FULLY_PAID',
+    buyerUsername: 'buyer_xyz',
+    totalAmount: 42,
+    currency: 'AUD',
+    lineItems: [],
+    local_status: null,
+    displayStatus: 'sold',
+    appCode: 'myapp',
+    appName: 'My App',
+    ...overrides,
+  }
+}
+
+describe('SoldOrdersTable', () => {
+  it('renders column headers', () => {
+    render(<SoldOrdersTable orders={[]} isLoading={false} selectedId={undefined} onRowClick={vi.fn()} />)
+    expect(screen.getByText('CARD')).toBeTruthy()
+    expect(screen.getByText('PRICE')).toBeTruthy()
+    expect(screen.getByText('BUYER')).toBeTruthy()
+    expect(screen.getByText('STATUS')).toBeTruthy()
+  })
+
+  it('shows skeleton rows when loading', () => {
+    const { container } = render(
+      <SoldOrdersTable orders={[]} isLoading={true} selectedId={undefined} onRowClick={vi.fn()} />
+    )
+    expect(container.querySelectorAll('[data-testid="skeleton-row"]').length).toBeGreaterThan(0)
+  })
+
+  it('renders order row with buyer name', () => {
+    render(
+      <SoldOrdersTable orders={[makeOrder()]} isLoading={false} selectedId={undefined} onRowClick={vi.fn()} />
+    )
+    expect(screen.getByText('buyer_xyz')).toBeTruthy()
+  })
+
+  it('calls onRowClick with orderId when row clicked', () => {
+    const onClick = vi.fn()
+    render(
+      <SoldOrdersTable orders={[makeOrder()]} isLoading={false} selectedId={undefined} onRowClick={onClick} />
+    )
+    fireEvent.click(screen.getByText('buyer_xyz').closest('tr')!)
+    expect(onClick).toHaveBeenCalledWith('ord-1')
+  })
+
+  it('highlights the selected row', () => {
+    const { container } = render(
+      <SoldOrdersTable orders={[makeOrder()]} isLoading={false} selectedId="ord-1" onRowClick={vi.fn()} />
+    )
+    const row = container.querySelector('[data-selected="true"]')
+    expect(row).toBeTruthy()
+  })
+
+  it('shows message icon for non-complete orders', () => {
+    const { container } = render(
+      <SoldOrdersTable orders={[makeOrder({ displayStatus: 'sold' })]} isLoading={false} selectedId={undefined} onRowClick={vi.fn()} />
+    )
+    expect(container.querySelector('[data-testid="msg-icon"]')).toBeTruthy()
+  })
+
+  it('hides message icon for complete orders', () => {
+    const { container } = render(
+      <SoldOrdersTable orders={[makeOrder({ displayStatus: 'complete' })]} isLoading={false} selectedId={undefined} onRowClick={vi.fn()} />
+    )
+    expect(container.querySelector('[data-testid="msg-icon"]')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/SoldOrdersTable.test.tsx 2>&1 | tail -5
+```
+
+Expected: `Cannot find module '../SoldOrdersTable'`.
+
+- [ ] **Step 3: Create SoldOrdersTable.tsx**
+
+```tsx
+// src/frontend/src/features/ebay/components/SoldOrdersTable.tsx
+import { LifecycleBadge } from './LifecycleBadge'
+import type { SoldOrder } from '../soldOrders'
+import styles from './SoldOrdersTable.module.css'
+
+interface SoldOrdersTableProps {
+  orders: SoldOrder[]
+  isLoading: boolean
+  selectedId: string | undefined
+  onRowClick: (orderId: string) => void
+}
+
+function MsgIcon({ orderId }: { orderId: string }) {
+  return (
+    <a
+      data-testid="msg-icon"
+      href={`https://www.ebay.com.au/msg/inbox`}
+      target="_blank"
+      rel="noreferrer"
+      className={styles.msgIcon}
+      title="View messages on eBay"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden>
+        <path
+          d="M2 3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7a1 1 0 0 1-1 1H9l-3 2v-2H3a1 1 0 0 1-1-1V3Z"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          fill="none"
+        />
+      </svg>
+    </a>
+  )
+}
+
+function SkeletonRow() {
+  return (
+    <tr data-testid="skeleton-row" className={styles.skeletonRow}>
+      <td><div className={styles.skeletonCell} /></td>
+      <td><div className={styles.skeletonCell} style={{ width: 50 }} /></td>
+      <td><div className={styles.skeletonCell} style={{ width: 70 }} /></td>
+      <td />
+      <td><div className={styles.skeletonCell} style={{ width: 80 }} /></td>
+      <td><div className={styles.skeletonCell} style={{ width: 55 }} /></td>
+    </tr>
+  )
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  const diff = Math.floor((Date.now() - d.getTime()) / 3_600_000)
+  if (diff < 1) return 'Just now'
+  if (diff < 24) return `${diff}h ago`
+  const days = Math.floor(diff / 24)
+  if (days === 1) return 'Yesterday'
+  if (days < 7) return `${days} days ago`
+  return d.toLocaleDateString()
+}
+
+export function SoldOrdersTable({ orders, isLoading, selectedId, onRowClick }: SoldOrdersTableProps) {
+  return (
+    <table className={styles.table}>
+      <thead>
+        <tr>
+          <th>CARD</th>
+          <th>PRICE</th>
+          <th>BUYER</th>
+          <th>MSG</th>
+          <th>STATUS</th>
+          <th>SOLD</th>
+        </tr>
+      </thead>
+      <tbody>
+        {isLoading
+          ? Array.from({ length: 5 }, (_, i) => <SkeletonRow key={i} />)
+          : orders.map((order) => (
+              <tr
+                key={order.orderId}
+                className={[styles.row, order.displayStatus === 'complete' ? styles.rowFaded : ''].filter(Boolean).join(' ')}
+                data-selected={order.orderId === selectedId ? 'true' : undefined}
+                onClick={() => onRowClick(order.orderId)}
+              >
+                <td className={styles.cardCell}>
+                  <div className={styles.cardTitle}>
+                    {order.lineItems[0]?.title ?? 'Order'}
+                  </div>
+                  <div className={styles.cardMeta}>#{order.legacyOrderId ?? order.orderId}</div>
+                </td>
+                <td className={styles.priceCell}>
+                  {order.totalAmount != null
+                    ? `$${order.totalAmount.toFixed(2)}`
+                    : '—'}
+                </td>
+                <td className={styles.buyerCell}>{order.buyerUsername ?? '—'}</td>
+                <td className={styles.msgCell}>
+                  {order.displayStatus !== 'complete' && <MsgIcon orderId={order.orderId} />}
+                </td>
+                <td>
+                  <LifecycleBadge status={order.displayStatus} />
+                </td>
+                <td className={styles.dateCell}>{formatDate(order.creationDate)}</td>
+              </tr>
+            ))}
+      </tbody>
+    </table>
+  )
+}
+```
+
+- [ ] **Step 4: Create SoldOrdersTable.module.css**
+
+```css
+/* src/frontend/src/features/ebay/components/SoldOrdersTable.module.css */
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.table th {
+  padding: 8px 12px;
+  text-align: left;
+  font-size: 11px;
+  color: var(--hd-sub, #555);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--hd-border, #1a1a1f);
+  background: var(--hd-surface-alt, #090909);
+}
+
+.row {
+  cursor: pointer;
+  border-bottom: 1px solid var(--hd-border-subtle, #13131a);
+  transition: background 120ms;
+}
+.row:hover { background: var(--hd-hover, #111118); }
+.row[data-selected="true"] {
+  background: color-mix(in srgb, var(--hd-accent, #7c6af7) 8%, transparent);
+  border-left: 2px solid var(--hd-accent, #7c6af7);
+}
+
+.rowFaded { opacity: 0.55; }
+.rowFaded:hover { opacity: 1; }
+
+.table td { padding: 11px 12px; vertical-align: middle; }
+
+.cardTitle { color: var(--hd-text, #e8e8e8); font-weight: 500; }
+.cardMeta  { font-size: 11px; color: var(--hd-sub, #555); margin-top: 2px; }
+
+.priceCell { color: var(--hd-text, #e8e8e8); font-variant-numeric: tabular-nums; }
+.buyerCell { font-size: 12px; color: var(--hd-sub2, #777); }
+.msgCell   { text-align: center; width: 36px; }
+.dateCell  { font-size: 11px; color: var(--hd-sub, #555); white-space: nowrap; }
+
+.msgIcon {
+  color: var(--hd-sub, #555);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  transition: color 120ms, background 120ms;
+}
+.msgIcon:hover {
+  color: var(--hd-accent, #7c6af7);
+  background: color-mix(in srgb, var(--hd-accent, #7c6af7) 12%, transparent);
+}
+
+.skeletonRow td { padding: 12px 12px; }
+.skeletonCell {
+  height: 12px;
+  width: 100%;
+  border-radius: 4px;
+  background: var(--hd-skeleton, #1a1a1f);
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0%, 100% { opacity: 0.4; }
+  50%       { opacity: 0.8; }
+}
+```
+
+- [ ] **Step 5: Run tests — expect green**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/SoldOrdersTable.test.tsx
+```
+
+Expected: 7 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/SoldOrdersTable.tsx \
+        src/frontend/src/features/ebay/components/SoldOrdersTable.module.css \
+        src/frontend/src/features/ebay/components/__tests__/SoldOrdersTable.test.tsx
+git commit -m "feat(ebay): add SoldOrdersTable component"
+```
+
+---
+
+## Task 12: SoldOrderDetailPanel component
+
+**Files:**
+- Create: `src/frontend/src/features/ebay/components/SoldOrderDetailPanel.tsx`
+- Create: `src/frontend/src/features/ebay/components/SoldOrderDetailPanel.module.css`
+- Create: `src/frontend/src/features/ebay/components/__tests__/SoldOrderDetailPanel.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/frontend/src/features/ebay/components/__tests__/SoldOrderDetailPanel.test.tsx
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SoldOrderDetailPanel } from '../SoldOrderDetailPanel'
+import type { SoldOrder } from '../../soldOrders'
+
+vi.mock('../../api', () => ({
+  markOrderSent: vi.fn().mockResolvedValue(undefined),
+  markOrderSentWithTracking: vi.fn().mockResolvedValue(undefined),
+  updateOrderLocalStatus: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { markOrderSent, updateOrderLocalStatus } from '../../api'
+
+function makeOrder(overrides: Partial<SoldOrder> = {}): SoldOrder {
+  return {
+    orderId: 'ord-1',
+    legacyOrderId: '12-34567',
+    creationDate: '2026-05-09T00:00:00Z',
+    orderFulfillmentStatus: 'NOT_STARTED',
+    orderPaymentStatus: 'FULLY_PAID',
+    buyerUsername: 'buyer_xyz',
+    totalAmount: 42,
+    currency: 'AUD',
+    lineItems: [{ lineItemId: 'li-1', legacyItemId: null, title: 'Sheoldred', quantity: 1, lineItemFulfillmentStatus: null }],
+    local_status: null,
+    displayStatus: 'sold',
+    appCode: 'myapp',
+    appName: 'My App',
+    ...overrides,
+  }
+}
+
+describe('SoldOrderDetailPanel', () => {
+  beforeEach(() => {
+    vi.mocked(markOrderSent).mockClear()
+    vi.mocked(updateOrderLocalStatus).mockClear()
+  })
+
+  it('renders order info', () => {
+    render(<SoldOrderDetailPanel order={makeOrder()} onClose={vi.fn()} onStatusChange={vi.fn()} />)
+    expect(screen.getByText('buyer_xyz')).toBeTruthy()
+    expect(screen.getByText('$42.00 AUD')).toBeTruthy()
+  })
+
+  it('shows Mark as sent and Add tracking buttons for sold stage', () => {
+    render(<SoldOrderDetailPanel order={makeOrder()} onClose={vi.fn()} onStatusChange={vi.fn()} />)
+    expect(screen.getByText(/Mark as sent/i)).toBeTruthy()
+    expect(screen.getByText(/Add tracking/i)).toBeTruthy()
+  })
+
+  it('calls markOrderSent and onStatusChange on mark sent click', async () => {
+    const onStatusChange = vi.fn()
+    render(<SoldOrderDetailPanel order={makeOrder()} onClose={vi.fn()} onStatusChange={onStatusChange} />)
+    fireEvent.click(screen.getByText(/Mark as sent/i))
+    await waitFor(() => expect(markOrderSent).toHaveBeenCalledWith('myapp', 'ord-1', ['li-1']))
+    expect(onStatusChange).toHaveBeenCalledWith('ord-1', 'sent')
+  })
+
+  it('shows Mark in transit button for sent stage', () => {
+    render(<SoldOrderDetailPanel order={makeOrder({ displayStatus: 'sent' })} onClose={vi.fn()} onStatusChange={vi.fn()} />)
+    expect(screen.getByText(/Mark in transit/i)).toBeTruthy()
+  })
+
+  it('shows Mark complete button for in_transit stage', () => {
+    render(<SoldOrderDetailPanel order={makeOrder({ displayStatus: 'in_transit' })} onClose={vi.fn()} onStatusChange={vi.fn()} />)
+    expect(screen.getByText(/Mark complete/i)).toBeTruthy()
+  })
+
+  it('shows no action buttons for complete stage', () => {
+    render(<SoldOrderDetailPanel order={makeOrder({ displayStatus: 'complete' })} onClose={vi.fn()} onStatusChange={vi.fn()} />)
+    expect(screen.queryByText(/Mark/i)).toBeNull()
+  })
+
+  it('reveals tracking form when Add tracking clicked', () => {
+    render(<SoldOrderDetailPanel order={makeOrder()} onClose={vi.fn()} onStatusChange={vi.fn()} />)
+    fireEvent.click(screen.getByText(/Add tracking/i))
+    expect(screen.getByPlaceholderText(/Tracking number/i)).toBeTruthy()
+  })
+
+  it('calls onClose when close button clicked', () => {
+    const onClose = vi.fn()
+    render(<SoldOrderDetailPanel order={makeOrder()} onClose={onClose} onStatusChange={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText('Close panel'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/SoldOrderDetailPanel.test.tsx 2>&1 | tail -5
+```
+
+Expected: `Cannot find module '../SoldOrderDetailPanel'`.
+
+- [ ] **Step 3: Create SoldOrderDetailPanel.tsx**
+
+```tsx
+// src/frontend/src/features/ebay/components/SoldOrderDetailPanel.tsx
+import { useState } from 'react'
+import type { SoldOrder, DisplayStatus } from '../soldOrders'
+import { markOrderSent, markOrderSentWithTracking, updateOrderLocalStatus } from '../api'
+import { LifecycleBadge } from './LifecycleBadge'
+import styles from './SoldOrderDetailPanel.module.css'
+
+const STAGES: DisplayStatus[] = ['sold', 'sent', 'in_transit', 'complete']
+const STAGE_ICONS: Record<DisplayStatus, string> = {
+  sold: '💰', sent: '📦', in_transit: '🚚', complete: '✅',
+}
+const STAGE_LABELS: Record<DisplayStatus, string> = {
+  sold: 'Sold', sent: 'Sent', in_transit: 'Transit', complete: 'Done',
+}
+
+const COMMON_CARRIERS = ['AusPost', 'DHL', 'FedEx', 'UPS', 'TNT', 'StarTrack', 'CouriersPlease']
+
+interface Props {
+  order: SoldOrder
+  onClose: () => void
+  onStatusChange: (orderId: string, newStatus: DisplayStatus) => void
+}
+
+export function SoldOrderDetailPanel({ order, onClose, onStatusChange }: Props) {
+  const [showTrackingForm, setShowTrackingForm] = useState(false)
+  const [carrier, setCarrier] = useState(COMMON_CARRIERS[0])
+  const [trackingNum, setTrackingNum] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const lineItemIds = order.lineItems.map((li) => li.lineItemId).filter(Boolean) as string[]
+
+  async function handleMarkSent() {
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await markOrderSent(order.appCode, order.orderId, lineItemIds)
+      onStatusChange(order.orderId, 'sent')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to mark as sent')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleMarkSentWithTracking(e: React.FormEvent) {
+    e.preventDefault()
+    if (!trackingNum.trim()) return
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await markOrderSentWithTracking(order.appCode, order.orderId, lineItemIds, carrier, trackingNum.trim())
+      onStatusChange(order.orderId, 'sent')
+      setShowTrackingForm(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to mark as sent')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleLocalStatus(newStatus: 'in_transit' | 'complete') {
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await updateOrderLocalStatus(order.appCode, order.orderId, newStatus)
+      onStatusChange(order.orderId, newStatus)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update status')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const currentIdx = STAGES.indexOf(order.displayStatus)
+  const cardTitle = order.lineItems[0]?.title ?? 'Order'
+
+  return (
+    <aside className={styles.panel}>
+      {/* Header */}
+      <div className={styles.header}>
+        <div>
+          <div className={styles.headerTitle}>{cardTitle}</div>
+          <div className={styles.headerMeta}>#{order.legacyOrderId ?? order.orderId}</div>
+        </div>
+        <button className={styles.closeBtn} aria-label="Close panel" onClick={onClose}>✕</button>
+      </div>
+
+      {/* Lifecycle strip */}
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Lifecycle</div>
+        <div className={styles.strip}>
+          {STAGES.map((stage, i) => (
+            <div key={stage} className={styles.stripItem}>
+              <div className={[styles.stripDot, i === currentIdx ? styles.stripDotActive : i < currentIdx ? styles.stripDotDone : styles.stripDotFuture].join(' ')}>
+                {STAGE_ICONS[stage]}
+              </div>
+              <div className={[styles.stripLabel, i === currentIdx ? styles.stripLabelActive : ''].join(' ')}>
+                {STAGE_LABELS[stage]}
+              </div>
+              {i < STAGES.length - 1 && (
+                <div className={[styles.stripLine, i < currentIdx ? styles.stripLineDone : ''].join(' ')} />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Order info */}
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Order</div>
+        <div className={styles.infoRow}>
+          <span className={styles.infoKey}>Sale price</span>
+          <span className={styles.infoVal}>
+            {order.totalAmount != null ? `$${order.totalAmount.toFixed(2)} ${order.currency ?? ''}` : '—'}
+          </span>
+        </div>
+        <div className={styles.infoRow}>
+          <span className={styles.infoKey}>Buyer</span>
+          <span className={styles.infoValAccent}>{order.buyerUsername ?? '—'}</span>
+        </div>
+        <div className={styles.infoRow}>
+          <span className={styles.infoKey}>Sold</span>
+          <span className={styles.infoVal}>
+            {order.creationDate ? new Date(order.creationDate).toLocaleDateString() : '—'}
+          </span>
+        </div>
+        <div className={styles.infoRow}>
+          <span className={styles.infoKey}>Order ID</span>
+          <span className={styles.infoValMono}>{order.orderId}</span>
+        </div>
+      </div>
+
+      {/* Message banner */}
+      <div className={styles.messageBanner}>
+        <span className={styles.messageBannerIcon}>💬</span>
+        <div className={styles.messageBannerBody}>
+          <div className={styles.messageBannerTitle}>Messages from buyer</div>
+        </div>
+        <a
+          className={styles.messageBannerLink}
+          href="https://www.ebay.com.au/msg/inbox"
+          target="_blank"
+          rel="noreferrer"
+        >
+          View ↗
+        </a>
+      </div>
+
+      {/* Error */}
+      {error && <div className={styles.errorMsg}>{error}</div>}
+
+      {/* Actions */}
+      <div className={styles.actions}>
+        {order.displayStatus === 'sold' && !showTrackingForm && (
+          <>
+            <button
+              className={styles.btnPrimary}
+              disabled={isSubmitting}
+              onClick={handleMarkSent}
+            >
+              📦 Mark as sent
+            </button>
+            <button
+              className={styles.btnSecondary}
+              disabled={isSubmitting}
+              onClick={() => setShowTrackingForm(true)}
+            >
+              🔗 Add tracking number
+            </button>
+          </>
+        )}
+
+        {order.displayStatus === 'sold' && showTrackingForm && (
+          <form onSubmit={handleMarkSentWithTracking} className={styles.trackingForm}>
+            <select
+              className={styles.trackingSelect}
+              value={carrier}
+              onChange={(e) => setCarrier(e.target.value)}
+            >
+              {COMMON_CARRIERS.map((c) => <option key={c} value={c}>{c}</option>)}
+            </select>
+            <input
+              className={styles.trackingInput}
+              placeholder="Tracking number"
+              value={trackingNum}
+              onChange={(e) => setTrackingNum(e.target.value)}
+              required
+            />
+            <button className={styles.btnPrimary} type="submit" disabled={isSubmitting}>
+              📦 Confirm & send
+            </button>
+            <button
+              className={styles.btnGhost}
+              type="button"
+              onClick={() => setShowTrackingForm(false)}
+            >
+              Cancel
+            </button>
+          </form>
+        )}
+
+        {order.displayStatus === 'sent' && (
+          <button
+            className={styles.btnSecondary}
+            disabled={isSubmitting}
+            onClick={() => handleLocalStatus('in_transit')}
+          >
+            🚚 Mark in transit
+          </button>
+        )}
+
+        {order.displayStatus === 'in_transit' && (
+          <button
+            className={styles.btnSecondary}
+            disabled={isSubmitting}
+            onClick={() => handleLocalStatus('complete')}
+          >
+            ✅ Mark complete
+          </button>
+        )}
+
+        <a
+          className={styles.btnGhost}
+          href={`https://www.ebay.com.au/vod/FetchOrderDetails?orderId=${order.legacyOrderId ?? order.orderId}`}
+          target="_blank"
+          rel="noreferrer"
+        >
+          View order on eBay ↗
+        </a>
+      </div>
+    </aside>
+  )
+}
+```
+
+- [ ] **Step 4: Create SoldOrderDetailPanel.module.css**
+
+```css
+/* src/frontend/src/features/ebay/components/SoldOrderDetailPanel.module.css */
+.panel {
+  width: 300px;
+  min-width: 280px;
+  background: var(--hd-surface-panel, #0a0a10);
+  border-left: 1px solid var(--hd-border, #1a1a1f);
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  height: 100%;
+}
+
+.header {
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--hd-border, #1a1a1f);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+.headerTitle { font-size: 13px; color: var(--hd-text, #e8e8e8); font-weight: 600; line-height: 1.3; }
+.headerMeta  { font-size: 11px; color: var(--hd-sub, #555); margin-top: 3px; }
+.closeBtn    { background: none; border: none; color: var(--hd-sub, #888); cursor: pointer; padding: 2px 4px; font-size: 14px; }
+.closeBtn:hover { color: var(--hd-text, #e8e8e8); }
+
+.section { padding: 14px 16px; border-bottom: 1px solid var(--hd-border, #1a1a1f); }
+.sectionLabel { font-size: 10px; color: var(--hd-sub, #555); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 10px; }
+
+/* Lifecycle strip */
+.strip { display: flex; align-items: flex-start; position: relative; }
+.stripItem { display: flex; flex-direction: column; align-items: center; gap: 3px; position: relative; flex: 1; }
+.stripDot {
+  width: 28px; height: 28px; border-radius: 50%; display: flex; align-items: center; justify-content: center;
+  font-size: 13px; border: 2px solid var(--hd-border-strong, #2a2a32);
+  background: var(--hd-surface-alt, #1a1a1f);
+}
+.stripDotActive { border-color: var(--hd-accent, #7c6af7); background: color-mix(in srgb, var(--hd-accent, #7c6af7) 15%, transparent); }
+.stripDotDone   { border-color: var(--hd-border-strong, #2a2a32); opacity: 0.6; }
+.stripDotFuture { opacity: 0.3; }
+.stripLabel       { font-size: 9px; color: var(--hd-sub, #555); font-weight: 600; text-align: center; }
+.stripLabelActive { color: var(--hd-accent, #7c6af7); }
+.stripLine {
+  position: absolute; top: 14px; left: 50%; width: 100%;
+  height: 2px; background: var(--hd-border, #1e1e24);
+}
+.stripLineDone { background: color-mix(in srgb, var(--hd-accent, #7c6af7) 40%, transparent); }
+
+/* Order info */
+.infoRow        { display: flex; justify-content: space-between; margin-bottom: 6px; }
+.infoKey        { font-size: 12px; color: var(--hd-sub, #555); }
+.infoVal        { font-size: 12px; color: var(--hd-text, #e8e8e8); }
+.infoValAccent  { font-size: 12px; color: var(--hd-accent, #7c6af7); }
+.infoValMono    { font-size: 11px; color: var(--hd-sub, #555); font-family: monospace; }
+
+/* Message banner */
+.messageBanner {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--hd-border, #1a1a1f);
+  background: color-mix(in srgb, var(--hd-accent, #7c6af7) 4%, transparent);
+}
+.messageBannerIcon { font-size: 16px; }
+.messageBannerBody { flex: 1; }
+.messageBannerTitle { font-size: 12px; color: var(--hd-text, #e8e8e8); font-weight: 500; }
+.messageBannerLink  { font-size: 11px; color: var(--hd-accent, #7c6af7); text-decoration: none; white-space: nowrap; }
+.messageBannerLink:hover { text-decoration: underline; }
+
+/* Error */
+.errorMsg { margin: 8px 16px; font-size: 12px; color: var(--hd-red, #e05252); background: color-mix(in srgb, var(--hd-red, #e05252) 8%, transparent); padding: 8px 12px; border-radius: 6px; }
+
+/* Actions */
+.actions { padding: 14px 16px; display: flex; flex-direction: column; gap: 8px; }
+
+.btnPrimary {
+  width: 100%; background: var(--hd-accent, #7c6af7); color: #fff; border: none;
+  border-radius: 7px; padding: 9px 14px; font-size: 13px; font-weight: 600; cursor: pointer;
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+}
+.btnPrimary:hover:not(:disabled) { opacity: 0.9; }
+.btnPrimary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btnSecondary {
+  width: 100%; background: var(--hd-surface-alt, #1a1a1f);
+  color: var(--hd-text-sub, #bbb);
+  border: 1px solid var(--hd-border-strong, #2a2a32);
+  border-radius: 7px; padding: 8px 14px; font-size: 12px; cursor: pointer;
+  display: flex; align-items: center; justify-content: center; gap: 6px;
+}
+.btnSecondary:hover:not(:disabled) { border-color: var(--hd-accent, #7c6af7); color: var(--hd-text, #e8e8e8); }
+.btnSecondary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btnGhost {
+  width: 100%; background: transparent; color: var(--hd-sub, #555); border: none;
+  border-radius: 7px; padding: 6px 14px; font-size: 11px; cursor: pointer;
+  text-align: center; text-decoration: none; display: block;
+}
+.btnGhost:hover { color: var(--hd-text, #e8e8e8); }
+
+.trackingForm { display: flex; flex-direction: column; gap: 8px; }
+.trackingSelect, .trackingInput {
+  width: 100%; background: var(--hd-surface-alt, #1a1a1f);
+  border: 1px solid var(--hd-border-strong, #2a2a32);
+  border-radius: 6px; padding: 7px 10px; font-size: 12px;
+  color: var(--hd-text, #e8e8e8); outline: none;
+}
+.trackingSelect:focus, .trackingInput:focus { border-color: var(--hd-accent, #7c6af7); }
+```
+
+- [ ] **Step 5: Run tests — expect green**
+
+```bash
+cd src/frontend && npx vitest run src/features/ebay/components/__tests__/SoldOrderDetailPanel.test.tsx
+```
+
+Expected: 8 PASSED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/ebay/components/SoldOrderDetailPanel.tsx \
+        src/frontend/src/features/ebay/components/SoldOrderDetailPanel.module.css \
+        src/frontend/src/features/ebay/components/__tests__/SoldOrderDetailPanel.test.tsx
+git commit -m "feat(ebay): add SoldOrderDetailPanel component with lifecycle strip and action buttons"
+```
+
+---
+
+## Task 13: Wire up the Sold tab in listings.tsx
+
+**Files:**
+- Modify: `src/frontend/src/routes/listings.tsx`
+- Modify: `src/frontend/src/routes/__tests__/listings.test.tsx` (add sold-tab test)
+
+- [ ] **Step 1: Add a sold-tab smoke test to the existing test file**
+
+Open `src/frontend/src/routes/__tests__/listings.test.tsx` and add:
+
+```typescript
+it('shows sold tab and switches to it', async () => {
+  render(<ListingsPage />)
+  const soldTab = screen.getByRole('tab', { name: /sold/i })
+  expect(soldTab).toBeTruthy()
+  fireEvent.click(soldTab)
+  // After clicking Sold, the active listings table should be gone and sold content visible
+  await waitFor(() => {
+    expect(screen.queryByText('Order history coming soon')).toBeNull()
+  })
+})
+```
+
+- [ ] **Step 2: Run to confirm the "coming soon" assertion still passes (it will until we wire up)**
+
+```bash
+cd src/frontend && npx vitest run src/routes/__tests__/listings.test.tsx 2>&1 | tail -10
+```
+
+Note the existing pass count.
+
+- [ ] **Step 3: Wire up the Sold tab in listings.tsx**
+
+At the top of `src/frontend/src/routes/listings.tsx`, add new imports:
+
+```typescript
+import { SoldOrdersTable } from '../features/ebay/components/SoldOrdersTable'
+import { SoldOrderDetailPanel } from '../features/ebay/components/SoldOrderDetailPanel'
+import {
+  fetchSoldOrders,
+  markOrderSent,
+  markOrderSentWithTracking,
+  updateOrderLocalStatus,
+} from '../features/ebay/api'
+import type { SoldOrder, DisplayStatus } from '../features/ebay/soldOrders'
+```
+
+Inside `ListingsPage`, add state for sold orders after the existing state declarations:
+
+```typescript
+const [soldOrders, setSoldOrders] = useState<SoldOrder[]>([])
+const [isSoldLoading, setIsSoldLoading] = useState(false)
+const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null)
+```
+
+Add a `useEffect` that fires when the tab switches to `'sold'`:
+
+```typescript
+useEffect(() => {
+  if (tab !== 'sold') return
+  let cancelled = false
+  async function loadSold() {
+    setIsSoldLoading(true)
+    try {
+      const results = await Promise.allSettled(
+        productionApps.map((app) =>
+          fetchSoldOrders(app.app_code, 25, 0).then(({ orders }) =>
+            orders.map((o) => ({ ...o, appName: app.app_name }))
+          )
+        )
+      )
+      if (cancelled) return
+      const merged: SoldOrder[] = []
+      results.forEach((r) => { if (r.status === 'fulfilled') merged.push(...r.value) })
+      setSoldOrders(merged)
+    } finally {
+      if (!cancelled) setIsSoldLoading(false)
+    }
+  }
+  loadSold()
+  return () => { cancelled = true }
+}, [tab, productionApps])
+```
+
+Add a status-change handler:
+
+```typescript
+function handleOrderStatusChange(orderId: string, newStatus: DisplayStatus) {
+  setSoldOrders((prev) =>
+    prev.map((o) => o.orderId === orderId ? { ...o, displayStatus: newStatus, local_status: newStatus } : o)
+  )
+}
+```
+
+Replace the existing `{tab === 'sold' && ...}` block with:
+
+```tsx
+{tab === 'sold' && (
+  <div className={selectedOrderId ? styles.withPanel : undefined}>
+    <div>
+      <SoldOrdersTable
+        orders={soldOrders}
+        isLoading={isSoldLoading}
+        selectedId={selectedOrderId ?? undefined}
+        onRowClick={(id) => setSelectedOrderId(id)}
+      />
+    </div>
+    {selectedOrderId && (() => {
+      const order = soldOrders.find((o) => o.orderId === selectedOrderId)
+      return order ? (
+        <div>
+          <SoldOrderDetailPanel
+            order={order}
+            onClose={() => setSelectedOrderId(null)}
+            onStatusChange={handleOrderStatusChange}
+          />
+        </div>
+      ) : null
+    })()}
+  </div>
+)}
+```
+
+Also update the Sold tab pill count in the tab bar — find the existing tab render and add the count for sold:
+
+```tsx
+{t === 'sold' && !isSoldLoading && soldOrders.length > 0 && (
+  <span className={styles.tabCount}>{soldOrders.length}</span>
+)}
+```
+
+- [ ] **Step 4: Run the full frontend test suite**
+
+```bash
+cd src/frontend && npx vitest run 2>&1 | tail -15
+```
+
+Expected: all previously passing tests still pass; the new sold-tab smoke test passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/routes/listings.tsx \
+        src/frontend/src/routes/__tests__/listings.test.tsx
+git commit -m "feat(ebay): wire sold tab to SoldOrdersTable + SoldOrderDetailPanel in listings page"
+```
+
+---
+
+## Self-Review Checklist (run after all tasks)
+
+```bash
+# Full backend test suite
+cd src && python -m pytest automana/tests/ -q --tb=short
+
+# Full frontend test suite
+cd src/frontend && npx vitest run
+
+# App import sanity (catches circular imports & registry conflicts)
+cd src && python -c "from automana.api.app import create_app; print('app OK')"
+
+# Check migration is listed
+docker exec automana-postgres-dev psql -U automana_admin automana \
+  -c "SELECT column_name FROM information_schema.columns WHERE table_name='ebay_order_status' ORDER BY ordinal_position;"
+```

--- a/src/automana/database/SQL/migrations/migration_25_fix2_fix3.sql
+++ b/src/automana/database/SQL/migrations/migration_25_fix2_fix3.sql
@@ -1,0 +1,91 @@
+BEGIN;
+
+-- ============================================================================
+-- Migration 25: Fix 2 & Fix 3 — Art Card + Token Resolution for MTGStock Price Pipeline
+-- ============================================================================
+--
+-- Problem: 7.2M rows stuck in stg_price_observation_reject due to:
+--   - Fix 2 (680K rows): Art cards use AAINR-style MTGStocks codes but ainr in Scryfall
+--   - Fix 3 (3.8M rows): Tokens have NULL collector_number; base set codes don't map to 't'-prefixed token sets
+--
+-- Solution: Two new mapping tables + two resolution paths in load_staging_prices_batched + resolve_price_rejects
+--
+-- Expected recovery: ~4.5M rows (~62% of stuck rows)
+
+-- ============================================================================
+-- CREATE MAPPING TABLES
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS pricing.mtgstock_art_set_map (
+    mtgstocks_set_code  TEXT PRIMARY KEY,
+    scryfall_set_code   TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE pricing.mtgstock_art_set_map IS
+    'Maps MTGStocks "A"-prefixed art set codes (AAINR, ADFT, etc.) to lowercase Scryfall equivalents (ainr, adft, etc.)';
+
+CREATE TABLE IF NOT EXISTS pricing.mtgstock_token_set_map (
+    mtgstocks_set_code  TEXT PRIMARY KEY,
+    token_set_code      TEXT NOT NULL,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE pricing.mtgstock_token_set_map IS
+    'Maps MTGStocks base set codes (CMM, WHO, MH3) to Scryfall "t"-prefixed token set codes (tcmm, twho, tmh3)';
+
+-- ============================================================================
+-- SEED MAPPING TABLES
+-- ============================================================================
+
+-- Fix 2: Art set mappings (manually from MTGSTOCK_REJECT_ANALYSIS.md known values)
+INSERT INTO pricing.mtgstock_art_set_map (mtgstocks_set_code, scryfall_set_code) VALUES
+    ('AAINR', 'ainr'),   -- Astral Arena art cards
+    ('ADFT',  'adft'),   -- Duskmourn art cards
+    ('AEOE',  'aeoe'),   -- Eldritch Ordeals
+    ('AFIN',  'afin'),   -- Final Format
+    ('AATDM', 'aatdm'),  -- Against the Darkness
+    ('ASLD',  'asld'),   -- Summer Legends
+    ('APRE',  'apre'),   -- Prerelease cards (if applicable)
+    ('AMAT',  'amat')    -- Mat cards (if applicable)
+ON CONFLICT (mtgstocks_set_code) DO NOTHING;
+
+-- Fix 3: Token set mappings (dynamically generated from catalog)
+-- First, check if card_catalog.set_type_list_ref exists and has token sets
+INSERT INTO pricing.mtgstock_token_set_map (mtgstocks_set_code, token_set_code)
+SELECT
+    UPPER(SUBSTR(s.set_code, 2)) AS mtgstocks_set_code,
+    s.set_code AS token_set_code
+FROM card_catalog.sets s
+JOIN card_catalog.set_type_list_ref stl ON s.set_type_id = stl.set_type_id
+WHERE stl.set_type = 'token'
+  AND LENGTH(s.set_code) >= 2
+  AND SUBSTR(s.set_code, 1, 1) = 't'
+  AND UPPER(SUBSTR(s.set_code, 2)) NOT IN (SELECT mtgstocks_set_code FROM pricing.mtgstock_token_set_map)
+ON CONFLICT (mtgstocks_set_code) DO NOTHING;
+
+-- ============================================================================
+-- GRANTS
+-- ============================================================================
+
+GRANT SELECT ON pricing.mtgstock_art_set_map   TO app_celery, app_rw, app_ro, app_backend, app_admin;
+GRANT SELECT ON pricing.mtgstock_token_set_map TO app_celery, app_rw, app_ro, app_backend, app_admin;
+
+-- ============================================================================
+-- UPDATE PROCEDURES
+-- ============================================================================
+
+-- This migration updates:
+-- 1. pricing.load_staging_prices_batched — adds tmp_map_art, tmp_map_token; extends tmp_resolved
+-- 2. pricing.resolve_price_rejects — adds map_art, map_token CTEs; extends final SELECT
+--
+-- These procedures are updated in the schema file (06_prices.sql) via CREATE OR REPLACE.
+-- Running the schema file after this migration will install the updated versions.
+-- For backwards compatibility, the full procedure bodies are NOT repeated here.
+-- Instead, the procedures are updated during schema application.
+
+-- Note: If running migrations in isolation (not rebuilding schema), copy the updated
+-- procedure CREATE OR REPLACE blocks from 06_prices.sql into this migration after
+-- the GRANT statements above. For now, we rely on schema-rebuild workflow.
+
+COMMIT;

--- a/src/automana/database/SQL/schemas/07_online_shop.sql
+++ b/src/automana/database/SQL/schemas/07_online_shop.sql
@@ -1,0 +1,127 @@
+/*
+-- Customers Table
+CREATE TABLE Customers (
+    customer_id SERIAL PRIMARY KEY,
+    organisation_or_person VARCHAR(50),
+    organisation_name VARCHAR(100),
+    gender VARCHAR(10),
+    first_name VARCHAR(50),
+    middle_initial CHAR(1),
+    last_name VARCHAR(50),
+    email_address VARCHAR(100) UNIQUE,
+    phone_number VARCHAR(20),
+    address_line_1 VARCHAR(255),
+    address_line_2 VARCHAR(255),
+    address_line_3 VARCHAR(255),
+    address_line_4 VARCHAR(255),
+    town_city VARCHAR(100),
+    county VARCHAR(100),
+    country VARCHAR(100)
+);
+*/
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS user_collection;
+
+CREATE TABLE IF NOT EXISTS user_collection.collections (
+    collection_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    collection_name VARCHAR(100) NOT NULL,
+    description VARCHAR(100) NOT NULL,
+    user_id UUID REFERENCES user_management.users(unique_id) ON DELETE CASCADE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    is_active BOOLEAN DEFAULT TRUE,
+    CONSTRAINT uc_collection_name_user UNIQUE (collection_name, user_id)
+);
+
+
+-- Collection Items (Tracks Owned Cards)
+CREATE TABLE IF NOT EXISTS user_collection.collection_items (
+    item_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    collection_id UUID REFERENCES user_collection.collections(collection_id) ON DELETE CASCADE,
+    unique_card_id UUID REFERENCES card_catalog.card_version(card_version_id) ON DELETE CASCADE,
+    finish_id SMALLINT NOT NULL DEFAULT 1 REFERENCES pricing.card_finished(finish_id),
+    purchase_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    purchase_price DECIMAL(10,2),
+    condition VARCHAR(5) NOT NULL DEFAULT 'NM' REFERENCES pricing.card_condition(code),
+    currency_code VARCHAR(3) NOT NULL DEFAULT 'USD' REFERENCES pricing.currency_ref(currency_code),
+    language_id INT REFERENCES card_catalog.language_ref(language_id)
+);
+
+
+/*
+
+-- Reference: Order Status Codes
+CREATE TABLE Ref_Order_Status_Codes (
+    order_status_code SERIAL PRIMARY KEY,
+    order_status_description VARCHAR(50)
+);
+
+-- Orders Table
+CREATE TABLE Orders (
+    order_id SERIAL PRIMARY KEY,
+    customer_id INT REFERENCES Customers(customer_id) ON DELETE CASCADE,
+    order_status_code INT REFERENCES Ref_Order_Status_Codes(order_status_code) ON DELETE SET NULL,
+    date_order_placed TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    order_details TEXT
+);
+
+-- Reference: Invoice Status Codes
+CREATE TABLE Ref_Invoice_Status_Codes (
+    invoice_status_code SERIAL PRIMARY KEY,
+    invoice_status_description VARCHAR(50)
+);
+
+-- Invoices Table
+CREATE TABLE Invoices (
+    invoice_number SERIAL PRIMARY KEY,
+    order_id INT REFERENCES Orders(order_id) ON DELETE CASCADE,
+    invoice_status_code INT REFERENCES Ref_Invoice_Status_Codes(invoice_status_code) ON DELETE SET NULL,
+    invoice_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    invoice_details TEXT
+);
+
+-- Payments Table
+CREATE TABLE Payments (
+    payment_id SERIAL PRIMARY KEY,
+    invoice_number INT REFERENCES Invoices(invoice_number) ON DELETE CASCADE,
+    payment_amount DECIMAL(10,2) NOT NULL
+);
+
+
+
+-- Reference: Order Item Status Codes
+CREATE TABLE Ref_Order_Item_Status_Codes (
+    order_item_status_code SERIAL PRIMARY KEY,
+    order_item_status_description VARCHAR(50)
+);
+
+-- Order Items Table
+CREATE TABLE Order_Items (
+    order_item_id SERIAL PRIMARY KEY,
+    order_id INT REFERENCES Orders(order_id) ON DELETE CASCADE,
+    product_id INT REFERENCES Products(product_id) ON DELETE CASCADE,
+    order_item_status_code INT REFERENCES Ref_Order_Item_Status_Codes(order_item_status_code) ON DELETE SET NULL,
+    order_item_quantity INT CHECK(order_item_quantity > 0),
+    order_item_price DECIMAL(10,2) NOT NULL,
+    RMA_number VARCHAR(50),
+    RMA_issued_by VARCHAR(100),
+    RMA_issued_date TIMESTAMP,
+    other_order_item_details TEXT
+);
+
+-- Shipments Table
+CREATE TABLE Shipments (
+    shipment_id SERIAL PRIMARY KEY,
+    invoice_number INT REFERENCES Invoices(invoice_number) ON DELETE CASCADE,
+    shipment_tracking_number VARCHAR(50) UNIQUE,
+    shipment_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    other_shipment_details TEXT
+);
+
+-- Shipment Items Table (Many-to-Many Relationship Between Shipments and Order Items)
+CREATE TABLE Shipment_Items (
+    shipment_id INT REFERENCES Shipments(shipment_id) ON DELETE CASCADE,
+    order_item_id INT REFERENCES Order_Items(order_item_id) ON DELETE CASCADE,
+    PRIMARY KEY (shipment_id, order_item_id)
+);
+*/
+COMMIT;

--- a/src/automana/database/SQL/schemas/08_shopify_staging.sql
+++ b/src/automana/database/SQL/schemas/08_shopify_staging.sql
@@ -1,0 +1,212 @@
+-- Shopify Staging Tables and Procedures for Price Data ETL
+-- All entities in pricing schema
+
+-- Note: This table definition appears incomplete in the original
+-- CREATE TABLE IF NOT EXISTS pricing.market_collection (
+--     -- Add columns here
+-- );
+
+-- Staging table for raw Shopify price data
+BEGIN;
+CREATE UNLOGGED TABLE IF NOT EXISTS pricing.shopify_staging_raw (
+    product_id BIGINT,
+    date DATE,
+    variation VARCHAR,
+    price NUMERIC,
+    scraped_at TIMESTAMP,
+    card_id BIGINT,
+    tcg_id BIGINT
+);
+
+-- Note: This function definition appears incomplete in the original
+-- CREATE OR REPLACE FUNCTION pricing.find_card_version(title TEXT)
+-- RETURNS ... AS $$
+-- BEGIN
+--     -- Add function body here
+-- END;
+-- $$ LANGUAGE plpgsql;
+
+-- Indexes for staging table
+CREATE INDEX IF NOT EXISTS idx_shopify_staging_raw_product_id ON pricing.shopify_staging_raw(product_id);
+CREATE INDEX IF NOT EXISTS idx_shopify_staging_raw_date ON pricing.shopify_staging_raw(date);     
+
+-- Procedure: Load raw Shopify data into staging
+CREATE OR REPLACE PROCEDURE pricing.raw_to_stage()
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    -- Create staging table if not exists
+    CREATE UNLOGGED TABLE IF NOT EXISTS pricing.price_observation_stage (
+        id SERIAL PRIMARY KEY,
+        ts_date DATE NOT NULL,
+        game_id INT NOT NULL REFERENCES pricing.card_game(game_id),
+        print_id BIGINT NOT NULL,
+        source_id INT NOT NULL REFERENCES pricing.price_source(source_id),
+        metric_id INT NOT NULL REFERENCES pricing.price_metric(metric_id),
+        value NUMERIC NOT NULL,
+        scraped_at TIMESTAMP NOT NULL,
+        condition_id INT REFERENCES pricing.card_condition(condition_id),
+        finish_id INT REFERENCES pricing.card_finished(finish_id),
+        UNIQUE(ts_date, game_id, print_id, source_id, metric_id, condition_id, finish_id)
+    );
+
+    -- Transform and load data
+    WITH norm AS (
+      SELECT
+        ssr.date::date                  AS ts_date,
+        cg.game_id                      AS game_id,
+        ssr.product_id                  AS print_id,
+        ps.source_id                    AS source_id,
+        ssr.scraped_at                  AS scraped_at,
+        ssr.price                       AS value,
+        string_to_array(
+          regexp_replace(trim(ssr.variation), '\s+', ' ', 'g'),
+          ' '
+        )                               AS parts
+      FROM pricing.shopify_staging_raw ssr
+      JOIN pricing.card_game     cg ON cg.code = 'mtg'
+      JOIN pricing.price_source  ps ON ps.code = 'gg_brisbane'
+    ),
+    split AS (
+      SELECT
+        ts_date, game_id, print_id, source_id, value, scraped_at,
+        /* condition = all words except the last only if last is "Foil" */
+        CASE
+          WHEN lower(parts[cardinality(parts)]) = 'foil'
+            THEN array_to_string(parts[1:cardinality(parts)-1], ' ')
+          ELSE array_to_string(parts, ' ')
+        END                                          AS condition_name,
+        /* finish = "Foil" or NULL (non-foil) */
+        CASE
+          WHEN lower(parts[cardinality(parts)]) = 'foil'
+            THEN 'foil'
+          ELSE 'nonfoil'
+        END                                          AS finish_name,
+
+        CASE
+            WHEN lower(parts[cardinality(parts)]) = 'foil'
+              THEN 2
+            ELSE 3
+          END AS metric_id
+        FROM norm
+    ),
+    lookups AS (
+      SELECT
+        s.ts_date,
+        s.game_id,
+        s.print_id,
+        s.source_id,
+        s.metric_id,
+        s.scraped_at,
+        s.value,
+        cc.condition_id                                       AS condition_id,
+        cf.finish_id                                          AS finish_id
+      FROM split s
+      JOIN pricing.card_condition cc
+        ON lower(cc.description) = lower(s.condition_name)
+      /* finish_id only when Foil; otherwise NULL */
+      LEFT JOIN pricing.card_finished cf
+        ON s.finish_name IS NOT NULL AND lower(cf.code) = 'foil'
+    )
+    INSERT INTO pricing.price_observation_stage 
+      (ts_date, game_id, print_id, source_id, metric_id, value, scraped_at, condition_id, finish_id)
+    SELECT
+      ts_date, game_id, print_id, source_id, metric_id, value, scraped_at, condition_id, finish_id
+    FROM lookups;
+END;
+$$;
+
+-- Procedure: Load from staging to final price observation table
+CREATE OR REPLACE PROCEDURE pricing.stage_to_price_observation()
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_count           bigint;
+    v_not_found_count bigint;
+    v_start_time      timestamp := clock_timestamp();
+    v_step_time       timestamp;
+BEGIN
+    ------------------------------------------------------------------
+    -- 1) Insert price observations
+    ------------------------------------------------------------------
+    v_step_time := clock_timestamp();
+
+    -- BROKEN — NEEDS REDESIGN.
+    --
+    -- The previous body inserted into pricing.price_observation with the
+    -- columns (ts_date, game_id, print_id, source_id, metric_id, value,
+    -- scraped_at, condition_id, finish_id). None of `game_id`, `print_id`,
+    -- `source_id`, `metric_id`, `value` exist on the current
+    -- pricing.price_observation schema (see 06_prices.sql:165 — it uses
+    -- price_type_id, finish_id, condition_id, language_id, *_cents,
+    -- source_product_id, data_provider_id).
+    --
+    -- Rewriting correctly requires mapping:
+    --   price_observation_stage.(game_id, print_id, source_id, metric_id)
+    --     → pricing.price_observation.(source_product_id, price_type_id, data_provider_id)
+    -- which is a non-trivial join with pricing.source_product and is
+    -- left for a follow-up that can decide the canonical mapping.
+    RAISE EXCEPTION
+        'pricing.stage_to_price_observation needs to be rewritten against the current price_observation schema (see 07_shopify_staging.sql for context).';
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE INFO 'Inserted % rows into price_observation in %',
+               v_count, clock_timestamp() - v_step_time;
+
+    ------------------------------------------------------------------
+    -- 2) Insert external identifiers (gg_brisbane_id)
+    ------------------------------------------------------------------
+    v_step_time := clock_timestamp();
+
+    -- Explicit PK conflict target. Note the JOIN to card_external_identifier on
+    -- tcgplayer_id can now return multiple card_version_ids per shared
+    -- tcgplayer_id (foil + nonfoil pairs share IDs — see
+    -- 02_card_schema.sql comments). That's intentional: each card_version
+    -- gets its own gg_brisbane_id row pointing at the same Shopify product.
+    INSERT INTO card_catalog.card_external_identifier
+        (card_identifier_ref_id, card_version_id, value)
+    SELECT
+        cir2.card_identifier_ref_id,
+        cce1.card_version_id,
+        ssr.product_id::TEXT
+    FROM pricing.shopify_staging_raw ssr
+    JOIN card_catalog.card_identifier_ref cir1
+         ON cir1.identifier_name = 'tcgplayer_id'
+    JOIN card_catalog.card_external_identifier cce1
+         ON cce1.card_identifier_ref_id = cir1.card_identifier_ref_id
+        AND cce1.value::bigint = ssr.tcg_id
+    JOIN card_catalog.card_identifier_ref cir2
+         ON cir2.identifier_name = 'gg_brisbane_id'
+    ON CONFLICT (card_version_id, card_identifier_ref_id) DO NOTHING;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RAISE INFO 'Inserted % rows into card_external_identifier in %',
+               v_count, clock_timestamp() - v_step_time;
+
+    ------------------------------------------------------------------
+    -- 3) Count tcg_ids with no mapping (not found)
+    ------------------------------------------------------------------
+    v_step_time := clock_timestamp();
+
+    SELECT COUNT(*)
+    INTO v_not_found_count
+    FROM pricing.shopify_staging_raw ssr
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM card_catalog.card_identifier_ref cir1
+        JOIN card_catalog.card_external_identifier cce1
+          ON cce1.card_identifier_ref_id = cir1.card_identifier_ref_id
+         AND cce1.value::bigint = ssr.tcg_id
+        WHERE cir1.identifier_name = 'tcgplayer_id'
+    );
+
+    RAISE INFO 'tcg_ids not found in card_external_identifier: % (checked in %)',
+               v_not_found_count, clock_timestamp() - v_step_time;
+
+    ------------------------------------------------------------------
+    -- 4) Total time
+    ------------------------------------------------------------------
+    RAISE INFO 'Total procedure time: %', clock_timestamp() - v_start_time;
+END;
+$$;
+COMMIT;

--- a/src/automana/database/SQL/schemas/09_markets_prices.sql
+++ b/src/automana/database/SQL/schemas/09_markets_prices.sql
@@ -1,0 +1,230 @@
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS markets;
+
+-- TimescaleDB is required for `create_hypertable` + continuous aggregates
+-- below. The extension is installed once in 01_set_schema.sql; this is a
+-- belt-and-suspenders guard for direct-file runs.
+CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE;
+
+-- ============================================================
+-- Function defined early so the triggers at the bottom can wire to
+-- it by name. Schema-qualified so it lands in `markets` regardless
+-- of the caller's search_path.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION markets.trigger_set_updated_at()
+RETURNS trigger AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ============================================================
+-- Tables
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS markets.market_ref (
+    market_id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    country_code VARCHAR(3) NOT NULL DEFAULT 'AUD',
+    city VARCHAR(20) NOT NULL DEFAULT 'Unknown',
+    api_url TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (name, city, country_code)
+);
+
+CREATE TABLE IF NOT EXISTS markets.product_ref (
+    product_shop_id VARCHAR(64) PRIMARY KEY,
+    product_id TEXT NOT NULL,
+    market_id INT NOT NULL REFERENCES markets.market_ref(market_id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (market_id, product_id)
+);
+
+CREATE TABLE IF NOT EXISTS markets.card_products_ref (
+    tcgplayer_id INT NOT NULL,
+    product_shop_id VARCHAR(64) NOT NULL REFERENCES markets.product_ref(product_shop_id) ON DELETE CASCADE,
+    description TEXT,
+    quantity INTEGER DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (tcgplayer_id, product_shop_id)
+);
+
+CREATE TABLE IF NOT EXISTS markets.product_prices (
+    time TIMESTAMPTZ NOT NULL,
+    product_shop_id VARCHAR(64) NOT NULL REFERENCES markets.product_ref(product_shop_id) ON DELETE CASCADE,
+    price NUMERIC NOT NULL,
+    currency VARCHAR(3) NOT NULL,
+    price_usd NUMERIC NOT NULL,
+    source TEXT,
+    is_foil BOOLEAN DEFAULT FALSE,
+    PRIMARY KEY (time, product_shop_id, is_foil)
+);
+
+CREATE TABLE IF NOT EXISTS markets.collection_handles (
+    handle_id SERIAL PRIMARY KEY,
+    market_id INT NOT NULL REFERENCES markets.market_ref(market_id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE (market_id, name)
+);
+
+-- handles_theme.theme_id references the canonical card-game table in
+-- the `pricing` schema (`pricing.card_game`, defined in 06_prices.sql).
+-- Previously this was an unqualified FK to `card_game` which could not
+-- resolve at replay time.
+CREATE TABLE IF NOT EXISTS markets.handles_theme (
+    handle_id INT NOT NULL REFERENCES markets.collection_handles(handle_id) ON DELETE CASCADE,
+    theme_id SMALLINT REFERENCES pricing.card_game(game_id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    is_active BOOLEAN DEFAULT TRUE,
+    PRIMARY KEY (handle_id, theme_id)
+);
+
+
+-- ============================================================
+-- Trigger functions
+-- ============================================================
+
+-- Soft-delete rows in markets.handles_theme when their pricing.card_game
+-- parent is deleted. Fires before DELETE so we update the child before
+-- ON DELETE SET NULL would otherwise nil the FK.
+CREATE OR REPLACE FUNCTION markets.soft_delete_handles_theme()
+RETURNS TRIGGER AS $$
+BEGIN
+    UPDATE markets.handles_theme
+    SET is_active = FALSE
+    WHERE theme_id = OLD.game_id;
+    RETURN OLD;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- ============================================================
+-- Indexes
+-- ============================================================
+
+CREATE INDEX IF NOT EXISTS idx_product_prices_shop_time
+    ON markets.product_prices (product_shop_id, time DESC);
+
+
+-- ============================================================
+-- Triggers
+-- ============================================================
+
+DROP TRIGGER IF EXISTS collection_handles_set_updated_at ON markets.collection_handles;
+CREATE TRIGGER collection_handles_set_updated_at
+BEFORE UPDATE ON markets.collection_handles
+FOR EACH ROW
+EXECUTE FUNCTION markets.trigger_set_updated_at();
+
+-- Removed: trigger BEFORE UPDATE ON theme_ref — that table does not exist
+-- anywhere in the schema. It was dead code tied to a historical design.
+
+DROP TRIGGER IF EXISTS soft_delete_handles_theme_trigger ON pricing.card_game;
+CREATE TRIGGER soft_delete_handles_theme_trigger
+BEFORE DELETE ON pricing.card_game
+FOR EACH ROW
+EXECUTE FUNCTION markets.soft_delete_handles_theme();
+
+
+-- ============================================================
+-- TimescaleDB: hypertable, compression policy, continuous aggregate
+-- ============================================================
+
+SELECT create_hypertable(
+    'markets.product_prices',
+    'time',
+    chunk_time_interval => interval '7 days',
+    if_not_exists => TRUE
+);
+
+ALTER TABLE markets.product_prices
+SET (timescaledb.compress, timescaledb.compress_segmentby = 'product_shop_id');
+
+SELECT add_compression_policy('markets.product_prices', INTERVAL '30 days', if_not_exists => TRUE);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS markets.card_price_daily_avg
+WITH (timescaledb.continuous) AS
+SELECT time_bucket('1 day', time) AS day,
+       product_shop_id,
+       AVG(price) AS avg_price
+FROM markets.product_prices
+GROUP BY day, product_shop_id
+WITH NO DATA;
+
+
+-- ============================================================
+-- Stored procedures
+-- ============================================================
+
+CREATE OR REPLACE PROCEDURE markets.add_price_batch_arrays(
+    p_times            timestamptz[],
+    p_product_shop_ids text[],
+    p_prices           numeric[],
+    p_currencies       text[],
+    p_prices_usd       numeric[],
+    p_is_foil          boolean[],
+    p_sources          text[]
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO markets.product_prices
+        (time, product_shop_id, price, currency, price_usd, is_foil, source)
+    SELECT b.time, b.product_shop_id, b.price, b.currency, b.price_usd, b.is_foil, b.source
+    FROM unnest(
+            p_times, p_product_shop_ids, p_prices, p_currencies,
+            p_prices_usd, p_is_foil, p_sources
+         ) AS b(time, product_shop_id, price, currency, price_usd, is_foil, source)
+    ON CONFLICT (time, product_shop_id, is_foil) DO NOTHING;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE markets.add_product_batch_arrays(
+    p_product_shop_ids text[],
+    p_product_ids      text[],
+    p_market_ids       int[],
+    p_created_at       timestamptz[],
+    p_updated_at       timestamptz[]
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO markets.product_ref
+        (product_shop_id, product_id, market_id, created_at, updated_at)
+    SELECT b.product_shop_id, b.product_id, b.market_id, b.created_at, b.updated_at
+    FROM unnest(
+            p_product_shop_ids, p_product_ids, p_market_ids,
+            p_created_at, p_updated_at
+         ) AS b(product_shop_id, product_id, market_id, created_at, updated_at)
+    ON CONFLICT (product_shop_id) DO NOTHING;
+END;
+$$;
+
+CREATE OR REPLACE PROCEDURE markets.add_card_product_ref_batch(
+    p_tcgplayer_ids    INT[],
+    p_product_shop_ids TEXT[],
+    p_created_ats      TIMESTAMPTZ[],
+    p_updated_ats      TIMESTAMPTZ[]
+)
+LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO markets.card_products_ref
+        (tcgplayer_id, product_shop_id, created_at, updated_at)
+    SELECT b.tcgplayer_id, b.product_shop_id, b.created_at, b.updated_at
+    FROM unnest(
+            p_tcgplayer_ids, p_product_shop_ids,
+            p_created_ats, p_updated_ats
+         ) AS b(tcgplayer_id, product_shop_id, created_at, updated_at)
+    ON CONFLICT (tcgplayer_id, product_shop_id) DO NOTHING;
+END;
+$$;
+
+COMMIT;

--- a/src/automana/database/SQL/schemas/10_ops_schema.sql
+++ b/src/automana/database/SQL/schemas/10_ops_schema.sql
@@ -1,0 +1,379 @@
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS ops;
+
+-- ============================================================
+-- GROUP 1: SOURCE REGISTRY
+-- Static(ish) configuration describing external data sources
+-- and the named resources they expose.
+--
+--   sources          → one row per external system (scryfall, mtgstock, …)
+--   resources        → named endpoints/files within a source
+--   resource_versions→ each distinct download of a resource (tracks URI + hash)
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ops.sources (
+  id            bigserial PRIMARY KEY,
+  name          text UNIQUE NOT NULL,     -- e.g. 'scryfall', 'tcgplayer'
+  base_uri      text,
+  kind          text,                     -- 'http', 's3', 'ftp', etc.
+  rate_limit_hz numeric,                  -- optional request-rate governance
+  created_at    timestamptz DEFAULT now(),
+  updated_at    timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS ops.resources (
+  id                bigserial PRIMARY KEY,
+  source_id         bigint NOT NULL REFERENCES ops.sources(id),
+  external_type     text NOT NULL,        -- e.g. 'bulk_data', 'sets', 'prices'
+  external_id       text,                 -- provider's own identifier
+  canonical_key     text,                 -- internal stable key
+  name              text,
+  description       text,
+  api_uri           text,                 -- current endpoint URI
+  web_uri           text,
+  metadata          jsonb,
+  updated_at_source timestamptz,
+  created_at        timestamptz DEFAULT now(),
+  CHECK (external_id IS NOT NULL OR canonical_key IS NOT NULL)
+);
+
+-- Full natural key: a resource is unique per (source, type, external_id, canonical_key).
+-- NULLs in `canonical_key` don't collide with each other in the default index,
+-- so this covers the (…, canonical_key IS NOT NULL) case cleanly but doesn't
+-- prevent duplicates when canonical_key IS NULL — the partial index below
+-- handles that case.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_resources_source_type_natkey
+ON ops.resources (source_id, external_type, external_id, canonical_key);
+
+-- Partial unique index matching the Scryfall bulk upsert's ON CONFLICT target
+-- in scryfall_data.py (`ON CONFLICT (source_id, external_type, external_id)
+-- WHERE canonical_key IS NULL`). Without this the upsert errors with
+-- "there is no unique or exclusion constraint matching the ON CONFLICT
+-- specification" on any run where canonical_key is NULL.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_resources_no_canonical_key
+ON ops.resources (source_id, external_type, external_id)
+WHERE canonical_key IS NULL;
+
+CREATE TABLE IF NOT EXISTS ops.resource_versions (
+  id                bigserial PRIMARY KEY,
+  resource_id       bigint NOT NULL REFERENCES ops.resources(id) ON DELETE CASCADE,
+  download_uri      text NOT NULL,        -- ephemeral URL for this specific download
+  content_type      text,
+  content_encoding  text,
+  bytes             bigint,
+  etag              text,
+  last_modified     timestamptz,
+  sha256            text,                 -- integrity check / dedup key
+  status            text NOT NULL CHECK (status IN ('downloaded','processed','failed')),
+  error             text,
+  created_at        timestamptz DEFAULT now(),
+  UNIQUE (resource_id, sha256)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_resource_versions_natkey
+ON ops.resource_versions(resource_id, download_uri, last_modified);
+
+
+-- ============================================================
+-- GROUP 2: PIPELINE EXECUTION LOG
+-- High-write tables that track every pipeline run, its steps,
+-- per-run summary metrics, per-step detail metrics, and
+-- per-step batch-level counters.
+--
+--   ingestion_runs         → one row per pipeline execution
+--   ingestion_run_steps    → one row per named step within a run
+--   ingestion_run_metrics  → summary key/value metrics at run level
+--   ingestion_step_metrics → fine-grained metrics at step level
+--   ingestion_step_batches → batch counters for chunked steps (e.g. card import)
+--   ingestion_run_resources→ links a run to the resource_versions it consumed
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ops.ingestion_runs (
+  id             bigserial PRIMARY KEY,
+  pipeline_name  text NOT NULL,
+  source_id      bigint NOT NULL REFERENCES ops.sources(id),
+  run_key        text UNIQUE,            -- idempotency key, e.g. 'scryfall_daily:2026-03-29'
+  celery_task_id text,                   -- root Celery task id for correlation
+  started_at     timestamptz DEFAULT now(),
+  ended_at       timestamptz,
+  status         text CHECK (status IN ('pending','running','success','partial','failed')),
+  current_step   text,                   -- last active step name
+  progress       numeric(5,2),           -- 0–100 overall progress
+  error_code     text,
+  error_details  jsonb,
+  notes          text,
+  created_at     timestamptz DEFAULT now(),
+  updated_at     timestamptz DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_ingestion_runs_key
+ON ops.ingestion_runs (pipeline_name, source_id, run_key);
+
+CREATE TABLE IF NOT EXISTS ops.ingestion_run_steps (
+  id               bigserial PRIMARY KEY,
+  ingestion_run_id bigint NOT NULL REFERENCES ops.ingestion_runs(id) ON DELETE CASCADE,
+  step_name        text NOT NULL,        -- e.g. 'download_sets', 'process_large_cards_json'
+  started_at       timestamptz DEFAULT now(),
+  ended_at         timestamptz,
+  status           text CHECK (status IN ('pending','running','success','partial','failed')),
+  progress         numeric(5,2),         -- 0–100 step-level progress
+  error_code       text,
+  error_details    jsonb,
+  notes            text,
+  UNIQUE (ingestion_run_id, step_name)
+);
+
+CREATE INDEX IF NOT EXISTS ix_ingestion_run_steps_run
+ON ops.ingestion_run_steps (ingestion_run_id);
+
+-- Run-level summary metrics (one value per metric name per run).
+-- Written by OpsRepository.add_metric().
+-- Use for totals you want to query across runs (e.g. total cards ingested today).
+CREATE TABLE IF NOT EXISTS ops.ingestion_run_metrics (
+  id                 bigserial PRIMARY KEY,
+  ingestion_run_id   bigint NOT NULL REFERENCES ops.ingestion_runs(id) ON DELETE CASCADE,
+  metric_name        text NOT NULL,      -- e.g. 'total_cards', 'total_sets', 'bytes_downloaded'
+  metric_value_num   double precision,
+  metric_value_text  text,
+  recorded_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (ingestion_run_id, metric_name)
+);
+
+CREATE INDEX IF NOT EXISTS ix_run_metrics_run
+ON ops.ingestion_run_metrics (ingestion_run_id);
+
+CREATE INDEX IF NOT EXISTS ix_run_metrics_name
+ON ops.ingestion_run_metrics (metric_name);
+
+-- Step-level fine-grained metrics (multiple values per metric name per step).
+-- Use for time-series counters within a step (e.g. items_processed per batch tick).
+CREATE TABLE IF NOT EXISTS ops.ingestion_step_metrics (
+  id                    bigserial PRIMARY KEY,
+  ingestion_run_step_id bigint NOT NULL REFERENCES ops.ingestion_run_steps(id) ON DELETE CASCADE,
+  metric_name           text NOT NULL,   -- e.g. 'items_processed', 'bytes_downloaded', 'http_429s'
+  metric_type           text NOT NULL DEFAULT 'counter', -- counter / gauge / timer
+  metric_value_num      double precision,
+  metric_value_text     text,
+  recorded_at           timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ix_step_metrics_step
+ON ops.ingestion_step_metrics (ingestion_run_step_id);
+
+CREATE INDEX IF NOT EXISTS ix_step_metrics_name
+ON ops.ingestion_step_metrics (metric_name);
+
+-- Batch-level counters for steps that process data in chunks (e.g. card import).
+-- Each row is one batch: how many succeeded, failed, bytes processed, duration.
+CREATE TABLE IF NOT EXISTS ops.ingestion_step_batches (
+  id                    bigserial PRIMARY KEY,
+  ingestion_run_step_id bigint NOT NULL REFERENCES ops.ingestion_run_steps(id) ON DELETE CASCADE,
+  batch_seq             int NOT NULL,
+  range_start           bigint,
+  range_end             bigint,
+  status                text CHECK (status IN ('pending','running','success','partial','failed')),
+  items_ok              int,
+  items_failed          int,
+  bytes_processed       bigint,
+  duration_ms           int,
+  error_code            text,
+  error_details         jsonb,
+  created_at            timestamptz DEFAULT now(),
+  UNIQUE (ingestion_run_step_id, batch_seq)
+);
+
+CREATE INDEX IF NOT EXISTS ix_step_batches_step
+ON ops.ingestion_step_batches (ingestion_run_step_id, status);
+
+-- Links a pipeline run to the specific resource versions it consumed.
+-- Enables traceability: which file version was processed in which run.
+CREATE TABLE IF NOT EXISTS ops.ingestion_run_resources (
+  id                  bigserial PRIMARY KEY,
+  ingestion_run_id    bigint NOT NULL REFERENCES ops.ingestion_runs(id) ON DELETE CASCADE,
+  resource_version_id bigint NOT NULL REFERENCES ops.resource_versions(id) ON DELETE CASCADE,
+  status              text CHECK (status IN ('pending','processed','failed')),
+  notes               text,
+  UNIQUE (ingestion_run_id, resource_version_id)
+);
+
+
+-- ============================================================
+-- GROUP 3: CROSS-SYSTEM ID MAPPING
+-- Resolves card identifiers across external providers.
+-- NOTE: This table is MTGStock-specific. It lives here because
+-- it is populated during ingestion runs, but its content is
+-- persistent reference data — not ephemeral ops data.
+-- Consider moving to card_catalog schema in a future migration.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ops.ingestion_ids_mapping (
+  id               serial PRIMARY KEY,
+  -- Must be BIGINT to match ops.ingestion_runs.id (bigserial). A plain INT
+  -- FK would refuse rows once run ids exceed 2^31 and could silently error.
+  ingestion_run_id BIGINT NOT NULL REFERENCES ops.ingestion_runs(id) ON DELETE CASCADE,
+  mtgstock_id      bigint NOT NULL,
+  scryfall_id      uuid,
+  multiverse_id    bigint,
+  tcg_id           bigint,
+  created_at       timestamptz DEFAULT now(),
+  UNIQUE (ingestion_run_id, mtgstock_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_ids_mapping_run
+ON ops.ingestion_ids_mapping (ingestion_run_id);
+
+CREATE INDEX IF NOT EXISTS idx_ingestion_ids_mapping_scryfall
+ON ops.ingestion_ids_mapping (scryfall_id);
+
+INSERT INTO ops.sources (name, base_uri, kind, rate_limit_hz)
+VALUES ('mtgstocks', 'https://api.mtgstocks.com', 'http', 2.0)
+ON CONFLICT (name) DO UPDATE
+SET base_uri = EXCLUDED.base_uri,
+    kind = EXCLUDED.kind,
+    rate_limit_hz = EXCLUDED.rate_limit_hz;
+
+WITH src AS (
+  SELECT id FROM ops.sources WHERE name = 'mtgstocks'
+)
+INSERT INTO ops.resources (
+    source_id, external_type, external_id, canonical_key,
+    name, description, api_uri, web_uri, metadata
+)
+VALUES
+  (
+    (SELECT id FROM src),
+    'print_details', 'prints/{print_id}', 'mtgstock.print.details',
+    'MTGStocks print details',
+    'JSON details for a print',
+    'https://api.mtgstocks.com/prints/{print_id}',
+    'https://www.mtgstocks.com/prints/{print_id}',
+    '{"format":"json"}'::jsonb
+  ),
+  (
+    (SELECT id FROM src),
+    'print_prices', 'prints/{print_id}/prices', 'mtgstock.print.prices',
+    'MTGStocks print prices',
+    'Price history for a print',
+    'https://api.mtgstocks.com/prints/{print_id}/prices',
+    'https://www.mtgstocks.com/prints/{print_id}',
+    '{"format":"json"}'::jsonb
+  )
+ON CONFLICT (source_id, external_type, external_id, canonical_key) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    api_uri = EXCLUDED.api_uri,
+    web_uri = EXCLUDED.web_uri,
+    metadata = EXCLUDED.metadata;
+
+
+-- ============================================================
+-- Scryfall source + bulk_data resource
+--
+-- Read by `staging.scryfall.get_bulk_data_uri` → OpsRepository
+-- .get_bulk_data_uri() via the query:
+--   SELECT r.api_uri FROM ops.resources r
+--   JOIN ops.sources s ON s.kind='http' AND s.name='scryfall'
+--                     AND r.external_type='bulk_data'
+-- Without this row the Scryfall pipeline fails on its first step.
+-- ============================================================
+
+INSERT INTO ops.sources (name, base_uri, kind, rate_limit_hz)
+VALUES ('scryfall', 'https://api.scryfall.com', 'http', 10.0)
+ON CONFLICT (name) DO UPDATE
+SET base_uri = EXCLUDED.base_uri,
+    kind = EXCLUDED.kind,
+    rate_limit_hz = EXCLUDED.rate_limit_hz;
+
+WITH src AS (
+  SELECT id FROM ops.sources WHERE name = 'scryfall'
+)
+INSERT INTO ops.resources (
+    source_id, external_type, external_id, canonical_key,
+    name, description, api_uri, web_uri, metadata
+)
+VALUES
+  (
+    (SELECT id FROM src),
+    'bulk_data', 'bulk-data', 'scryfall.bulk_data',
+    'Scryfall bulk data',
+    'Scryfall bulk data catalog endpoint (lists all bulk data manifests).',
+    'https://api.scryfall.com/bulk-data',
+    'https://scryfall.com/docs/api/bulk-data',
+    '{"format":"json"}'::jsonb
+  )
+ON CONFLICT (source_id, external_type, external_id, canonical_key) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    api_uri = EXCLUDED.api_uri,
+    web_uri = EXCLUDED.web_uri,
+    metadata = EXCLUDED.metadata;
+
+
+-- ============================================================
+-- MTGJson source + all_printings resource
+--
+-- Read by `staging.mtgjson.check_version` via
+-- OpsRepository.get_mtgjson_resource_version() /
+-- .upsert_mtgjson_resource_version(), which filter on
+-- canonical_key = 'mtgjson.all_printings'. Seeded here so the
+-- version gate works on a fresh rebuild without manual inserts.
+-- ============================================================
+
+INSERT INTO ops.sources (name, base_uri, kind, rate_limit_hz)
+VALUES ('mtgjson', 'https://mtgjson.com/api/v5', 'http', 2.0)
+ON CONFLICT (name) DO UPDATE
+SET base_uri = EXCLUDED.base_uri,
+    kind = EXCLUDED.kind,
+    rate_limit_hz = EXCLUDED.rate_limit_hz;
+
+WITH src AS (
+  SELECT id FROM ops.sources WHERE name = 'mtgjson'
+)
+INSERT INTO ops.resources (
+    source_id, external_type, external_id, canonical_key,
+    name, description, api_uri, web_uri, metadata
+)
+VALUES
+  (
+    (SELECT id FROM src),
+    'catalog', 'AllPrintings', 'mtgjson.all_printings',
+    'MTGJson AllPrintings catalog',
+    'Version metadata for the MTGJson card catalog (Meta.json).',
+    'https://mtgjson.com/api/v5/Meta.json',
+    'https://mtgjson.com/',
+    '{"format":"json"}'::jsonb
+  )
+ON CONFLICT (source_id, external_type, external_id, canonical_key) DO UPDATE
+SET name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    api_uri = EXCLUDED.api_uri,
+    web_uri = EXCLUDED.web_uri,
+    metadata = EXCLUDED.metadata;
+
+-- ============================================================
+-- ops.pipeline_health_snapshot
+--
+-- One row per (run_id, check_set). Captures every ops.integrity.*
+-- service result so HealthAlertService can diff status transitions
+-- across runs and alert Discord only on changes.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS ops.pipeline_health_snapshot (
+    id              bigserial PRIMARY KEY,
+    run_id          uuid        NOT NULL,
+    captured_at     timestamptz NOT NULL DEFAULT now(),
+    check_set       text        NOT NULL,
+    pipeline        text        NOT NULL,
+    status          text        NOT NULL CHECK (status IN ('ok','warn','error')),
+    error_count     int         NOT NULL,
+    warn_count      int         NOT NULL,
+    total_checks    int         NOT NULL,
+    report          jsonb       NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_health_snapshot_check_set_captured_at
+    ON ops.pipeline_health_snapshot (check_set, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pipeline_health_snapshot_run_id
+    ON ops.pipeline_health_snapshot (run_id);
+
+COMMIT;

--- a/src/automana/database/SQL/schemas/11_mtgjson_schema.sql
+++ b/src/automana/database/SQL/schemas/11_mtgjson_schema.sql
@@ -1,0 +1,358 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS pricing.mtgjson_staging (
+  cardFinish TEXT,
+  currency TEXT,
+  date DATE,
+  gameAvailability TEXT,
+  price FLOAT,
+  priceProvider TEXT,
+  providerListing TEXT,
+  uuid TEXT,
+    -- Audit
+  created_at      timestamptz DEFAULT now(),
+  updated_at      timestamptz DEFAULT now()
+);
+
+-- NOTE: `pricing.mtgjson_payloads` and `pricing.process_mtgjson_payload`
+-- were removed as part of the streaming-refactor. The raw .xz payload is
+-- no longer archived as JSONB in the database — it's streamed directly
+-- from disk into `pricing.mtgjson_card_prices_staging` via lzma + ijson +
+-- asyncpg COPY (see staging.mtgjson.stream_to_staging in data_loader.py,
+-- and docs/MTGJSON_PIPELINE.md for the design rationale). Do not re-add
+-- either object without revisiting that decision first.
+
+CREATE TABLE IF NOT EXISTS pricing.mtgjson_card_prices_staging (
+    id SERIAL PRIMARY KEY,
+    card_uuid TEXT NOT NULL,
+    price_source TEXT NOT NULL,      -- provenance (tcgplayer, cardmarket, ...)
+    price_type  TEXT,                -- buylist, retail
+    finish_type TEXT NOT NULL,       -- foil, nonfoil, etched, showcase
+    currency TEXT NOT NULL,
+    price_value FLOAT NOT NULL,
+    price_date DATE NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Promote staged rows into pricing.price_observation.
+-- No `p_payload_id` parameter — the streaming pipeline writes rows without
+-- payload provenance (see stream_to_staging service), so there's no payload
+-- to scope by. The proc processes the entire staging table in batch_days
+-- windows and deletes rows it successfully resolves.
+CREATE OR REPLACE PROCEDURE pricing.load_price_observation_from_mtgjson_staging_batched(
+   batch_days int DEFAULT 30
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_data_provider_id bigint;
+
+  v_min date;
+  v_max date;
+  v_start date;
+  v_end date;
+
+  v_upserted bigint := 0;
+  v_deleted  bigint := 0;
+  v_total_upserted bigint := 0;
+  v_total_deleted  bigint := 0;
+  v_is_ok boolean := false;
+BEGIN
+  IF batch_days IS NULL OR batch_days <= 0 THEN
+    RAISE EXCEPTION 'batch_days must be > 0 (got %)', batch_days;
+  END IF;
+
+  -- normalize finish: map 'normal'→'NONFOIL' first, then uppercase everything
+  UPDATE pricing.mtgjson_card_prices_staging
+  SET finish_type = 'NONFOIL'
+  WHERE lower(finish_type) = 'normal';
+
+  UPDATE pricing.mtgjson_card_prices_staging
+  SET finish_type = UPPER(finish_type)
+  WHERE finish_type IS NOT NULL;
+
+  -- normalize tcgplayer
+  UPDATE pricing.mtgjson_card_prices_staging
+  SET price_source = 'tcg'
+  WHERE lower(price_source) = 'tcgplayer';
+
+  -- normalize sell and buy (transaction_type_code)
+  UPDATE pricing.mtgjson_card_prices_staging
+  SET price_type = CASE
+    WHEN lower(price_type) IN ('retail', 'market') THEN 'sell'
+    WHEN lower(price_type) IN ('buylist', 'directlow') THEN 'buy'
+    ELSE lower(price_type)
+  END;
+
+  -- provider
+  SELECT dp.data_provider_id
+  INTO v_data_provider_id
+  FROM pricing.data_provider dp
+  WHERE dp.code = 'mtgjson'
+  LIMIT 1;
+
+  IF v_data_provider_id IS NULL THEN
+    RAISE EXCEPTION 'Missing pricing.data_provider row with code=mtgjson';
+  END IF;
+
+  -- staging span
+  SELECT min(price_date)::date, max(price_date)::date
+  INTO v_min, v_max
+  FROM pricing.mtgjson_card_prices_staging
+  WHERE price_date IS NOT NULL;
+
+  IF v_min IS NULL THEN
+    RAISE NOTICE 'No rows in pricing.mtgjson_card_prices_staging to process.';
+    RETURN;
+  END IF;
+
+  v_start := v_min;
+
+  WHILE v_start <= v_max LOOP
+    v_end := (v_start + (batch_days - 1));
+
+    BEGIN
+      v_is_ok := false;
+      -- upsert price sources for this batch
+      INSERT INTO pricing.price_source (code, name, currency_code)
+      SELECT DISTINCT s.price_source, s.price_source, s.currency
+      FROM pricing.mtgjson_card_prices_staging s
+      WHERE s.price_date::date BETWEEN v_start AND v_end
+        AND s.price_source IS NOT NULL
+        AND s.currency IS NOT NULL
+      ON CONFLICT (code) DO NOTHING;
+
+      -- upsert finishes for this batch (IMPORTANT)
+      INSERT INTO pricing.card_finished (code)
+      SELECT DISTINCT UPPER(s.finish_type)
+      FROM pricing.mtgjson_card_prices_staging s
+      WHERE s.price_date::date BETWEEN v_start AND v_end
+        AND s.finish_type IS NOT NULL
+      ON CONFLICT (code) DO NOTHING;
+
+      -- upsert observations
+      with src AS (
+        SELECT ps.source_id, ps.code, ps.name, ps.currency_code
+        FROM pricing.price_source ps
+      ),
+      fin AS (
+        SELECT cf.finish_id, cf.code
+        FROM pricing.card_finished cf
+      ),
+      cv AS (
+        SELECT
+          cei.value::uuid AS card_uuid,
+          cei.card_version_id
+        FROM card_catalog.card_external_identifier cei
+        JOIN card_catalog.card_identifier_ref cir
+          ON cir.card_identifier_ref_id = cei.card_identifier_ref_id
+        WHERE cir.identifier_name = 'mtgjson_id'
+      ),
+      prod AS (
+        SELECT
+          cv.card_version_id,
+	 cv.card_uuid, 
+          mcp.product_id
+        FROM cv
+        JOIN pricing.mtg_card_products mcp
+          ON mcp.card_version_id = cv.card_version_id
+      ),
+  pairs AS (
+    SELECT DISTINCT
+      p.product_id,
+      s.source_id
+    FROM pricing.mtgjson_card_prices_staging st
+    JOIN src s
+      ON s.code = st.price_source
+    AND s.currency_code = st.currency
+    JOIN prod p
+      ON p.card_uuid::uuid = st.card_uuid::uuid
+  WHERE st.price_date::date BETWEEN v_start AND v_end
+    AND st.price_date IS NOT NULL
+    AND st.card_uuid IS NOT NULL
+    AND st.price_source IS NOT NULL
+    AND st.currency IS NOT NULL
+  ),
+  insert_product_source AS (
+    INSERT INTO pricing.source_product (product_id, source_id)
+    SELECT product_id, source_id
+    FROM pairs
+    ON CONFLICT (product_id, source_id) DO UPDATE
+      SET product_id = EXCLUDED.product_id  -- no-op; ensures RETURNING fires on conflicts too
+    RETURNING source_product_id, product_id, source_id
+  ),
+        staged AS (
+          SELECT
+            s.id,
+            s.price_date::date AS ts_date,
+            s.price_source,
+            tt.transaction_type_id AS price_type_id,
+            s.currency,
+            s.finish_type,
+            s.card_uuid,
+            LEAST(round((s.price_value::numeric) * 100), 2147483647::numeric)::int AS price_cents
+          FROM pricing.mtgjson_card_prices_staging s
+          JOIN pricing.transaction_type tt
+            ON tt.transaction_type_code = s.price_type
+          WHERE s.price_date::date BETWEEN v_start AND v_end
+            AND s.price_date IS NOT NULL
+            AND s.card_uuid  IS NOT NULL
+            AND s.price_source IS NOT NULL
+            AND s.currency   IS NOT NULL
+            AND s.finish_type IS NOT NULL
+            AND s.price_value IS NOT NULL
+        ) ,resolved AS (
+          SELECT
+            st.id,
+            st.ts_date,
+            fin.finish_id,
+            pricing.default_condition_id() AS condition_id,
+            card_catalog.default_language_id() AS language_id,
+            st.price_cents,
+            st.price_type_id,
+    sp.source_id, 
+            sp.source_product_id
+          FROM staged st
+          JOIN src
+            ON src.code = st.price_source
+          AND src.currency_code = st.currency
+          JOIN fin
+            ON fin.code = st.finish_type
+          JOIN prod
+          ON prod.card_uuid::uuid = st.card_uuid::uuid
+          JOIN insert_product_source sp
+            ON sp.product_id = prod.product_id
+           AND sp.source_id = src.source_id
+        ),
+        upserted AS (
+          INSERT INTO pricing.price_observation (
+            ts_date,
+            price_type_id,
+            finish_id,
+            condition_id,
+            language_id,
+            list_low_cents,
+            list_avg_cents,
+            sold_avg_cents,
+            list_count,
+            sold_count,
+            source_product_id,
+            data_provider_id,
+            scraped_at,
+            created_at,
+            updated_at
+          )
+          SELECT
+            r.ts_date,
+            r.price_type_id,
+            r.finish_id,
+            r.condition_id,
+            r.language_id,
+            NULL::int,
+            NULL::int,
+            r.price_cents,     -- your choice: always sold_avg
+            NULL::int,
+            1,
+            r.source_product_id,
+            v_data_provider_id,
+            now(), now(), now()
+          FROM resolved r
+          ON CONFLICT (ts_date, source_product_id, price_type_id, finish_id, condition_id, language_id, data_provider_id)
+          DO UPDATE SET
+            sold_avg_cents = EXCLUDED.sold_avg_cents,
+            sold_count     = EXCLUDED.sold_count,
+            scraped_at     = EXCLUDED.scraped_at,
+            updated_at     = now()
+          RETURNING 1
+        )
+        SELECT count(*) INTO v_upserted FROM upserted;
+
+      -- delete only rows that resolved (same resolution logic) -- the card from store has been insert
+      WITH
+      src AS (
+        SELECT ps.source_id, ps.code, ps.name, ps.currency_code
+        FROM pricing.price_source ps
+      ),
+      fin AS (
+        SELECT cf.finish_id, cf.code
+        FROM pricing.card_finished cf
+      ),
+      cv AS (
+        SELECT
+          cei.value::uuid AS card_uuid,
+          cei.card_version_id
+        FROM card_catalog.card_external_identifier cei
+        JOIN card_catalog.card_identifier_ref cir
+          ON cir.card_identifier_ref_id = cei.card_identifier_ref_id
+        WHERE cir.identifier_name = 'mtgjson_id'
+      ),
+      prod AS (
+        SELECT
+          cv.card_version_id,
+          cv.card_uuid,
+          mcp.product_id
+        FROM cv
+        JOIN pricing.mtg_card_products mcp
+          ON mcp.card_version_id = cv.card_version_id
+      ),
+      staged AS (
+        SELECT
+          s.id,
+          s.price_source,
+          s.currency,
+          s.finish_type,
+          s.card_uuid,
+          s.price_type
+        FROM pricing.mtgjson_card_prices_staging s
+        WHERE s.price_date::date BETWEEN v_start AND v_end
+          AND s.price_date IS NOT NULL
+          AND s.card_uuid  IS NOT NULL
+          AND s.price_source IS NOT NULL
+          AND s.currency   IS NOT NULL
+          AND s.finish_type IS NOT NULL
+          AND s.price_value IS NOT NULL
+      ),
+      resolved_ids AS (
+        SELECT st.id
+        FROM staged st
+        JOIN pricing.transaction_type tt
+          ON tt.transaction_type_code = st.price_type
+        JOIN src
+          ON src.code = st.price_source AND src.currency_code = st.currency
+        JOIN fin
+          ON fin.code = st.finish_type
+        JOIN prod
+          ON prod.card_uuid::uuid = st.card_uuid::uuid --gere we want to find 
+        JOIN pricing.source_product sp
+          ON sp.product_id = prod.product_id
+         AND sp.source_id  = src.source_id
+      )
+      DELETE FROM pricing.mtgjson_card_prices_staging s
+      USING resolved_ids r
+      WHERE s.id = r.id;
+
+      GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+      v_total_upserted := v_total_upserted + coalesce(v_upserted, 0);
+      v_total_deleted  := v_total_deleted  + coalesce(v_deleted, 0);
+
+      v_is_ok := true;
+    EXCEPTION WHEN OTHERS THEN
+      v_is_ok := false;
+      RAISE;
+    END;
+
+    IF v_is_ok THEN
+      RAISE NOTICE 'Batch % to %: upserted %, deleted %',
+          v_start, v_end, v_upserted, v_deleted;
+      COMMIT;
+    END IF;
+    v_start := v_end + 1;
+  END LOOP;
+
+  RAISE NOTICE 'Done. Total upserted %, total deleted %', v_total_upserted, v_total_deleted;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

- MTG Finance Knowledge Base doc
- Superpowers plan files (migrations consolidation, eBay setup wizard, listings page, sold orders dashboard)
- SQL schema files 07–12 (online shop, Shopify staging, markets/prices, ops, MTGJson, staging)
- Migration `migration_25_fix2_fix3.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)