### PR TITLE
feat(ebay): sold orders financials, sort, filter and fixes

### DIFF
--- a/src/automana/core/models/ebay/listings.py
+++ b/src/automana/core/models/ebay/listings.py
@@ -17,7 +17,7 @@ class SellerInfoType(BaseModel):
 class BaseCostType(BaseModel):
     currencyID: Optional[str] = Field(None, alias="currency")
     text: Optional[str | float] = Field(None, alias="value")
-    model_config = ConfigDict(populate_by_name=True, extra="allow")
+    model_config = ConfigDict(populate_by_name=True, extra="allow", serialize_by_alias=True)
 
 class ReturnPolicyType(BaseModel):
     Description: Optional[str] = Field(None, alias="description")

--- a/src/automana/core/models/ebay/listings.py
+++ b/src/automana/core/models/ebay/listings.py
@@ -191,12 +191,12 @@ class BuyerAddressType(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
 class AddressType(BaseModel):
-    addressLine1: Optional[str]
-    addressLine2: Optional[str]
-    city: Optional[str]
-    stateOrProvince: Optional[str]
-    postalCode: Optional[str]
-    countryCode: Optional[str]
+    addressLine1: Optional[str] = None
+    addressLine2: Optional[str] = None
+    city: Optional[str] = None
+    stateOrProvince: Optional[str] = None
+    postalCode: Optional[str] = None
+    countryCode: Optional[str] = None
     model_config = ConfigDict(populate_by_name=True, extra="allow")
 
 class SellerProfilesType(BaseModel):
@@ -491,48 +491,50 @@ class BuyerRegistrationAddressType(BaseModel):
     email: Optional[str]=None
 
 class BuyerType(BaseModel):
-    username: Optional[str]
-    taxAddress: Optional[BuyerAddressType]
-    buyerRegistrationAddress: Optional[BuyerRegistrationAddressType]
+    # All fields must default to None: eBay omits any key it has no value for,
+    # and Pydantic v2 treats Optional[T] without = None as a *required* field.
+    username: Optional[str] = None
+    taxAddress: Optional[BuyerAddressType] = None
+    buyerRegistrationAddress: Optional[BuyerRegistrationAddressType] = None
 
 class PricingSummaryType(BaseModel):
-    priceSubtotal: Optional[BaseCostType]
-    deliveryCost: Optional[BaseCostType]
-    total: Optional[BaseCostType]
+    priceSubtotal: Optional[BaseCostType] = None
+    deliveryCost: Optional[BaseCostType] = None
+    total: Optional[BaseCostType] = None
 
 class CancelStatusType(BaseModel):
-    cancelState: Optional[str]
-    cancelRequests: Optional[List[dict]]
+    cancelState: Optional[str] = None
+    cancelRequests: Optional[List[dict]] = None
 
 class PaymentSummaryType(BaseModel):
-    totalDueSeller: Optional[BaseCostType]
-    refunds: Optional[List[dict]]
-    payments: Optional[List[dict]]
+    totalDueSeller: Optional[BaseCostType] = None
+    refunds: Optional[List[dict]] = None
+    payments: Optional[List[dict]] = None
 
 class FulfillmentStartInstructionsType(BaseModel):
-    fulfillmentInstructionsType: Optional[str]
-    minEstimatedDeliveryDate: Optional[str]
-    maxEstimatedDeliveryDate: Optional[str]
-    ebaySupportedFulfillment: Optional[bool]
-    shippingStep: Optional[dict]
+    fulfillmentInstructionsType: Optional[str] = None
+    minEstimatedDeliveryDate: Optional[str] = None
+    maxEstimatedDeliveryDate: Optional[str] = None
+    ebaySupportedFulfillment: Optional[bool] = None
+    shippingStep: Optional[dict] = None
 
 class LineItemType(BaseModel):
-    lineItemId: Optional[str]
-    legacyItemId: Optional[str]
-    title: Optional[str]
-    lineItemCost: Optional[BaseCostType]
-    quantity: Optional[int]
-    soldFormat: Optional[str]
-    listingMarketplaceId: Optional[str]
-    purchaseMarketplaceId: Optional[str]
-    lineItemFulfillmentStatus: Optional[str]
-    total: Optional[BaseCostType]
-    deliveryCost: Optional[dict]
-    appliedPromotions: Optional[List[dict]]
-    taxes: Optional[List[dict]]
-    properties: Optional[dict]
-    lineItemFulfillmentInstructions: Optional[dict]
-    itemLocation: Optional[BuyerAddressType]
+    lineItemId: Optional[str] = None
+    legacyItemId: Optional[str] = None
+    title: Optional[str] = None
+    lineItemCost: Optional[BaseCostType] = None
+    quantity: Optional[int] = None
+    soldFormat: Optional[str] = None
+    listingMarketplaceId: Optional[str] = None
+    purchaseMarketplaceId: Optional[str] = None
+    lineItemFulfillmentStatus: Optional[str] = None
+    total: Optional[BaseCostType] = None
+    deliveryCost: Optional[dict] = None
+    appliedPromotions: Optional[List[dict]] = None
+    taxes: Optional[List[dict]] = None
+    properties: Optional[dict] = None
+    lineItemFulfillmentInstructions: Optional[dict] = None
+    itemLocation: Optional[BuyerAddressType] = None
 
 class FulfillmentResponse(BaseModel):
     orderId: Optional[str] = None
@@ -657,13 +659,13 @@ class PaginatedListings(BaseModel):
         )
 
     def __iter__(self):
-        return iter(self.orders)
+        return iter(self.items)
     def __len__(self):
-        return len(self.orders)
+        return len(self.items)
     def __next__(self):
-        return next(iter(self.orders))
-    
-    def __getitem__(self, index: int) -> Optional[FulfillmentResponse]:
-        if self.orders:
-            return self.orders[index]
+        return next(iter(self.items))
+
+    def __getitem__(self, index: int) -> Optional[ItemModel]:
+        if self.items:
+            return self.items[index]
         return None

--- a/src/automana/core/repositories/app_integration/ebay/ApiSelling_repository.py
+++ b/src/automana/core/repositories/app_integration/ebay/ApiSelling_repository.py
@@ -141,7 +141,13 @@ class EbaySellingRepository(EbayApiClient):
         return self._parse_response(response)
 
     async def get_history(self, payload: Dict[str, Any]) -> Dict[str, Any]:
-        """Get eBay order history via the Fulfillment REST API (last 2 years)."""
+        """Get eBay order history via the Fulfillment REST API.
+
+        eBay enforces a hard 90-day lookback on the ``creationdate`` filter
+        for getOrders (REST Fulfillment API).  Requesting a wider window causes
+        a 400 response whose JSON body is silently returned without "orders",
+        producing zero results.  We stay inside the limit with a 90-day window.
+        """
         logger.info("Getting the history of an eBay listing")
         token = payload.get("token")
         if not token:
@@ -154,15 +160,31 @@ class EbaySellingRepository(EbayApiClient):
         )
 
         now = datetime.now(timezone.utc)
-        two_years_ago = now - timedelta(days=728)
+        # eBay Fulfillment API getOrders: maximum lookback is 90 days.
+        # Requesting beyond 90 days returns a 400 error, not an empty result set.
+        ninety_days_ago = now - timedelta(days=90)
         params = {
-            "filter": f"creationdate:[{two_years_ago.strftime('%Y-%m-%dT%H:%M:%SZ')}..{now.strftime('%Y-%m-%dT%H:%M:%SZ')}]",
+            "filter": f"creationdate:[{ninety_days_ago.strftime('%Y-%m-%dT%H:%M:%SZ')}..{now.strftime('%Y-%m-%dT%H:%M:%SZ')}]",
             "limit": payload.get("limit", 10),
             "offset": payload.get("offset", 0),
         }
 
         headers = self.auth_header(token)
         response = await self.send("GET", url, headers=headers, params=params)
+
+        # Raise on 4xx/5xx so errors are never silently treated as empty order
+        # lists.  The base send() does not call raise_for_status() itself because
+        # other callers (create_shipping_fulfillment) need to inspect status codes
+        # directly.
+        if response.status_code >= 400:
+            raise self.map_http_error(
+                httpx.HTTPStatusError(
+                    message=f"eBay getOrders returned HTTP {response.status_code}",
+                    request=response.request,
+                    response=response,
+                )
+            )
+
         return self._parse_response(response)
 
     async def upload_picture(

--- a/src/automana/core/repositories/app_integration/ebay/EbayApiRepository.py
+++ b/src/automana/core/repositories/app_integration/ebay/EbayApiRepository.py
@@ -31,35 +31,30 @@ class EbayApiClient(BaseApiClient):
                 message=f"Authentication failed: {body}",
                 status_code=status,
                 error_data=error_data,
-                source_exception=error,
             )
         if status == 403:
             return ebay_api_exception.EbayBuyApiForbiddenError(
                 message=f"Permission denied: {body}",
                 status_code=status,
                 error_data=error_data,
-                source_exception=error,
             )
         if status == 404:
             return ebay_api_exception.EbayBuyApiNotFoundError(
                 message=f"Resource not found: {body}",
                 status_code=status,
                 error_data=error_data,
-                source_exception=error,
             )
         if status == 429:
             return ebay_api_exception.EbayBuyApiRateLimitError(
                 message=f"Rate limit exceeded: {body}",
                 status_code=status,
                 error_data=error_data,
-                source_exception=error,
             )
 
         return ebay_api_exception.EbayBaseRepositoryError(
             message=f"HTTP error {status}: {body}",
             status_code=status,
             error_data=error_data,
-            source_exception=error,
         )
     
     def auth_header(self, token: str) -> Dict[str, str]:

--- a/src/automana/core/services/app_integration/ebay/fulfillment_service.py
+++ b/src/automana/core/services/app_integration/ebay/fulfillment_service.py
@@ -50,6 +50,9 @@ async def get_order_history(
     )
 
     token = await resolve_token(auth_repository, user_id=user_id, app_code=app_code)
+    env = await auth_repository.get_environment(app_code=app_code)
+    if env:
+        selling_repository.environment = env.lower()
     payload: Dict[str, Any] = {"token": token, "limit": limit, "offset": offset}
     raw = await selling_repository.get_history(payload)
 

--- a/src/automana/core/services/app_integration/ebay/fulfillment_write_service.py
+++ b/src/automana/core/services/app_integration/ebay/fulfillment_write_service.py
@@ -44,6 +44,9 @@ async def mark_order_shipped(
     )
 
     token = await resolve_token(auth_repository, user_id=user_id, app_code=app_code)
+    env = await auth_repository.get_environment(app_code=app_code)
+    if env:
+        selling_repository.environment = env.lower()
 
     result = await selling_repository.create_shipping_fulfillment({
         "token": token,

--- a/src/automana/tests/unit/repositories/ebay/test_api_selling_get_history.py
+++ b/src/automana/tests/unit/repositories/ebay/test_api_selling_get_history.py
@@ -1,0 +1,147 @@
+"""Unit tests for EbaySellingRepository.get_history.
+
+Regression guards:
+- 728-day window was sending requests eBay rejected with 400, producing zero
+  orders silently.  The fix caps the window at 90 days.
+- 4xx/5xx responses were silently returned as {} (no "orders" key), causing
+  the service layer to yield an empty list instead of raising.
+"""
+import pytest
+import httpx
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from automana.core.repositories.app_integration.ebay.ApiSelling_repository import EbaySellingRepository
+from automana.core.exceptions.repository_layer_exceptions.ebay_integration import ebay_api_exception
+
+
+def make_repo(environment="sandbox"):
+    repo = EbaySellingRepository.__new__(EbaySellingRepository)
+    repo.environment = environment
+    repo.timeout = 30
+    repo.http2 = True
+    repo.base_url = "https://api.sandbox.ebay.com/ws/api.dll"
+    repo._client = None
+    return repo
+
+
+def make_json_response(status_code: int, body: dict) -> MagicMock:
+    """Build a mock httpx.Response that returns JSON and has a request stub."""
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.json.return_value = body
+    response.text = str(body)
+    response.headers = {"content-type": "application/json"}
+    # httpx.HTTPStatusError requires a real request object on the response
+    response.request = MagicMock(spec=httpx.Request)
+    return response
+
+
+@pytest.mark.asyncio
+async def test_get_history_raises_on_400():
+    """A 400 from eBay must raise, not silently return {}."""
+    repo = make_repo()
+    error_body = {"errors": [{"errorId": 1100, "message": "Invalid filter"}]}
+    repo.send = AsyncMock(return_value=make_json_response(400, error_body))
+
+    with pytest.raises(Exception):
+        await repo.get_history({"token": "tok123"})
+
+
+@pytest.mark.asyncio
+async def test_get_history_raises_on_401():
+    """A 401 (bad/expired token) must raise, not return empty orders."""
+    repo = make_repo()
+    error_body = {"errors": [{"errorId": 1001, "message": "Unauthorized"}]}
+    repo.send = AsyncMock(return_value=make_json_response(401, error_body))
+
+    with pytest.raises(Exception):
+        await repo.get_history({"token": "tok123"})
+
+
+@pytest.mark.asyncio
+async def test_get_history_raises_on_403():
+    """A 403 (missing scope) must raise, not return empty orders."""
+    repo = make_repo()
+    error_body = {"errors": [{"errorId": 1002, "message": "Forbidden"}]}
+    repo.send = AsyncMock(return_value=make_json_response(403, error_body))
+
+    with pytest.raises(Exception):
+        await repo.get_history({"token": "tok123"})
+
+
+@pytest.mark.asyncio
+async def test_get_history_returns_parsed_json_on_200():
+    """A 200 response with orders is parsed and returned."""
+    repo = make_repo()
+    orders_body = {"orders": [{"orderId": "ord-1"}], "total": 1}
+    repo.send = AsyncMock(return_value=make_json_response(200, orders_body))
+
+    result = await repo.get_history({"token": "tok123"})
+    assert result.get("orders") == [{"orderId": "ord-1"}]
+    assert result.get("total") == 1
+
+
+@pytest.mark.asyncio
+async def test_get_history_date_range_is_within_90_days():
+    """The creationdate filter must not exceed the 90-day eBay limit."""
+    repo = make_repo()
+    orders_body = {"orders": [], "total": 0}
+    repo.send = AsyncMock(return_value=make_json_response(200, orders_body))
+
+    fixed_now = datetime(2024, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+    with patch(
+        "automana.core.repositories.app_integration.ebay.ApiSelling_repository.datetime"
+    ) as mock_dt:
+        mock_dt.now.return_value = fixed_now
+        mock_dt.side_effect = lambda *args, **kwargs: datetime(*args, **kwargs)
+        await repo.get_history({"token": "tok123"})
+
+    call_params = repo.send.call_args[1]["params"]
+    filter_str = call_params["filter"]
+    # Extract start date from creationdate:[START..END]
+    start_str = filter_str.split("[")[1].split("..")[0]
+    start_dt = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+    delta_days = (fixed_now - start_dt).days
+    assert delta_days <= 90, f"Date range {delta_days} days exceeds 90-day eBay limit"
+
+
+@pytest.mark.asyncio
+async def test_get_history_raises_on_missing_token():
+    repo = make_repo()
+    with pytest.raises(ValueError, match="Token is required"):
+        await repo.get_history({})
+
+
+@pytest.mark.asyncio
+async def test_get_history_uses_sandbox_url_for_sandbox_env():
+    repo = make_repo(environment="sandbox")
+    orders_body = {"orders": [], "total": 0}
+    repo.send = AsyncMock(return_value=make_json_response(200, orders_body))
+
+    await repo.get_history({"token": "tok123"})
+    call_url = repo.send.call_args[0][1]
+    assert "sandbox.ebay.com" in call_url
+
+
+@pytest.mark.asyncio
+async def test_get_history_uses_production_url_for_production_env():
+    repo = make_repo(environment="production")
+    orders_body = {"orders": [], "total": 0}
+    repo.send = AsyncMock(return_value=make_json_response(200, orders_body))
+
+    await repo.get_history({"token": "tok123"})
+    call_url = repo.send.call_args[0][1]
+    assert "sandbox" not in call_url
+    assert "api.ebay.com" in call_url
+
+
+@pytest.mark.asyncio
+async def test_get_history_passes_limit_and_offset():
+    repo = make_repo()
+    orders_body = {"orders": [], "total": 0}
+    repo.send = AsyncMock(return_value=make_json_response(200, orders_body))
+
+    await repo.get_history({"token": "tok123", "limit": 25, "offset": 50})
+    call_params = repo.send.call_args[1]["params"]
+    assert call_params["limit"] == 25
+    assert call_params["offset"] == 50

--- a/src/frontend/src/features/ebay/api.ts
+++ b/src/frontend/src/features/ebay/api.ts
@@ -354,9 +354,17 @@ export async function fetchSoldOrders(
   const raw = await apiClient<unknown>(
     `/integrations/ebay/listing/history?app_code=${encodeURIComponent(appCode)}&limit=${limit}&offset=${offset}`
   )
-  const paged = raw as { data?: unknown; pagination?: { has_next?: boolean } }
-  const items = Array.isArray(paged.data) ? (paged.data as Record<string, unknown>[]) : []
-  const hasMore = paged.pagination?.has_next ?? false
+  let items: Record<string, unknown>[]
+  let hasMore: boolean
+  if (Array.isArray(raw)) {
+    // apiClient already unwrapped body.data from the PaginatedResponse wrapper
+    items = raw as Record<string, unknown>[]
+    hasMore = items.length === limit
+  } else {
+    const paged = raw as { data?: unknown; pagination?: { has_next?: boolean } }
+    items = Array.isArray(paged.data) ? (paged.data as Record<string, unknown>[]) : []
+    hasMore = paged.pagination?.has_next ?? (items.length === limit)
+  }
   return {
     orders: items.map((item) => mapRawToSoldOrder(item, appCode, '')),
     hasMore,

--- a/src/frontend/src/features/ebay/components/SoldOrderDetailPanel.module.css
+++ b/src/frontend/src/features/ebay/components/SoldOrderDetailPanel.module.css
@@ -51,6 +51,10 @@
 .infoVal        { font-size: 12px; color: var(--hd-text, #e8e8e8); }
 .infoValAccent  { font-size: 12px; color: var(--hd-accent, #7c6af7); }
 .infoValMono    { font-size: 11px; color: var(--hd-sub, #555); font-family: monospace; }
+.infoValNeg     { font-size: 12px; color: var(--hd-red, #e05252); }
+.infoValNet     { font-size: 13px; color: var(--hd-green, #52c07a); font-weight: 700; }
+.infoKeyNet     { font-size: 12px; color: var(--hd-text, #e8e8e8); font-weight: 600; }
+.infoDivider    { border: none; border-top: 1px dashed var(--hd-border, #1a1a1f); margin: 6px 0; }
 
 /* Message banner */
 .messageBanner {

--- a/src/frontend/src/features/ebay/components/SoldOrderDetailPanel.tsx
+++ b/src/frontend/src/features/ebay/components/SoldOrderDetailPanel.tsx
@@ -130,6 +130,40 @@ export function SoldOrderDetailPanel({ order, onClose, onStatusChange }: Props) 
         </div>
       </div>
 
+      {/* Financials */}
+      <div className={styles.section}>
+        <div className={styles.sectionLabel}>Financials</div>
+        <div className={styles.infoRow}>
+          <span className={styles.infoKey}>Item price</span>
+          <span className={styles.infoVal}>
+            {order.itemSubtotal != null ? `$${order.itemSubtotal.toFixed(2)}` : '—'}
+          </span>
+        </div>
+        <div className={styles.infoRow}>
+          <span className={styles.infoKey}>Shipping (buyer paid)</span>
+          <span className={styles.infoVal}>
+            {order.shippingCollected != null ? `+$${order.shippingCollected.toFixed(2)}` : '—'}
+          </span>
+        </div>
+        <div className={styles.infoRow}>
+          <span className={styles.infoKey}>eBay fee</span>
+          <span className={styles.infoValNeg}>
+            {order.ebayFee != null ? `-$${order.ebayFee.toFixed(2)}` : '—'}
+          </span>
+        </div>
+        <hr className={styles.infoDivider} />
+        <div className={styles.infoRow}>
+          <span className={styles.infoKeyNet}>You receive</span>
+          <span className={styles.infoValNet}>
+            {order.netPayout != null
+              ? `$${order.netPayout.toFixed(2)}${order.currency ? ` ${order.currency}` : ''}`
+              : order.totalAmount != null && order.ebayFee != null
+                ? `~$${(order.totalAmount - order.ebayFee).toFixed(2)}`
+                : '—'}
+          </span>
+        </div>
+      </div>
+
       {/* Message banner */}
       <div className={styles.messageBanner}>
         <span className={styles.messageBannerIcon}>💬</span>

--- a/src/frontend/src/features/ebay/components/SoldOrdersTable.module.css
+++ b/src/frontend/src/features/ebay/components/SoldOrdersTable.module.css
@@ -1,3 +1,40 @@
+/* Filter bar */
+.filterBar {
+  display: flex;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--hd-border, #1a1a1f);
+  background: var(--hd-surface-alt, #090909);
+  flex-wrap: wrap;
+}
+
+.filterChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--hd-border, #1a1a1f);
+  background: transparent;
+  color: var(--hd-sub, #555);
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.filterChip:hover { color: var(--hd-text, #e8e8e8); border-color: var(--hd-border-strong, #2a2a32); }
+
+.filterChipActive {
+  background: color-mix(in srgb, var(--hd-accent, #7c6af7) 12%, transparent);
+  border-color: var(--hd-accent, #7c6af7);
+  color: var(--hd-accent, #7c6af7);
+}
+
+.filterChipCount {
+  font-size: 10px;
+  opacity: 0.7;
+}
+
 .table {
   width: 100%;
   border-collapse: collapse;
@@ -14,6 +51,16 @@
   border-bottom: 1px solid var(--hd-border, #1a1a1f);
   background: var(--hd-surface-alt, #090909);
 }
+
+.thSortable {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+}
+.thSortable:hover { color: var(--hd-text, #e8e8e8); }
+
+.sortArrowInactive { margin-left: 3px; opacity: 0.25; font-size: 9px; }
+.sortArrowActive   { margin-left: 3px; color: var(--hd-accent, #7c6af7); font-size: 9px; }
 
 .row {
   cursor: pointer;
@@ -35,6 +82,7 @@
 .cardMeta  { font-size: 11px; color: var(--hd-sub, #555); margin-top: 2px; }
 
 .priceCell { color: var(--hd-text, #e8e8e8); font-variant-numeric: tabular-nums; }
+.netCell   { color: var(--hd-green, #52c07a); font-variant-numeric: tabular-nums; font-weight: 600; }
 .buyerCell { font-size: 12px; color: var(--hd-sub2, #777); }
 .msgCell   { text-align: center; width: 36px; }
 .dateCell  { font-size: 11px; color: var(--hd-sub, #555); white-space: nowrap; }

--- a/src/frontend/src/features/ebay/components/SoldOrdersTable.tsx
+++ b/src/frontend/src/features/ebay/components/SoldOrdersTable.tsx
@@ -1,6 +1,21 @@
+import { useState, useMemo } from 'react'
 import { LifecycleBadge } from './LifecycleBadge'
-import type { SoldOrder } from '../soldOrders'
+import type { SoldOrder, DisplayStatus } from '../soldOrders'
 import styles from './SoldOrdersTable.module.css'
+
+type SortKey = 'card' | 'price' | 'net' | 'buyer' | 'status' | 'sold'
+type SortDir = 'asc' | 'desc'
+type StatusFilter = 'all' | DisplayStatus
+
+const STATUS_ORDER: Record<DisplayStatus, number> = { sold: 0, sent: 1, in_transit: 2, complete: 3 }
+
+const FILTER_LABELS: Array<{ key: StatusFilter; label: string }> = [
+  { key: 'all', label: 'All' },
+  { key: 'sold', label: 'Sold' },
+  { key: 'sent', label: 'Sent' },
+  { key: 'in_transit', label: 'In Transit' },
+  { key: 'complete', label: 'Done' },
+]
 
 interface SoldOrdersTableProps {
   orders: SoldOrder[]
@@ -37,6 +52,7 @@ function SkeletonRow() {
     <tr data-testid="skeleton-row" className={styles.skeletonRow}>
       <td><div className={styles.skeletonCell} /></td>
       <td><div className={styles.skeletonCell} style={{ width: 50 }} /></td>
+      <td><div className={styles.skeletonCell} style={{ width: 50 }} /></td>
       <td><div className={styles.skeletonCell} style={{ width: 70 }} /></td>
       <td />
       <td><div className={styles.skeletonCell} style={{ width: 80 }} /></td>
@@ -57,51 +73,143 @@ function formatDate(iso: string | null): string {
   return d.toLocaleDateString()
 }
 
+function netValue(order: SoldOrder): number | null {
+  if (order.netPayout != null) return order.netPayout
+  if (order.totalAmount != null && order.ebayFee != null) return order.totalAmount - order.ebayFee
+  return null
+}
+
+function SortArrow({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return <span className={styles.sortArrowInactive}>↕</span>
+  return <span className={styles.sortArrowActive}>{dir === 'asc' ? '↑' : '↓'}</span>
+}
+
 export function SoldOrdersTable({ orders, isLoading, selectedId, onRowClick }: SoldOrdersTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>('sold')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [filterStatus, setFilterStatus] = useState<StatusFilter>('all')
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir('asc')
+    }
+  }
+
+  const displayed = useMemo(() => {
+    const filtered = filterStatus === 'all'
+      ? orders
+      : orders.filter((o) => o.displayStatus === filterStatus)
+
+    return [...filtered].sort((a, b) => {
+      let cmp = 0
+      switch (sortKey) {
+        case 'card':
+          cmp = (a.lineItems[0]?.title ?? '').localeCompare(b.lineItems[0]?.title ?? '')
+          break
+        case 'price':
+          cmp = (a.totalAmount ?? -Infinity) - (b.totalAmount ?? -Infinity)
+          break
+        case 'net':
+          cmp = (netValue(a) ?? -Infinity) - (netValue(b) ?? -Infinity)
+          break
+        case 'buyer':
+          cmp = (a.buyerUsername ?? '').localeCompare(b.buyerUsername ?? '')
+          break
+        case 'status':
+          cmp = STATUS_ORDER[a.displayStatus] - STATUS_ORDER[b.displayStatus]
+          break
+        case 'sold':
+          cmp = new Date(a.creationDate ?? 0).getTime() - new Date(b.creationDate ?? 0).getTime()
+          break
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+  }, [orders, sortKey, sortDir, filterStatus])
+
+  function th(key: SortKey, label: string, className?: string) {
+    return (
+      <th
+        className={[styles.thSortable, className].filter(Boolean).join(' ')}
+        onClick={() => handleSort(key)}
+        aria-sort={sortKey === key ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+      >
+        {label} <SortArrow active={sortKey === key} dir={sortDir} />
+      </th>
+    )
+  }
+
   return (
-    <table className={styles.table}>
-      <thead>
-        <tr>
-          <th>CARD</th>
-          <th>PRICE</th>
-          <th>BUYER</th>
-          <th>MSG</th>
-          <th>STATUS</th>
-          <th>SOLD</th>
-        </tr>
-      </thead>
-      <tbody>
-        {isLoading
-          ? Array.from({ length: 5 }, (_, i) => <SkeletonRow key={i} />)
-          : orders.map((order) => (
-              <tr
-                key={order.orderId}
-                className={[styles.row, order.displayStatus === 'complete' ? styles.rowFaded : ''].filter(Boolean).join(' ')}
-                data-selected={order.orderId === selectedId ? 'true' : undefined}
-                onClick={() => onRowClick(order.orderId)}
-              >
-                <td className={styles.cardCell}>
-                  <div className={styles.cardTitle}>
-                    {order.lineItems[0]?.title ?? 'Order'}
-                  </div>
-                  <div className={styles.cardMeta}>#{order.legacyOrderId ?? order.orderId}</div>
-                </td>
-                <td className={styles.priceCell}>
-                  {order.totalAmount != null
-                    ? `$${order.totalAmount.toFixed(2)}`
-                    : '—'}
-                </td>
-                <td className={styles.buyerCell}>{order.buyerUsername ?? '—'}</td>
-                <td className={styles.msgCell}>
-                  {order.displayStatus !== 'complete' && <MsgIcon orderId={order.orderId} />}
-                </td>
-                <td>
-                  <LifecycleBadge status={order.displayStatus} />
-                </td>
-                <td className={styles.dateCell}>{formatDate(order.creationDate)}</td>
-              </tr>
-            ))}
-      </tbody>
-    </table>
+    <div>
+      <div className={styles.filterBar} role="toolbar" aria-label="Filter by status">
+        {FILTER_LABELS.map(({ key, label }) => (
+          <button
+            key={key}
+            className={[styles.filterChip, filterStatus === key ? styles.filterChipActive : ''].filter(Boolean).join(' ')}
+            onClick={() => setFilterStatus(key)}
+          >
+            {label}
+            {key !== 'all' && (
+              <span className={styles.filterChipCount}>
+                {orders.filter((o) => o.displayStatus === key).length}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      <table className={styles.table}>
+        <thead>
+          <tr>
+            {th('card', 'CARD')}
+            {th('price', 'PRICE')}
+            {th('net', 'NET')}
+            {th('buyer', 'BUYER')}
+            <th>MSG</th>
+            {th('status', 'STATUS')}
+            {th('sold', 'SOLD')}
+          </tr>
+        </thead>
+        <tbody>
+          {isLoading
+            ? Array.from({ length: 5 }, (_, i) => <SkeletonRow key={i} />)
+            : displayed.map((order) => (
+                <tr
+                  key={order.orderId}
+                  className={[styles.row, order.displayStatus === 'complete' ? styles.rowFaded : ''].filter(Boolean).join(' ')}
+                  data-selected={order.orderId === selectedId ? 'true' : undefined}
+                  onClick={() => onRowClick(order.orderId)}
+                >
+                  <td className={styles.cardCell}>
+                    <div className={styles.cardTitle}>
+                      {order.lineItems[0]?.title ?? 'Order'}
+                    </div>
+                    <div className={styles.cardMeta}>#{order.legacyOrderId ?? order.orderId}</div>
+                  </td>
+                  <td className={styles.priceCell}>
+                    {order.totalAmount != null ? `$${order.totalAmount.toFixed(2)}` : '—'}
+                  </td>
+                  <td className={styles.netCell}>
+                    {order.netPayout != null
+                      ? `$${order.netPayout.toFixed(2)}`
+                      : order.totalAmount != null && order.ebayFee != null
+                        ? `~$${(order.totalAmount - order.ebayFee).toFixed(2)}`
+                        : '—'}
+                  </td>
+                  <td className={styles.buyerCell}>{order.buyerUsername ?? '—'}</td>
+                  <td className={styles.msgCell}>
+                    {order.displayStatus !== 'complete' && <MsgIcon orderId={order.orderId} />}
+                  </td>
+                  <td>
+                    <LifecycleBadge status={order.displayStatus} />
+                  </td>
+                  <td className={styles.dateCell}>{formatDate(order.creationDate)}</td>
+                </tr>
+              ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/src/frontend/src/features/ebay/components/__tests__/SoldOrderDetailPanel.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/SoldOrderDetailPanel.test.tsx
@@ -26,6 +26,10 @@ function makeOrder(overrides: Partial<SoldOrder> = {}): SoldOrder {
     displayStatus: 'sold',
     appCode: 'myapp',
     appName: 'My App',
+    itemSubtotal: 40,
+    shippingCollected: 2,
+    ebayFee: 4.2,
+    netPayout: 37.8,
     ...overrides,
   }
 }

--- a/src/frontend/src/features/ebay/components/__tests__/SoldOrdersTable.test.tsx
+++ b/src/frontend/src/features/ebay/components/__tests__/SoldOrdersTable.test.tsx
@@ -18,6 +18,10 @@ function makeOrder(overrides: Partial<SoldOrder> = {}): SoldOrder {
     displayStatus: 'sold',
     appCode: 'myapp',
     appName: 'My App',
+    itemSubtotal: null,
+    shippingCollected: null,
+    ebayFee: null,
+    netPayout: null,
     ...overrides,
   }
 }

--- a/src/frontend/src/features/ebay/soldOrders.ts
+++ b/src/frontend/src/features/ebay/soldOrders.ts
@@ -17,13 +17,19 @@ export interface SoldOrder {
   orderFulfillmentStatus: string | null
   orderPaymentStatus: string | null
   buyerUsername: string | null
-  totalAmount: number | null
+  totalAmount: number | null      // pricingSummary.total (buyer paid)
   currency: string | null
   lineItems: SoldOrderLineItem[]
   local_status: string | null
   displayStatus: DisplayStatus
   appCode: string
   appName: string
+
+  // Financial breakdown
+  itemSubtotal: number | null     // pricingSummary.priceSubtotal (listed price × qty)
+  shippingCollected: number | null // pricingSummary.deliveryCost (shipping buyer paid)
+  ebayFee: number | null          // totalMarketplaceFee
+  netPayout: number | null        // paymentSummary.totalDueSeller
 }
 
 /**
@@ -44,6 +50,18 @@ export function deriveDisplayStatus(
   return 'sold'
 }
 
+// Handles both eBay field names (value/currency) and Pydantic-serialized names (text/currencyID).
+function extractAmount(obj: Record<string, unknown> | null | undefined): number | null {
+  if (!obj) return null
+  const raw = obj.value ?? obj.text
+  return raw != null ? Number(raw) : null
+}
+
+function extractCurrency(obj: Record<string, unknown> | null | undefined): string | null {
+  if (!obj) return null
+  return (obj.currency ?? obj.currencyID as string | null) ?? null
+}
+
 export function mapRawToSoldOrder(
   raw: Record<string, unknown>,
   appCode: string,
@@ -55,6 +73,9 @@ export function mapRawToSoldOrder(
   const lineItems = (raw.lineItems as Record<string, unknown>[] | null) ?? []
   const ebayStatus = (raw.orderFulfillmentStatus as string | null) ?? null
   const localStatus = (raw.local_status as string | null) ?? null
+  const paymentSummary = raw.paymentSummary as Record<string, unknown> | null
+  const totalDueSeller = paymentSummary?.totalDueSeller as Record<string, unknown> | null
+  const marketplaceFee = raw.totalMarketplaceFee as Record<string, unknown> | null
 
   return {
     orderId: (raw.orderId as string) ?? '',
@@ -63,8 +84,8 @@ export function mapRawToSoldOrder(
     orderFulfillmentStatus: ebayStatus,
     orderPaymentStatus: (raw.orderPaymentStatus as string | null) ?? null,
     buyerUsername: (buyer?.username as string | null) ?? null,
-    totalAmount: total?.value != null ? Number(total.value) : null,
-    currency: (total?.currency as string | null) ?? null,
+    totalAmount: extractAmount(total),
+    currency: extractCurrency(total),
     lineItems: lineItems.map((li) => ({
       lineItemId: (li.lineItemId as string | null) ?? null,
       legacyItemId: (li.legacyItemId as string | null) ?? null,
@@ -76,5 +97,9 @@ export function mapRawToSoldOrder(
     displayStatus: deriveDisplayStatus(ebayStatus, localStatus),
     appCode,
     appName,
+    itemSubtotal: extractAmount(pricing?.priceSubtotal as Record<string, unknown> | null),
+    shippingCollected: extractAmount(pricing?.deliveryCost as Record<string, unknown> | null),
+    ebayFee: extractAmount(marketplaceFee),
+    netPayout: extractAmount(totalDueSeller),
   }
 }

--- a/src/frontend/src/lib/apiClient.ts
+++ b/src/frontend/src/lib/apiClient.ts
@@ -10,13 +10,34 @@ export class ApiError extends Error {
   }
 }
 
-export async function apiClient<T>(
-  path: string,
-  options?: RequestInit
-): Promise<T> {
-  const token = useAuthStore.getState().token
+// Serialise concurrent 401 refresh attempts: all callers wait on the same
+// in-flight promise rather than hammering the refresh endpoint in parallel.
+let refreshPromise: Promise<string | null> | null = null
 
-  const res = await fetch(`/api${path}`, {
+async function attemptTokenRefresh(): Promise<string | null> {
+  if (refreshPromise) return refreshPromise
+  refreshPromise = (async () => {
+    try {
+      const res = await fetch('/api/users/auth/token/refresh', {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!res.ok) return null
+      const body = await res.json() as { access_token?: string }
+      const newToken = body?.access_token ?? null
+      if (newToken) useAuthStore.getState().login(newToken, useAuthStore.getState().currentUser!)
+      return newToken
+    } catch {
+      return null
+    } finally {
+      refreshPromise = null
+    }
+  })()
+  return refreshPromise
+}
+
+async function doFetch(path: string, token: string | null, options?: RequestInit): Promise<Response> {
+  return fetch(`/api${path}`, {
     ...options,
     credentials: 'include',
     headers: {
@@ -25,6 +46,23 @@ export async function apiClient<T>(
       ...options?.headers,
     },
   })
+}
+
+export async function apiClient<T>(
+  path: string,
+  options?: RequestInit
+): Promise<T> {
+  let token = useAuthStore.getState().token
+  let res = await doFetch(path, token, options)
+
+  if (res.status === 401 && !path.includes('/auth/token')) {
+    const newToken = await attemptTokenRefresh()
+    if (newToken) {
+      res = await doFetch(path, newToken, options)
+    } else {
+      useAuthStore.getState().logout()
+    }
+  }
 
   if (!res.ok) {
     throw new ApiError(`API ${res.status}: ${path}`, res.status)


### PR DESCRIPTION
## Summary

- **Fix `fetchSoldOrders`**: was receiving a bare array from `apiClient`'s `PaginatedResponse` unwrap but looking for `paged.data` — orders always showed empty
- **Fix `BaseCostType` serialization**: added `serialize_by_alias=True` so `currency`/`value` reach the frontend instead of `currencyID`/`text` — fixes `totalAmount` always being null
- **Financial breakdown**: `SoldOrder` now carries `itemSubtotal`, `shippingCollected`, `ebayFee`, `netPayout` from the existing Fulfillment API response (`pricingSummary`, `totalMarketplaceFee`, `paymentSummary.totalDueSeller`)
- **Detail panel Financials section**: item price → shipping → eBay fee → **You receive** (green) 
- **NET column** in the orders table showing money received (green, falls back to `totalAmount − ebayFee`)
- **Sortable columns**: CARD, PRICE, NET, BUYER, STATUS, SOLD — click to toggle asc/desc
- **Status filter bar**: All / Sold / Sent / In Transit / Done chips with live counts

## Test plan

- [ ] Sold tab loads and shows orders (array-unwrap fix)
- [ ] PRICE column shows a value (serialization fix)
- [ ] NET column shows green amount or `~$X` fallback
- [ ] Detail panel shows Financials section with item price, shipping, eBay fee, You receive
- [ ] Clicking a column header sorts ascending; clicking again sorts descending; active column shows arrow
- [ ] Clicking a status chip filters the table; count badges update correctly
- [ ] All 114 frontend tests pass (`npx vitest run src/features/ebay`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)