### PR TITLE
fix(card_catalog): exclude digital cards from search and suggest by default

### DIFF
--- a/src/automana/api/dependancies/query_deps.py
+++ b/src/automana/api/dependancies/query_deps.py
@@ -99,7 +99,7 @@ async def card_search_params(
     toughness: Optional[int] = Query(None, ge=0, description="Filter by toughness"),
     flavor_text: Optional[str] = Query(None, description="Filter by flavor text"),
     card_faces: Optional[List[UUID]] = Query(None, description="Filter by card faces"),
-    digital: Optional[bool] = Query(None, description="Filter by digital status"),
+    digital: bool = Query(False, description="Filter by digital status (default excludes MTGO/Arena-only cards)"),
     oracle_text: Optional[str] = Query(None, description="Filter by oracle text (full-text search)"),
     format: Optional[str] = Query(None, description="Filter by format legality (e.g. 'standard', 'modern')"),
     layout: Optional[str] = Query(None, description="Filter by layout type (e.g. 'normal', 'token', 'saga')"),

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -108,6 +108,7 @@ class CardReferenceRepository(AbstractRepository[Any]):
             LEFT JOIN card_catalog.card_external_identifier cei
                 ON cei.card_version_id = v.card_version_id AND cei.card_identifier_ref_id = 1
             WHERE $1 % v.card_name
+              AND cv.is_digital = false
             ORDER BY score DESC
             LIMIT $2
         """


### PR DESCRIPTION
# Summary

MTGO and Arena-only cards (`is_digital = true`) were leaking into all card search and autocomplete results. The digital filter in `card_search_params` defaulted to `None` (no SQL constraint applied), and the `suggest()` query had no filter at all. This fix makes paper-only the server-side default for both endpoints.

---

# Changes Introduced

- `query_deps.py`: `digital` param changed from `Optional[bool] = None` to `bool = False` — now always passes a concrete `False` to the repository, triggering the `AND v.is_digital = false` predicate on every default search
- `card_repository.py` (`suggest()`): added `AND cv.is_digital = false` to the autocomplete SQL — digital cards can no longer appear in typeahead results

Callers can still explicitly pass `?digital=true` to request digital-only results.

---

# How to Test

1. `GET /card-reference/?q=island` — verify no MTGO/Arena-only printings appear
2. `GET /card-reference/suggest?q=island` — verify suggest results are paper only
3. `GET /card-reference/?digital=true` — verify digital-only cards are still accessible when explicitly requested

---

# Acceptance Checklist
- [x] Code compiles without errors
- [x] No debug logs left behind
- [x] Follows project coding standards
- [x] Ready for review

🤖 Generated with [Claude Code](https://claude.com/claude-code)