### PR TITLE
feat(card_catalog): finish selector on card detail page

### DIFF
--- a/docs/superpowers/plans/2026-05-10-finish-selector.md
+++ b/docs/superpowers/plans/2026-05-10-finish-selector.md
@@ -1,0 +1,721 @@
+# Finish Selector — Card Detail Page Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface the available finishes (nonfoil / foil / etched) for a card version on the detail page, letting users switch between them and have the price chart re-fetch for the selected finish.
+
+**Architecture:** The backend `card_repository.get()` query gains a correlated subquery that reads `card_version_finish` and returns `available_finishes: list[str]`. The `CardDetail` Pydantic model exposes the field. On the frontend, `CardDetailView` holds `selectedFinish` state and renders clickable finish chips; `PriceCharts` accepts a `finish` prop and forwards it to the price-history query.
+
+**Tech Stack:** Python / asyncpg / Pydantic v2 (backend); React 18, TypeScript, TanStack Query, Vitest, MSW (frontend)
+
+---
+
+## File Map
+
+| File | Action | What changes |
+|------|--------|-------------|
+| `src/automana/core/repositories/card_catalog/card_repository.py` | Modify | `get()` adds correlated subquery for `available_finishes` |
+| `src/automana/core/models/card_catalog/card.py` | Modify | `CardDetail` gets `available_finishes: Optional[List[str]]` |
+| `src/frontend/src/features/cards/types.ts` | Modify | `CardDetail` interface gets `available_finishes?: string[]` |
+| `src/frontend/src/mocks/data.ts` | Modify | `MOCK_CARD_DETAIL` entries get `available_finishes` |
+| `src/frontend/src/features/cards/components/PriceCharts.tsx` | Modify | Accept `finish?: string`, pass to query |
+| `src/frontend/src/features/cards/components/CardDetailView.tsx` | Modify | `selectedFinish` state + dynamic chip row |
+| `tests/unit/core/repositories/card_catalog/test_card_repository_get.py` | Create | Unit tests for `get()` returning `available_finishes` |
+| `tests/unit/core/models/card_catalog/test_card_detail_model.py` | Create | Unit tests for `CardDetail` `available_finishes` field |
+| `src/frontend/src/features/cards/components/__tests__/PriceCharts.test.tsx` | Create | Tests `finish` prop reaches the query |
+| `src/frontend/src/features/cards/components/__tests__/CardDetailView.test.tsx` | Create | Tests chip rendering and finish selection |
+
+---
+
+## Task 1: Backend — `card_repository.get()` returns `available_finishes`
+
+**Files:**
+- Modify: `src/automana/core/repositories/card_catalog/card_repository.py:82-97`
+- Create: `tests/unit/core/repositories/card_catalog/test_card_repository_get.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/unit/core/repositories/card_catalog/test_card_repository_get.py
+"""Unit tests for CardReferenceRepository.get()"""
+import pytest
+from unittest.mock import AsyncMock
+from uuid import UUID
+from automana.core.repositories.card_catalog.card_repository import CardReferenceRepository
+
+pytestmark = pytest.mark.unit
+
+_CARD_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+_BASE_ROW = {
+    "card_version_id": str(_CARD_ID),
+    "card_name": "Sheoldred",
+    "rarity_name": "rare",
+    "set_name": "March of the Machine",
+    "set_code": "mom",
+    "cmc": 4,
+    "oracle_text": "...",
+    "released_at": "2023-04-21",
+    "digital": False,
+    "image_large": None,
+}
+
+
+def _make_repo(rows):
+    repo = CardReferenceRepository.__new__(CardReferenceRepository)
+    repo.execute_query = AsyncMock(return_value=rows)
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_get_returns_available_finishes():
+    row = {**_BASE_ROW, "available_finishes": ["nonfoil", "foil"]}
+    repo = _make_repo([row])
+    result = await repo.get(card_id=_CARD_ID)
+    assert result["available_finishes"] == ["nonfoil", "foil"]
+
+
+@pytest.mark.asyncio
+async def test_get_returns_empty_list_when_no_finish_rows():
+    row = {**_BASE_ROW, "available_finishes": []}
+    repo = _make_repo([row])
+    result = await repo.get(card_id=_CARD_ID)
+    assert result["available_finishes"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_when_card_not_found():
+    repo = _make_repo([])
+    result = await repo.get(card_id=UUID("00000000-0000-0000-0000-000000000000"))
+    assert result is None
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+pytest tests/unit/core/repositories/card_catalog/test_card_repository_get.py -v
+```
+
+Expected: `KeyError: 'available_finishes'` on the first two tests (field not in query yet); third passes.
+
+- [ ] **Step 3: Add correlated subquery to `get()`**
+
+In `card_repository.py`, replace the `get()` query string (currently ends at `WHERE cv.card_version_id = $1;`) with:
+
+```python
+    async def get(self,
+                  card_id: UUID,
+                 ) -> dict[str, Any]|None:
+        query = """
+            SELECT
+                cv.card_version_id,
+                uc.card_name,
+                r.rarity_name,
+                s.set_name,
+                s.set_code,
+                uc.cmc,
+                cv.oracle_text,
+                s.released_at,
+                s.digital,
+                cvi.image_uris->>'large' AS image_large,
+                ARRAY(
+                    SELECT LOWER(cf.code)
+                    FROM card_catalog.card_version_finish cvf
+                    JOIN card_catalog.card_finished cf ON cf.finish_id = cvf.finish_id
+                    WHERE cvf.card_version_id = cv.card_version_id
+                ) AS available_finishes
+            FROM card_catalog.unique_cards_ref uc
+            JOIN card_catalog.card_version cv ON uc.unique_card_id = cv.unique_card_id
+            JOIN card_catalog.rarities_ref r ON cv.rarity_id = r.rarity_id
+            JOIN card_catalog.sets s ON cv.set_id = s.set_id
+            LEFT JOIN card_catalog.card_version_illustration cvi
+                ON cvi.card_version_id = cv.card_version_id
+            WHERE cv.card_version_id = $1;
+        """
+        result = await self.execute_query(query, (card_id,))
+        return result[0] if result else None
+```
+
+- [ ] **Step 4: Run tests — expect all pass**
+
+```bash
+pytest tests/unit/core/repositories/card_catalog/test_card_repository_get.py -v
+```
+
+Expected: `3 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/core/repositories/card_catalog/test_card_repository_get.py \
+        src/automana/core/repositories/card_catalog/card_repository.py
+git commit -m "feat(card_catalog): return available_finishes from card_repository.get()"
+```
+
+---
+
+## Task 2: Backend — `CardDetail` model field
+
+**Files:**
+- Modify: `src/automana/core/models/card_catalog/card.py:36-45`
+- Create: `tests/unit/core/models/card_catalog/test_card_detail_model.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# tests/unit/core/models/card_catalog/test_card_detail_model.py
+"""Unit tests for CardDetail.available_finishes field."""
+import pytest
+from automana.core.models.card_catalog.card import CardDetail
+
+pytestmark = pytest.mark.unit
+
+_BASE = {
+    "card_name": "Sheoldred",
+    "set_name": "March of the Machine",
+    "set_code": "mom",
+    "cmc": 4,
+    "rarity_name": "rare",
+    "oracle_text": "",
+    "digital": False,
+    "image_normal": None,
+}
+
+
+def test_card_detail_available_finishes_populated():
+    card = CardDetail.model_validate({**_BASE, "available_finishes": ["nonfoil", "foil"]})
+    assert card.available_finishes == ["nonfoil", "foil"]
+
+
+def test_card_detail_available_finishes_defaults_to_empty_list():
+    card = CardDetail.model_validate(_BASE)
+    assert card.available_finishes == []
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+pytest tests/unit/core/models/card_catalog/test_card_detail_model.py -v
+```
+
+Expected: `ValidationError` or `AttributeError` — field doesn't exist yet.
+
+- [ ] **Step 3: Add field to `CardDetail`**
+
+In `card.py`, update the `CardDetail` class (currently at line ~36):
+
+```python
+class CardDetail(BaseCard):
+    image_large: Optional[str] = Field(default=None, title="URL to large-sized card image from Scryfall")
+    available_finishes: Optional[List[str]] = Field(default_factory=list)
+    price_history_list_avg: Optional[List[float]] = Field(
+        default=None,
+        title="Daily list average prices in dollars for selected time range"
+    )
+    price_history_sold_avg: Optional[List[float]] = Field(
+        default=None,
+        title="Daily sold average prices in dollars for selected time range"
+    )
+```
+
+- [ ] **Step 4: Run tests — expect all pass**
+
+```bash
+pytest tests/unit/core/models/card_catalog/test_card_detail_model.py -v
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 5: Run full backend unit suite to check for regressions**
+
+```bash
+pytest tests/unit/ -v --tb=short
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/unit/core/models/card_catalog/test_card_detail_model.py \
+        src/automana/core/models/card_catalog/card.py
+git commit -m "feat(card_catalog): add available_finishes field to CardDetail model"
+```
+
+---
+
+## Task 3: Frontend — TypeScript types and mock data
+
+**Files:**
+- Modify: `src/frontend/src/features/cards/types.ts`
+- Modify: `src/frontend/src/mocks/data.ts`
+
+No separate test file — TypeScript compilation is the gate. The mock data update keeps existing tests type-correct.
+
+- [ ] **Step 1: Add `available_finishes` to `CardDetail` interface**
+
+In `types.ts`, update the `CardDetail` interface:
+
+```typescript
+export interface CardDetail extends CardSummary {
+  mana_cost?: string
+  type_line?: string
+  oracle_text?: string
+  artist?: string
+  price_history?: number[]
+  prints?: CardPrint[]
+  image_large?: string | null
+  price_history_list_avg?: number[]
+  price_history_sold_avg?: number[]
+  available_finishes?: string[]
+}
+```
+
+- [ ] **Step 2: Add `available_finishes` to `MOCK_CARD_DETAIL`**
+
+In `src/frontend/src/mocks/data.ts`, update the `'ragavan-mh2'` entry (and any other entries) to include `available_finishes`. Since `CardPrint` has a `set_code` field that doesn't exist in its type definition — use the existing `prints` data as a guide and add the new field:
+
+```typescript
+export const MOCK_CARD_DETAIL: Record<string, CardDetail> = {
+  'ragavan-mh2': {
+    ...MOCK_CARDS[0],
+    available_finishes: ['nonfoil', 'foil', 'etched'],
+    mana_cost: '{R}',
+    type_line: 'Legendary Creature — Monkey Pirate',
+    oracle_text: "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token and exile the top card of that player's library. Until end of turn, you may cast that card.\nDash {R}",
+    artist: 'Simon Dominic',
+    price_history: makeSpark(50, 84.5, 365),
+    prints: [
+      { id: 'ragavan-mh2-foil',   set: 'MH2', set_name: 'Modern Horizons 2', finish: 'foil',     price: 110.0, image_uri: null },
+      { id: 'ragavan-mh2-etched', set: 'MH2', set_name: 'Modern Horizons 2', finish: 'etched',   price: 95.0,  image_uri: null },
+      { id: 'ragavan-mh2-retro',  set: 'MH2', set_name: 'Modern Horizons 2', finish: 'non-foil', price: 88.0,  image_uri: null },
+    ],
+  },
+}
+```
+
+- [ ] **Step 3: Check TypeScript compiles cleanly**
+
+```bash
+cd src/frontend && npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/frontend/src/features/cards/types.ts \
+        src/frontend/src/mocks/data.ts
+git commit -m "feat(frontend): add available_finishes to CardDetail type and mock data"
+```
+
+---
+
+## Task 4: Frontend — `PriceCharts` accepts `finish` prop
+
+**Files:**
+- Modify: `src/frontend/src/features/cards/components/PriceCharts.tsx`
+- Create: `src/frontend/src/features/cards/components/__tests__/PriceCharts.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// src/frontend/src/features/cards/components/__tests__/PriceCharts.test.tsx
+import { describe, it, expect } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../../../mocks/server'
+import { PriceCharts } from '../PriceCharts'
+import type { CardDetail } from '../../types'
+
+const mockCard: CardDetail = {
+  card_version_id: '11111111-1111-1111-1111-111111111111',
+  card_name: 'Sheoldred',
+  set_code: 'mom',
+  set_name: 'March of the Machine',
+  finish: 'non-foil',
+  rarity_name: 'rare',
+  price_change_1d: 0,
+  price_change_7d: 0,
+  price_change_30d: 0,
+  image_uri: null,
+  spark: [],
+  available_finishes: ['nonfoil', 'foil'],
+}
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+)
+
+describe('PriceCharts', () => {
+  it('sends finish query param when finish prop is provided', async () => {
+    let capturedFinish: string | null = null
+
+    server.use(
+      http.get('/api/catalog/mtg/card-reference/:id/price-history', ({ request }) => {
+        capturedFinish = new URL(request.url).searchParams.get('finish')
+        return HttpResponse.json({
+          data: { price_history_list_avg: [], price_history_sold_avg: [] },
+        })
+      })
+    )
+
+    render(<PriceCharts card={mockCard} finish="foil" />, { wrapper: Wrapper })
+
+    await waitFor(() => expect(capturedFinish).toBe('foil'))
+  })
+
+  it('omits finish query param when no finish prop is provided', async () => {
+    let capturedFinish: string | null = 'sentinel'
+
+    server.use(
+      http.get('/api/catalog/mtg/card-reference/:id/price-history', ({ request }) => {
+        capturedFinish = new URL(request.url).searchParams.get('finish')
+        return HttpResponse.json({
+          data: { price_history_list_avg: [], price_history_sold_avg: [] },
+        })
+      })
+    )
+
+    render(<PriceCharts card={mockCard} />, { wrapper: Wrapper })
+
+    await waitFor(() => expect(capturedFinish).toBeNull())
+  })
+})
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```bash
+cd src/frontend && npx vitest run --reporter=verbose src/features/cards/components/__tests__/PriceCharts.test.tsx
+```
+
+Expected: TypeScript error — `PriceCharts` doesn't accept `finish` prop yet.
+
+- [ ] **Step 3: Add `finish` prop to `PriceCharts`**
+
+Replace the `PriceChartsProps` interface and the `useQuery` call in `PriceCharts.tsx`:
+
+```typescript
+interface PriceChartsProps {
+  card: CardDetail
+  finish?: string
+}
+
+export function PriceCharts({ card, finish }: PriceChartsProps) {
+  const [selectedRange, setSelectedRange] = useState<'1w' | '1m' | '3m' | '1y' | 'all'>('all')
+
+  const { data: priceData, isLoading } = useQuery(
+    cardPriceHistoryQueryOptions(card.card_version_id, selectedRange, finish)
+  )
+  // ... rest of function body unchanged
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+cd src/frontend && npx vitest run --reporter=verbose src/features/cards/components/__tests__/PriceCharts.test.tsx
+```
+
+Expected: `2 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/frontend/src/features/cards/components/PriceCharts.tsx \
+        src/frontend/src/features/cards/components/__tests__/PriceCharts.test.tsx
+git commit -m "feat(frontend): PriceCharts accepts finish prop and forwards to price-history query"
+```
+
+---
+
+## Task 5: Frontend — `CardDetailView` finish chip row
+
+**Files:**
+- Modify: `src/frontend/src/features/cards/components/CardDetailView.tsx`
+- Create: `src/frontend/src/features/cards/components/__tests__/CardDetailView.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// src/frontend/src/features/cards/components/__tests__/CardDetailView.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CardDetailView } from '../CardDetailView'
+import type { CardDetail } from '../../types'
+
+vi.mock('../PriceCharts', () => ({
+  PriceCharts: ({ finish }: { finish?: string }) => (
+    <div data-testid="price-charts" data-finish={finish ?? ''} />
+  ),
+}))
+vi.mock('../../../../components/design-system/CardArt', () => ({
+  CardArt: () => <div />,
+}))
+vi.mock('../../../../components/design-system/AreaChart', () => ({
+  AreaChart: () => <div />,
+}))
+vi.mock('../../../../components/design-system/Pip', () => ({
+  Pip: () => <span />,
+}))
+
+const mockCard: CardDetail = {
+  card_version_id: '11111111-1111-1111-1111-111111111111',
+  card_name: 'Sheoldred',
+  set_code: 'mom',
+  set_name: 'March of the Machine',
+  finish: 'non-foil',
+  rarity_name: 'rare',
+  price: 42.5,
+  price_change_1d: 1.2,
+  price_change_7d: -0.5,
+  price_change_30d: 3.1,
+  image_uri: null,
+  spark: [],
+  available_finishes: ['nonfoil', 'foil'],
+}
+
+describe('CardDetailView', () => {
+  it('renders a chip for each available finish', () => {
+    render(<CardDetailView card={mockCard} />)
+    expect(screen.getByText('nonfoil')).toBeTruthy()
+    expect(screen.getByText('foil')).toBeTruthy()
+  })
+
+  it('defaults selected finish to first available finish', () => {
+    render(<CardDetailView card={mockCard} />)
+    expect(screen.getByTestId('price-charts').dataset.finish).toBe('nonfoil')
+  })
+
+  it('updates selected finish and passes it to PriceCharts when chip clicked', () => {
+    render(<CardDetailView card={mockCard} />)
+    fireEvent.click(screen.getByText('foil'))
+    expect(screen.getByTestId('price-charts').dataset.finish).toBe('foil')
+  })
+
+  it('falls back to nonfoil chip when available_finishes is empty', () => {
+    render(<CardDetailView card={{ ...mockCard, available_finishes: [] }} />)
+    expect(screen.getByText('nonfoil')).toBeTruthy()
+  })
+
+  it('falls back to nonfoil chip when available_finishes is undefined', () => {
+    const { available_finishes: _, ...cardWithoutFinishes } = mockCard
+    render(<CardDetailView card={cardWithoutFinishes as CardDetail} />)
+    expect(screen.getByText('nonfoil')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — expect failure**
+
+```bash
+cd src/frontend && npx vitest run --reporter=verbose src/features/cards/components/__tests__/CardDetailView.test.tsx
+```
+
+Expected: tests fail — hardcoded "Non-foil" chip doesn't match `available_finishes`.
+
+- [ ] **Step 3: Update `CardDetailView`**
+
+Replace the existing `printChips` section and add `selectedFinish` state. Full updated component:
+
+```typescript
+// src/frontend/src/features/cards/components/CardDetailView.tsx
+import { useState } from 'react'
+import { CardArt } from '../../../components/design-system/CardArt'
+import { AreaChart } from '../../../components/design-system/AreaChart'
+import { Pip, type ManaColor } from '../../../components/design-system/Pip'
+import { Chip } from '../../../components/ui/Chip'
+import { Button } from '../../../components/ui/Button'
+import { PriceCharts } from './PriceCharts'
+import type { CardDetail } from '../types'
+import styles from './CardDetailView.module.css'
+
+interface CardDetailViewProps {
+  card: CardDetail
+}
+
+const RANGE_LABELS = ['1W', '1M', '3M', '1Y', 'ALL']
+
+function parseMana(cost: string): ManaColor[] {
+  return (cost.match(/[WUBRG]/g) ?? []) as ManaColor[]
+}
+
+export function CardDetailView({ card }: CardDetailViewProps) {
+  const finishes = card.available_finishes?.length ? card.available_finishes : ['nonfoil']
+  const [selectedFinish, setSelectedFinish] = useState(finishes[0])
+
+  const delta1d = card.price_change_1d
+  const delta7d = card.price_change_7d
+  const delta30d = card.price_change_30d
+
+  return (
+    <div className={styles.layout}>
+      <div className={styles.artCol}>
+        <CardArt
+          name={card.card_name}
+          w={420}
+          h={585}
+          hue={20}
+          label={false}
+          imageUrl={card.image_large}
+          style={{ borderRadius: 16 }}
+        />
+        <div className={styles.printChips}>
+          {finishes.map((f) => (
+            <button
+              key={f}
+              onClick={() => setSelectedFinish(f)}
+              style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+            >
+              <Chip
+                color={f === selectedFinish ? 'var(--hd-accent)' : undefined}
+                style={f === selectedFinish ? { border: '1px solid var(--hd-accent)' } : {}}
+              >
+                {f === selectedFinish ? '● ' : ''}{f}
+              </Chip>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={styles.rightCol}>
+        <div className={styles.infoCol}>
+          <div className={styles.meta}>
+            {card.set_code.toUpperCase()} · {card.rarity_name?.charAt(0).toUpperCase() + card.rarity_name?.slice(1)} · {card.type_line}
+          </div>
+          <h1 className={styles.name}>{card.card_name}</h1>
+
+          {card.mana_cost && (
+            <div className={styles.manaRow}>
+              {parseMana(card.mana_cost).map((c, i) => <Pip key={i} color={c} size={18} />)}
+              <span className={styles.manaCost}>{card.mana_cost}</span>
+              <span className={styles.artist}>by {card.artist}</span>
+            </div>
+          )}
+
+          <div className={styles.priceSection}>
+            <div className={styles.priceLabel}>Market price</div>
+            <div className={styles.priceRow}>
+              <div className={styles.price}>
+                {card.price != null ? (
+                  <>
+                    ${Math.floor(card.price)}<span className={styles.priceCents}>.{(card.price % 1).toFixed(2).slice(2)}</span>
+                  </>
+                ) : (
+                  'N/A'
+                )}
+              </div>
+              <div className={styles.deltas}>
+                <span className={delta1d >= 0 ? styles.up : styles.down}>
+                  {delta1d >= 0 ? '▲' : '▼'} {Math.abs(delta1d).toFixed(2)}% 1d
+                </span>
+                <span className={delta7d >= 0 ? styles.up : styles.down}>
+                  {delta7d >= 0 ? '▲' : '▼'} {Math.abs(delta7d).toFixed(2)}% 7d
+                </span>
+                <span className={delta30d >= 0 ? styles.up : styles.down}>
+                  {delta30d >= 0 ? '▲' : '▼'} {Math.abs(delta30d).toFixed(2)}% 30d
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {card.price_history && card.price_history.length > 0 ? (
+            <div className={styles.chartSection}>
+              <div className={styles.chartHeader}>
+                <span className={styles.chartLabel}>Price · 1y</span>
+                <div className={styles.rangeButtons}>
+                  {RANGE_LABELS.map((r, i) => (
+                    <button key={r} className={[styles.rangeBtn, i === 3 ? styles.rangeActive : ''].join(' ')}>{r}</button>
+                  ))}
+                </div>
+              </div>
+              <AreaChart
+                points={card.price_history.slice(-365)}
+                color="var(--hd-accent)"
+                height={220}
+                gridColor="rgba(150,200,255,0.05)"
+              />
+            </div>
+          ) : null}
+
+          <div className={styles.actions}>
+            <Button variant="accent" style={{ flex: 1 }}>+ Add to collection</Button>
+            <Button variant="ghost">Watch</Button>
+            <Button variant="ghost">Set alert</Button>
+          </div>
+        </div>
+        <PriceCharts card={card} finish={selectedFinish} />
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Run tests — expect all pass**
+
+```bash
+cd src/frontend && npx vitest run --reporter=verbose src/features/cards/components/__tests__/CardDetailView.test.tsx
+```
+
+Expected: `5 passed`.
+
+- [ ] **Step 5: Run full frontend test suite to check for regressions**
+
+```bash
+cd src/frontend && npm test
+```
+
+Expected: all tests pass (or pre-existing skipped tests remain skipped).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/frontend/src/features/cards/components/CardDetailView.tsx \
+        src/frontend/src/features/cards/components/__tests__/CardDetailView.test.tsx
+git commit -m "feat(frontend): finish selector chips on card detail page"
+```
+
+---
+
+## Task 6: Smoke test end-to-end
+
+Prerequisites: dev database is running and the Scryfall pipeline has populated `card_version_finish`.
+
+- [ ] **Step 1: Confirm `card_version_finish` has data**
+
+```bash
+docker exec automana-postgres-dev psql -U automana_admin automana \
+  -c "SELECT cf.code, COUNT(*) FROM card_catalog.card_version_finish cvf JOIN card_catalog.card_finished cf ON cf.finish_id = cvf.finish_id GROUP BY cf.code ORDER BY COUNT(*) DESC;"
+```
+
+Expected: rows for `NONFOIL`, `FOIL`, `ETCHED`, etc. If the table is empty, run the Scryfall pipeline first (see CLAUDE.md rebuild sequence) before continuing.
+
+- [ ] **Step 2: Hit the card detail endpoint manually**
+
+Pick any `card_version_id` from the DB:
+
+```bash
+docker exec automana-postgres-dev psql -U automana_admin automana \
+  -c "SELECT cv.card_version_id FROM card_catalog.card_version cv LIMIT 1;"
+```
+
+Then fetch via the API (replace `<UUID>`):
+
+```bash
+curl -s http://localhost:8000/api/catalog/mtg/card-reference/<UUID> | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('available_finishes', 'MISSING'))"
+```
+
+Expected: a list like `['nonfoil', 'foil']`.
+
+- [ ] **Step 3: Open the card detail page in the browser**
+
+Navigate to `http://localhost:5173/cards/<UUID>`. Verify:
+- Finish chips appear under the card art
+- Each chip matches the finishes returned by the API
+- Clicking a chip highlights it and the price chart re-fetches for that finish (watch network tab for `?finish=foil`)

--- a/docs/superpowers/specs/2026-05-10-finish-selector-design.md
+++ b/docs/superpowers/specs/2026-05-10-finish-selector-design.md
@@ -1,0 +1,69 @@
+# Finish Selector — Card Detail Page
+
+**Date:** 2026-05-10  
+**Branch:** feat/scryfall-all-cards-illustration-fix  
+**Scope:** Card detail page (`/cards/$id`) only
+
+## Problem
+
+The card detail page hardcodes a single "Non-foil" chip regardless of which finishes are actually available for a card version. The `card_version_finish` table correctly records available finishes per card version (populated by the Scryfall upsert procedure), but this data is never surfaced to the frontend.
+
+## Goal
+
+Show selectable finish chips (nonfoil / foil / etched / etc.) on the card detail page, limited to the finishes actually linked to that card version in `card_version_finish`. Selecting a finish re-fetches the price chart for that finish.
+
+## Design
+
+### Layout
+
+Finish chips sit under the card art (Option A), extending the existing `printChips` row. The selected chip is highlighted with `--hd-accent`. The price chart below re-fetches on selection change. The top-level `$XX.XX` price and delta row stay as-is (from the initial card fetch — finish-agnostic headline price).
+
+### Data flow
+
+```
+Scryfall pipeline
+  → upsert_card() procedure
+  → card_version_finish (one row per finish per card_version_id)
+
+GET /api/catalog/mtg/card-reference/{id}
+  card_repository.get()
+    correlated subquery in SELECT:
+      ARRAY(SELECT LOWER(cf.code)
+            FROM card_catalog.card_version_finish cvf
+            JOIN card_catalog.card_finished cf ON cf.finish_id = cvf.finish_id
+            WHERE cvf.card_version_id = cv.card_version_id)
+      AS available_finishes
+  CardDetail Pydantic model → available_finishes: Optional[List[str]]
+
+CardDetailView (React)
+  selectedFinish = useState(available_finishes[0] ?? 'nonfoil')
+  chip row renders from available_finishes
+  ↓ passes selectedFinish prop
+PriceCharts
+  cardPriceHistoryQueryOptions(card_version_id, range, selectedFinish)
+  chart re-fetches when selectedFinish changes
+```
+
+### Edge cases
+
+- `available_finishes` empty or null → treat as `['nonfoil']` in the frontend
+- Single-finish cards → one chip renders, no meaningful interaction but display is correct
+- Finish codes come from DB as uppercase (`NONFOIL`) → lowercased in the SQL query for consistency with existing API conventions
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/automana/core/repositories/card_catalog/card_repository.py` | `get()` adds `LEFT JOIN card_version_finish + card_finished` with `ARRAY_AGG(LOWER(cf.code))` |
+| `src/automana/core/models/card_catalog/card.py` | `CardDetail` gets `available_finishes: Optional[List[str]] = Field(default_factory=list)` |
+| `src/frontend/src/features/cards/types.ts` | `CardDetail` gets `available_finishes?: string[]` |
+| `src/frontend/src/features/cards/components/CardDetailView.tsx` | `useState` for `selectedFinish`, replace hardcoded chip with dynamic chip row, pass `selectedFinish` to `PriceCharts` |
+| `src/frontend/src/features/cards/components/PriceCharts.tsx` | Accept `finish?: string` prop, pass to `cardPriceHistoryQueryOptions` |
+
+No new endpoints, no new components, no database migrations.
+
+## Out of Scope
+
+- Finish chips on the search results grid
+- Updating the top-level `$XX.XX` price per finish (requires a separate API call)
+- Filter by finish in the search page (already exists via `SearchFilters`)

--- a/src/automana/core/models/card_catalog/card.py
+++ b/src/automana/core/models/card_catalog/card.py
@@ -35,7 +35,7 @@ class BaseCard(BaseModel):
 
 class CardDetail(BaseCard):
     image_large: Optional[str] = Field(default=None, title="URL to large-sized card image from Scryfall")
-    available_finishes: Optional[List[str]] = Field(default_factory=list)
+    available_finishes: List[str] = Field(default_factory=list)
     price_history_list_avg: Optional[List[float]] = Field(
         default=None,
         title="Daily list average prices in dollars for selected time range"

--- a/src/automana/core/models/card_catalog/card.py
+++ b/src/automana/core/models/card_catalog/card.py
@@ -35,6 +35,7 @@ class BaseCard(BaseModel):
 
 class CardDetail(BaseCard):
     image_large: Optional[str] = Field(default=None, title="URL to large-sized card image from Scryfall")
+    available_finishes: Optional[List[str]] = Field(default_factory=list)
     price_history_list_avg: Optional[List[float]] = Field(
         default=None,
         title="Daily list average prices in dollars for selected time range"
@@ -236,7 +237,7 @@ class CreateCard(BaseCard):
 
             "image_uris": data["image_uris"] or [],
 
-            "finish": (data.get("finishes") or ["nonfoil"])[0],
+            "finishes": data.get("finishes") or ["nonfoil"],
             "frame_effects": data.get("frame_effects") or [],
             "lang": data.get("lang") or "en",
 

--- a/src/automana/core/models/card_catalog/card.py
+++ b/src/automana/core/models/card_catalog/card.py
@@ -56,6 +56,7 @@ class CardFace(BaseModel):
     artist: Optional[str] = None
     artist_id: Optional[UUID] = None
     illustration_id: Optional[UUID] = None
+    image_uris: Optional[Dict[str, Any]] = None
     supertypes: List[str] = []
     types: List[str] = []
     subtypes: List[str] = []
@@ -109,6 +110,8 @@ class CreateCard(BaseCard):
     textless : Optional[bool]=False
     power : Optional[Union[int, str]] = None
     lang : Optional[str]='en'
+    finishes: Optional[List[str]] = Field(default_factory=list)
+    frame_effects: Optional[List[str]] = Field(default_factory=list)
     loyalty : Optional[Union[int, str]]=None
     promo_types : Optional[List[str]]=[]
     toughness : Optional[Union[int, str]]=None
@@ -233,7 +236,11 @@ class CreateCard(BaseCard):
 
             "image_uris": data["image_uris"] or [],
 
-            "scryfall_id": data["id"],  
+            "finish": (data.get("finishes") or ["nonfoil"])[0],
+            "frame_effects": data.get("frame_effects") or [],
+            "lang": data.get("lang") or "en",
+
+            "scryfall_id": data["id"],
             "oracle_id": data["oracle_id"],
             "multiverse_ids": data["multiverse_ids"] or [],
             "tcgplayer_id": data["tcgplayer_id"],

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -82,17 +82,32 @@ class CardReferenceRepository(AbstractRepository[Any]):
     async def get(self,
                   card_id: UUID,
                  ) -> dict[str, Any]|None:
-        # if a list
-
-        query = """ SELECT cv.card_version_id, uc.card_name, r.rarity_name, s.set_name, s.set_code, uc.cmc, cv.oracle_text, s.released_at, s.digital, r.rarity_name,
-                           cvi.image_uris->>'large' AS image_large
-                FROM card_catalog.unique_cards_ref uc
-                JOIN card_catalog.card_version cv ON uc.unique_card_id = cv.unique_card_id
-                JOIN card_catalog.rarities_ref r ON cv.rarity_id = r.rarity_id
-                JOIN card_catalog.sets s ON cv.set_id = s.set_id
-                LEFT JOIN card_catalog.card_version_illustration cvi ON cvi.card_version_id = cv.card_version_id
-                WHERE cv.card_version_id = $1;"""
-
+        query = """
+            SELECT
+                cv.card_version_id,
+                uc.card_name,
+                r.rarity_name,
+                s.set_name,
+                s.set_code,
+                uc.cmc,
+                cv.oracle_text,
+                s.released_at,
+                s.digital,
+                cvi.image_uris->>'large' AS image_large,
+                ARRAY(
+                    SELECT LOWER(cf.code)
+                    FROM card_catalog.card_version_finish cvf
+                    JOIN card_catalog.card_finished cf ON cf.finish_id = cvf.finish_id
+                    WHERE cvf.card_version_id = cv.card_version_id
+                ) AS available_finishes
+            FROM card_catalog.unique_cards_ref uc
+            JOIN card_catalog.card_version cv ON uc.unique_card_id = cv.unique_card_id
+            JOIN card_catalog.rarities_ref r ON cv.rarity_id = r.rarity_id
+            JOIN card_catalog.sets s ON cv.set_id = s.set_id
+            LEFT JOIN card_catalog.card_version_illustration cvi
+                ON cvi.card_version_id = cv.card_version_id
+            WHERE cv.card_version_id = $1;
+        """
         result = await self.execute_query(query, (card_id,))
         return result[0] if result else None
 
@@ -719,7 +734,7 @@ class CardReferenceRepository(AbstractRepository[Any]):
                     AVG(ppd.list_avg_cents)::float / 100 AS list_avg_price,
                     AVG(ppd.sold_avg_cents)::float / 100 AS sold_avg_price
                 FROM pricing.print_price_daily ppd
-                JOIN pricing.card_finished f ON f.finish_id = ppd.finish_id
+                JOIN card_catalog.card_finished f ON f.finish_id = ppd.finish_id
                 WHERE ppd.card_version_id = $1
                   AND ppd.price_date >= $2
                   AND ppd.price_date <= $3
@@ -732,7 +747,7 @@ class CardReferenceRepository(AbstractRepository[Any]):
                     AVG(ppw.list_avg_cents)::float / 100 AS list_avg_price,
                     AVG(ppw.sold_avg_cents)::float / 100 AS sold_avg_price
                 FROM pricing.print_price_weekly ppw
-                JOIN pricing.card_finished f ON f.finish_id = ppw.finish_id
+                JOIN card_catalog.card_finished f ON f.finish_id = ppw.finish_id
                 WHERE ppw.card_version_id = $1
                   AND ppw.price_week >= $2
                   AND ppw.price_week <= $3
@@ -765,7 +780,7 @@ class CardReferenceRepository(AbstractRepository[Any]):
                     AVG(ppd.list_avg_cents)::float / 100 AS list_avg_price,
                     AVG(ppd.sold_avg_cents)::float / 100 AS sold_avg_price
                 FROM pricing.print_price_daily ppd
-                JOIN pricing.card_finished f ON f.finish_id = ppd.finish_id
+                JOIN card_catalog.card_finished f ON f.finish_id = ppd.finish_id
                 WHERE ppd.card_version_id = $1
                   AND ppd.price_date >= $2
                   AND ppd.price_date <= $3

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -85,13 +85,12 @@ class CardReferenceRepository(AbstractRepository[Any]):
         # if a list
 
         query = """ SELECT cv.card_version_id, uc.card_name, r.rarity_name, s.set_name, s.set_code, uc.cmc, cv.oracle_text, s.released_at, s.digital, r.rarity_name,
-                           ill.image_uris->>'large' AS image_large
+                           cvi.image_uris->>'large' AS image_large
                 FROM card_catalog.unique_cards_ref uc
                 JOIN card_catalog.card_version cv ON uc.unique_card_id = cv.unique_card_id
                 JOIN card_catalog.rarities_ref r ON cv.rarity_id = r.rarity_id
                 JOIN card_catalog.sets s ON cv.set_id = s.set_id
                 LEFT JOIN card_catalog.card_version_illustration cvi ON cvi.card_version_id = cv.card_version_id
-                LEFT JOIN card_catalog.illustrations ill ON ill.illustration_id = cvi.illustration_id
                 WHERE cv.card_version_id = $1;"""
 
         result = await self.execute_query(query, (card_id,))
@@ -281,7 +280,6 @@ class CardReferenceRepository(AbstractRepository[Any]):
             "FROM card_catalog.v_card_versions_complete v"
             " JOIN card_catalog.sets s ON s.set_id = v.set_id"
             " LEFT JOIN card_catalog.card_version_illustration cvi ON cvi.card_version_id = v.card_version_id"
-            " LEFT JOIN card_catalog.illustrations ill ON ill.illustration_id = cvi.illustration_id"
         )
 
         query = f"""
@@ -295,7 +293,7 @@ class CardReferenceRepository(AbstractRepository[Any]):
                 v.oracle_text,
                 v.is_digital AS digital,
                 s.released_at,
-                ill.image_uris->>'normal' AS image_normal
+                cvi.image_uris->>'normal' AS image_normal
             {from_clause}
             {where_clause}
             {order_clause}

--- a/src/automana/core/services/app_integration/scryfall/data_loader.py
+++ b/src/automana/core/services/app_integration/scryfall/data_loader.py
@@ -146,7 +146,7 @@ async def download_cards_bulk(
     ops_repository: OpsRepository,
     ingestion_run_id: int = None,
     uris_to_download: list[dict] | None = None,
-    resource_type: str = "default_cards",
+    resource_type: str = "all_cards",
     storage_service: StorageService = None,
 ) -> dict:
     """Stream-download Scryfall card bulk files to disk.
@@ -182,19 +182,19 @@ async def download_cards_bulk(
 async def delete_old_scryfall_folders(keep: int = 3
                                , storage_service: StorageService = None):
     """Delete Scryfall raw files older than specified days to keep"""
-    list_default_cards = await storage_service.list_directory("*default-card*")
-    if not list_default_cards:
-        logger.warning("No default card files found; nothing to clean")
+    list_all_cards = await storage_service.list_directory("*all-card*")
+    if not list_all_cards:
+        logger.warning("No all-cards files found; nothing to clean")
         return {"deleted_runs": []}
 
     def _parse_date(filename: str) -> str:
         parts = filename.split("_")
         return parts[1] if len(parts) >= 2 else ""
 
-    list_default_cards.sort(key=lambda p: _parse_date(p), reverse=True)  # newest first
-    to_delete = list_default_cards[keep:]
+    list_all_cards.sort(key=lambda p: _parse_date(p), reverse=True)  # newest first
+    to_delete = list_all_cards[keep:]
     results = await storage_service.delete_files([str(d) for d in to_delete])
-    return {"deleted_runs": results, "kept": [str(d) for d in list_default_cards[:keep]]}
+    return {"deleted_runs": results, "kept": [str(d) for d in list_all_cards[:keep]]}
 
 @ServiceRegistry.register("staging.scryfall.download_and_load_migrations",
                          api_repositories=["scryfall"], db_repositories=["card", "ops"])

--- a/src/automana/core/services/card_catalog/card_service.py
+++ b/src/automana/core/services/card_catalog/card_service.py
@@ -561,10 +561,18 @@ class EnhancedCardImportService:
                 
                             continue
                         
-                        # Validate and create card
+                        # Validate and create card; explode finishes so each
+                        # finish variant (nonfoil/foil/etched/surge_foil) becomes
+                        # its own card_version row.
                         card = card_schemas.CreateCard.model_validate(card_json)
                         if card:
-                            batch.append(card)
+                            is_surge_foil = "surgefoil" in (card.promo_types or [])
+                            for raw_finish in (card.finishes or ["nonfoil"]):
+                                effective_finish = (
+                                    "surge_foil" if raw_finish == "foil" and is_surge_foil
+                                    else raw_finish
+                                )
+                                batch.append(card.model_copy(update={"finishes": [effective_finish]}))
                             self.stats.total_cards += 1
                         
                         # Process batch when full

--- a/src/automana/core/services/card_catalog/card_service.py
+++ b/src/automana/core/services/card_catalog/card_service.py
@@ -544,8 +544,14 @@ class EnhancedCardImportService:
             async with self.storage_service.open_stream(file_name, "rb") as f:
                 cards_iter = ijson.items(f, "item")
 
+                _IMPORT_LANGUAGES = {"en", "ja"}
+
                 for card_json in cards_iter:
                     try:
+                        # Skip non-EN/JA cards (all_cards dataset includes all languages)
+                        if card_json.get("lang", "en") not in _IMPORT_LANGUAGES:
+                            continue
+
                         # Skip batches if resuming
                         if batch_count < resume_from_batch:
                             if len(batch) >= self.config.batch_size:

--- a/src/automana/core/services/card_catalog/card_service.py
+++ b/src/automana/core/services/card_catalog/card_service.py
@@ -562,17 +562,14 @@ class EnhancedCardImportService:
                             continue
                         
                         # Validate and create card; explode finishes so each
-                        # finish variant (nonfoil/foil/etched/surge_foil) becomes
-                        # its own card_version row.
+                        # finish variant (nonfoil / foil / etched) becomes its
+                        # own card_version row.  Promo treatments (surgefoil,
+                        # ripplefoil, etc.) are stored in promo_card via the
+                        # stored procedure — they do not change the finish value.
                         card = card_schemas.CreateCard.model_validate(card_json)
                         if card:
-                            is_surge_foil = "surgefoil" in (card.promo_types or [])
-                            for raw_finish in (card.finishes or ["nonfoil"]):
-                                effective_finish = (
-                                    "surge_foil" if raw_finish == "foil" and is_surge_foil
-                                    else raw_finish
-                                )
-                                batch.append(card.model_copy(update={"finishes": [effective_finish]}))
+                            for finish in (card.finishes or ["nonfoil"]):
+                                batch.append(card.model_copy(update={"finishes": [finish]}))
                             self.stats.total_cards += 1
                         
                         # Process batch when full

--- a/src/automana/database/SQL/maintenance/pricing_integrity_checks.sql
+++ b/src/automana/database/SQL/maintenance/pricing_integrity_checks.sql
@@ -195,7 +195,7 @@ chk_07_card_finished_core_codes AS (
         ) AS details
     FROM (VALUES ('NONFOIL'), ('FOIL'), ('ETCHED')) AS required(code)
     WHERE NOT EXISTS (
-        SELECT 1 FROM pricing.card_finished cf WHERE cf.code = required.code
+        SELECT 1 FROM card_catalog.card_finished cf WHERE cf.code = required.code
     )
 ),
 

--- a/src/automana/database/SQL/migrations/migration_28_cvi_image_uris.sql
+++ b/src/automana/database/SQL/migrations/migration_28_cvi_image_uris.sql
@@ -1,0 +1,28 @@
+-- migration_28_cvi_image_uris.sql
+-- Move image_uris storage from per-illustration to per-card-version.
+--
+-- Root cause: card_catalog.illustrations uses illustration_id as PK, and
+-- Scryfall reuses the same illustration_id across reprints of the same artwork
+-- in different sets. The prior ON CONFLICT DO UPDATE in insert_full_card_version
+-- overwrote image_uris with the last-processed printing's URLs, so cards from
+-- earlier sets displayed another set's card image (right art, wrong set symbol).
+--
+-- Fix: add image_uris to card_version_illustration (one row per card_version)
+-- so each printing keeps its own Scryfall image URL.
+-- The illustrations table retains illustration_id as an art-deduplication anchor.
+
+BEGIN;
+
+ALTER TABLE card_catalog.card_version_illustration
+    ADD COLUMN IF NOT EXISTS image_uris JSONB;
+
+-- Best-effort back-fill: copy current image_uris from the shared illustrations
+-- row into every card_version_illustration that references it.
+-- This gives a reasonable starting point; a full pipeline re-run will populate
+-- correct per-version URLs once insert_full_card_version is updated.
+UPDATE card_catalog.card_version_illustration cvi
+SET image_uris = ill.image_uris
+FROM card_catalog.illustrations ill
+WHERE cvi.illustration_id = ill.illustration_id;
+
+COMMIT;

--- a/src/automana/database/SQL/migrations/migration_29_card_version_finish.sql
+++ b/src/automana/database/SQL/migrations/migration_29_card_version_finish.sql
@@ -1,0 +1,51 @@
+-- migration_29_card_version_finish.sql
+-- Extend card_version to support treatment variants (finish) and language-exclusive
+-- prints (lang), and track frame_effects (showcase, extendedart, borderless).
+--
+-- Why: switching from default_cards to all_cards exposes multiple treatments of
+-- the same card in the same set (e.g. Ragavan non-foil, foil, showcase-foil in MH2)
+-- as distinct Scryfall entries sharing the same collector_number.  The old UNIQUE
+-- constraint (unique_card_id, set_id, collector_number) would silently drop every
+-- variant after the first.  Adding finish + lang to the constraint lets each
+-- distinct product coexist.
+--
+-- Also fixes a pre-existing silent bug: Japanese alternate-art planeswalkers
+-- (WAR, STA) share collector_numbers with English versions; without lang in the
+-- constraint the second language is always silently discarded.
+
+BEGIN;
+
+-- 1. Add finish (nonfoil / foil / etched / glossy / …)
+ALTER TABLE card_catalog.card_version
+    ADD COLUMN IF NOT EXISTS finish VARCHAR(20) NOT NULL DEFAULT 'nonfoil';
+
+-- 2. Add frame_effects (showcase, extendedart, borderless, inverted, …)
+ALTER TABLE card_catalog.card_version
+    ADD COLUMN IF NOT EXISTS frame_effects TEXT[] NOT NULL DEFAULT '{}';
+
+-- 3. Add lang (en, ja, ko, zhs, zht, …)
+ALTER TABLE card_catalog.card_version
+    ADD COLUMN IF NOT EXISTS lang VARCHAR(5) NOT NULL DEFAULT 'en';
+
+-- 4. Replace old constraint that lacked finish + lang
+ALTER TABLE card_catalog.card_version
+    DROP CONSTRAINT IF EXISTS card_version_unique_card_id_set_id_collector_number_key;
+
+-- New constraint: one row per (card, set, collector_number, finish, language).
+-- Examples of rows that now coexist:
+--   (Ragavan, MH2, 138, nonfoil, en)   ← regular non-foil
+--   (Ragavan, MH2, 138, foil,    en)   ← foil
+--   (Ragavan, MH2, 522, nonfoil, en)   ← showcase frame (different collector_number)
+--   (Liliana, WAR,   3, foil,    en)   ← English foil
+--   (Liliana, WAR,   3, foil,    ja)   ← Japanese alternate-art foil
+DO $$
+BEGIN
+    ALTER TABLE card_catalog.card_version
+        ADD CONSTRAINT card_version_unique_per_finish_lang
+        UNIQUE (unique_card_id, set_id, collector_number, finish, lang);
+EXCEPTION WHEN duplicate_object THEN
+    NULL; -- Already created by schema on a fresh build
+END;
+$$;
+
+COMMIT;

--- a/src/automana/database/SQL/schemas/02_card_schema.sql
+++ b/src/automana/database/SQL/schemas/02_card_schema.sql
@@ -157,7 +157,10 @@ CREATE TABLE IF NOT EXISTS card_catalog.card_version (
     is_multifaced BOOLEAN DEFAULT false, 
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now(),
-    UNIQUE (unique_card_id, set_id, collector_number)
+    finish VARCHAR(20) NOT NULL DEFAULT 'nonfoil',
+    frame_effects TEXT[] NOT NULL DEFAULT '{}',
+    lang VARCHAR(5) NOT NULL DEFAULT 'en',
+    CONSTRAINT card_version_unique_per_finish_lang UNIQUE (unique_card_id, set_id, collector_number, finish, lang)
 );
 
 CREATE TABLE IF NOT EXISTS card_catalog.illustrations(
@@ -178,6 +181,7 @@ CREATE TABLE IF NOT EXISTS card_catalog.illustration_artist (
 CREATE TABLE IF NOT EXISTS card_catalog.card_version_illustration (
     card_version_id UUID PRIMARY KEY REFERENCES card_catalog.card_version(card_version_id),
     illustration_id UUID NOT NULL REFERENCES card_catalog.illustrations(illustration_id),
+    image_uris JSONB,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now()
 );
@@ -413,7 +417,7 @@ illustrations_agg AS (
     jsonb_agg(
       jsonb_build_object(
         'illustration_id', cvi.illustration_id,
-        'image_uris', i.image_uris,
+        'image_uris', cvi.image_uris,
         'added_on', i.added_on,
         'artist_id', ar.artist_id,
         'artist_name', ar.artist_name
@@ -502,6 +506,11 @@ SELECT
     fr.frame_year,
     lr.layout_name,
     
+    -- Treatment and language
+    cv.finish,
+    cv.frame_effects,
+    cv.lang,
+
     -- Flags
     cv.is_promo,
     cv.is_digital,
@@ -634,6 +643,9 @@ CREATE OR REPLACE FUNCTION card_catalog.insert_full_card_version(
     p_card_faces JSONB,
     --new
     p_image_uris JSONB,
+    p_finish VARCHAR(20),
+    p_frame_effects TEXT[],
+    p_lang VARCHAR(5),
     --external ids
     p_scryfall_id UUID,
     p_oracle_id UUID,
@@ -749,15 +761,18 @@ BEGIN
         collector_number, rarity_id, border_color_id,
         frame_id, layout_id, is_promo, is_digital,
         is_oversized, full_art, textless, booster,
-        variation
+        variation, finish, frame_effects, lang
     ) VALUES (
         v_unique_card_id, p_oracle_text, v_set_id,
         p_collector_number, v_rarity_id, v_border_color_id,
         v_frame_id, v_layout_id, p_is_promo, p_is_digital,
         p_oversized, p_full_art, p_textless, p_booster,
-        p_variation
+        p_variation,
+        COALESCE(p_finish, 'nonfoil'),
+        COALESCE(p_frame_effects, '{}'),
+        COALESCE(p_lang, 'en')
     )
-    ON CONFLICT (unique_card_id, set_id, collector_number) DO NOTHING
+    ON CONFLICT (unique_card_id, set_id, collector_number, finish, lang) DO NOTHING
     RETURNING card_version_id INTO v_card_version_id;
 
     IF v_card_version_id IS NULL THEN
@@ -767,6 +782,8 @@ BEGIN
     WHERE unique_card_id = v_unique_card_id
         AND set_id = v_set_id
         AND collector_number = p_collector_number
+        AND finish = COALESCE(p_finish, 'nonfoil')
+        AND lang = COALESCE(p_lang, 'en')
     LIMIT 1;
     END IF;
     --add the ids
@@ -892,34 +909,58 @@ BEGIN
         END IF;
 
         -- Link illustration and artist for single-faced card.
-        INSERT INTO card_catalog.illustrations (illustration_id, image_uris)
-        VALUES (p_illustration_id, p_image_uris)
-        ON CONFLICT (illustration_id)
-        DO UPDATE SET
-            image_uris = EXCLUDED.image_uris,
-            updated_at = now()
+        -- illustrations row is an art-deduplication anchor only; image_uris
+        -- is now stored per card_version in card_version_illustration so that
+        -- reprints of the same art in different sets each keep their own URLs.
+        INSERT INTO card_catalog.illustrations (illustration_id)
+        VALUES (p_illustration_id)
+        ON CONFLICT (illustration_id) DO NOTHING
         RETURNING illustration_id INTO v_illustration_id;
 
         INSERT INTO card_catalog.illustration_artist (illustration_id, artist_id)
         VALUES (p_illustration_id, v_artist_uuid)
         ON CONFLICT (illustration_id, artist_id) DO NOTHING;
 
-        
-        --card illustrations
+        -- Store image_uris per card_version (not per illustration)
         WITH exists AS (
             SELECT card_version_id, illustration_id
             FROM card_catalog.card_version_illustration
             WHERE card_version_id = v_card_version_id
                 AND illustration_id = p_illustration_id
         )
-        INSERT INTO card_catalog.card_version_illustration (card_version_id, illustration_id)
-        SELECT v_card_version_id, p_illustration_id
+        INSERT INTO card_catalog.card_version_illustration (card_version_id, illustration_id, image_uris)
+        SELECT v_card_version_id, p_illustration_id, p_image_uris
         WHERE NOT EXISTS (SELECT 1 FROM exists);
 
     ELSE
         UPDATE card_catalog.card_version
         SET is_multifaced = true
         WHERE card_version_id = v_card_version_id;
+
+        -- Store per-version image_uris for multi-faced cards.
+        -- Adventure cards carry top-level illustration_id/image_uris; DFCs use the front face.
+        v_illustration_id := COALESCE(
+            p_illustration_id,
+            (p_card_faces -> 0 ->> 'illustration_id')::UUID
+        );
+        IF v_illustration_id IS NOT NULL THEN
+            INSERT INTO card_catalog.illustrations (illustration_id)
+            VALUES (v_illustration_id)
+            ON CONFLICT (illustration_id) DO NOTHING;
+
+            INSERT INTO card_catalog.card_version_illustration (card_version_id, illustration_id, image_uris)
+            SELECT v_card_version_id,
+                   v_illustration_id,
+                   CASE WHEN p_illustration_id IS NOT NULL
+                        THEN p_image_uris
+                        ELSE p_card_faces -> 0 -> 'image_uris'
+                   END
+            WHERE NOT EXISTS (
+                SELECT 1 FROM card_catalog.card_version_illustration
+                WHERE card_version_id = v_card_version_id
+            );
+        END IF;
+
         FOR v_face IN SELECT * FROM jsonb_array_elements(p_card_faces) LOOP
             v_artist_uuid := NULL;
             v_illustration_id := NULL;
@@ -953,7 +994,7 @@ BEGIN
                 LIMIT 1;
             END IF;
 
-            IF v_face ->> 'illustration_id' IS NOT NULL AND v_face ->> 'artist_id' IS NOT NULL THEN
+            IF v_face ->> 'illustration_id' IS NOT NULL THEN
                 v_illustration_id := (v_face ->> 'illustration_id')::UUID;
                 v_artist_uuid := (v_face ->> 'artist_id')::UUID;
                 v_artist_name := (v_face ->> 'artist')::TEXT;
@@ -1127,6 +1168,9 @@ BEGIN
                 (v_card ->> 'variation')::BOOLEAN,
                 v_card -> 'card_faces',
                 v_card -> 'image_uris',
+                COALESCE(v_card ->> 'finish', 'nonfoil'),
+                ARRAY(SELECT jsonb_array_elements_text(COALESCE(v_card -> 'frame_effects', '[]'::jsonb))),
+                COALESCE(v_card ->> 'lang', 'en'),
                 (v_card ->> 'scryfall_id')::UUID,
                 (v_card ->> 'oracle_id')::UUID,
                 v_card -> 'multiverse_ids',
@@ -1141,7 +1185,7 @@ BEGIN
             
         EXCEPTION
             WHEN unique_violation THEN
-                IF SQLERRM LIKE '%card_version_unique_card_id_set_id_collector_number_key%' THEN
+                IF SQLERRM LIKE '%card_version_unique_per_finish_lang%' THEN
                     -- Skipped (already exists)
                     v_skipped_inserts := v_skipped_inserts + 1;
                 ELSE

--- a/src/frontend/src/features/cards/components/CardDetailView.tsx
+++ b/src/frontend/src/features/cards/components/CardDetailView.tsx
@@ -44,6 +44,7 @@ export function CardDetailView({ card }: CardDetailViewProps) {
             <button
               key={f}
               onClick={() => setSelectedFinish(f)}
+              aria-pressed={f === selectedFinish}
               style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
             >
               <Chip

--- a/src/frontend/src/features/cards/components/CardDetailView.tsx
+++ b/src/frontend/src/features/cards/components/CardDetailView.tsx
@@ -1,4 +1,5 @@
 // src/frontend/src/features/cards/components/CardDetailView.tsx
+import { useState } from 'react'
 import { CardArt } from '../../../components/design-system/CardArt'
 import { AreaChart } from '../../../components/design-system/AreaChart'
 import { Pip, type ManaColor } from '../../../components/design-system/Pip'
@@ -19,6 +20,9 @@ function parseMana(cost: string): ManaColor[] {
 }
 
 export function CardDetailView({ card }: CardDetailViewProps) {
+  const finishes = card.available_finishes?.length ? card.available_finishes : ['nonfoil']
+  const [selectedFinish, setSelectedFinish] = useState(finishes[0])
+
   const delta1d = card.price_change_1d
   const delta7d = card.price_change_7d
   const delta30d = card.price_change_30d
@@ -36,82 +40,90 @@ export function CardDetailView({ card }: CardDetailViewProps) {
           style={{ borderRadius: 16 }}
         />
         <div className={styles.printChips}>
-          <Chip color="var(--hd-accent)" style={{ border: '1px solid var(--hd-accent)' }}>
-            ● Non-foil · {card.set_code.toUpperCase()}
-          </Chip>
-          {card.prints?.map((p) => (
-            <Chip key={p.id}>{p.finish} · {p.set}</Chip>
+          {finishes.map((f) => (
+            <button
+              key={f}
+              onClick={() => setSelectedFinish(f)}
+              style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
+            >
+              <Chip
+                color={f === selectedFinish ? 'var(--hd-accent)' : undefined}
+                style={f === selectedFinish ? { border: '1px solid var(--hd-accent)' } : {}}
+              >
+                {f === selectedFinish ? <span aria-hidden="true">● </span> : null}<span>{f}</span>
+              </Chip>
+            </button>
           ))}
         </div>
       </div>
 
       <div className={styles.rightCol}>
         <div className={styles.infoCol}>
-        <div className={styles.meta}>
-          {card.set_code.toUpperCase()} · {card.rarity_name?.charAt(0).toUpperCase() + card.rarity_name?.slice(1)} · {card.type_line}
-        </div>
-        <h1 className={styles.name}>{card.card_name}</h1>
-
-        {card.mana_cost && (
-          <div className={styles.manaRow}>
-            {parseMana(card.mana_cost).map((c, i) => <Pip key={i} color={c} size={18} />)}
-            <span className={styles.manaCost}>{card.mana_cost}</span>
-            <span className={styles.artist}>by {card.artist}</span>
+          <div className={styles.meta}>
+            {card.set_code.toUpperCase()} · {card.rarity_name?.charAt(0).toUpperCase() + card.rarity_name?.slice(1)} · {card.type_line}
           </div>
-        )}
+          <h1 className={styles.name}>{card.card_name}</h1>
 
-        <div className={styles.priceSection}>
-          <div className={styles.priceLabel}>Market price</div>
-          <div className={styles.priceRow}>
-            <div className={styles.price}>
-              {card.price != null ? (
-                <>
-                  ${Math.floor(card.price)}<span className={styles.priceCents}>.{(card.price % 1).toFixed(2).slice(2)}</span>
-                </>
-              ) : (
-                'N/A'
-              )}
+          {card.mana_cost && (
+            <div className={styles.manaRow}>
+              {parseMana(card.mana_cost).map((c, i) => <Pip key={i} color={c} size={18} />)}
+              <span className={styles.manaCost}>{card.mana_cost}</span>
+              <span className={styles.artist}>by {card.artist}</span>
             </div>
-            <div className={styles.deltas}>
-              <span className={delta1d >= 0 ? styles.up : styles.down}>
-                {delta1d >= 0 ? '▲' : '▼'} {Math.abs(delta1d).toFixed(2)}% 1d
-              </span>
-              <span className={delta7d >= 0 ? styles.up : styles.down}>
-                {delta7d >= 0 ? '▲' : '▼'} {Math.abs(delta7d).toFixed(2)}% 7d
-              </span>
-              <span className={delta30d >= 0 ? styles.up : styles.down}>
-                {delta30d >= 0 ? '▲' : '▼'} {Math.abs(delta30d).toFixed(2)}% 30d
-              </span>
-            </div>
-          </div>
-        </div>
+          )}
 
-        {card.price_history && card.price_history.length > 0 ? (
-          <div className={styles.chartSection}>
-            <div className={styles.chartHeader}>
-              <span className={styles.chartLabel}>Price · 1y</span>
-              <div className={styles.rangeButtons}>
-                {RANGE_LABELS.map((r, i) => (
-                  <button key={r} className={[styles.rangeBtn, i === 3 ? styles.rangeActive : ''].join(' ')}>{r}</button>
-                ))}
+          <div className={styles.priceSection}>
+            <div className={styles.priceLabel}>Market price</div>
+            <div className={styles.priceRow}>
+              <div className={styles.price}>
+                {card.price != null ? (
+                  <>
+                    ${Math.floor(card.price)}<span className={styles.priceCents}>.{(card.price % 1).toFixed(2).slice(2)}</span>
+                  </>
+                ) : (
+                  'N/A'
+                )}
+              </div>
+              <div className={styles.deltas}>
+                <span className={delta1d >= 0 ? styles.up : styles.down}>
+                  {delta1d >= 0 ? '▲' : '▼'} {Math.abs(delta1d).toFixed(2)}% 1d
+                </span>
+                <span className={delta7d >= 0 ? styles.up : styles.down}>
+                  {delta7d >= 0 ? '▲' : '▼'} {Math.abs(delta7d).toFixed(2)}% 7d
+                </span>
+                <span className={delta30d >= 0 ? styles.up : styles.down}>
+                  {delta30d >= 0 ? '▲' : '▼'} {Math.abs(delta30d).toFixed(2)}% 30d
+                </span>
               </div>
             </div>
-            <AreaChart
-              points={card.price_history.slice(-365)}
-              color="var(--hd-accent)"
-              height={220}
-              gridColor="rgba(150,200,255,0.05)"
-            />
           </div>
-        ) : null}
 
-        <div className={styles.actions}>
-          <Button variant="accent" style={{ flex: 1 }}>+ Add to collection</Button>
-          <Button variant="ghost">Watch</Button>
-          <Button variant="ghost">Set alert</Button>
+          {card.price_history && card.price_history.length > 0 ? (
+            <div className={styles.chartSection}>
+              <div className={styles.chartHeader}>
+                <span className={styles.chartLabel}>Price · 1y</span>
+                <div className={styles.rangeButtons}>
+                  {RANGE_LABELS.map((r, i) => (
+                    <button key={r} className={[styles.rangeBtn, i === 3 ? styles.rangeActive : ''].join(' ')}>{r}</button>
+                  ))}
+                </div>
+              </div>
+              <AreaChart
+                points={card.price_history.slice(-365)}
+                color="var(--hd-accent)"
+                height={220}
+                gridColor="rgba(150,200,255,0.05)"
+              />
+            </div>
+          ) : null}
+
+          <div className={styles.actions}>
+            <Button variant="accent" style={{ flex: 1 }}>+ Add to collection</Button>
+            <Button variant="ghost">Watch</Button>
+            <Button variant="ghost">Set alert</Button>
+          </div>
         </div>
-        </div>
-        <PriceCharts card={card} />
+        <PriceCharts card={card} finish={selectedFinish} />
       </div>
     </div>
   )

--- a/src/frontend/src/features/cards/components/PriceCharts.tsx
+++ b/src/frontend/src/features/cards/components/PriceCharts.tsx
@@ -7,6 +7,7 @@ import styles from './PriceCharts.module.css'
 
 interface PriceChartsProps {
   card: CardDetail
+  finish?: string
 }
 
 const TIME_RANGES = [
@@ -42,11 +43,11 @@ function trimNulls(
   }
 }
 
-export function PriceCharts({ card }: PriceChartsProps) {
+export function PriceCharts({ card, finish }: PriceChartsProps) {
   const [selectedRange, setSelectedRange] = useState<'1w' | '1m' | '3m' | '1y' | 'all'>('all')
 
   const { data: priceData, isLoading } = useQuery(
-    cardPriceHistoryQueryOptions(card.card_version_id, selectedRange)
+    cardPriceHistoryQueryOptions(card.card_version_id, selectedRange, finish)
   )
 
   const rawList = priceData?.price_history_list_avg ?? []

--- a/src/frontend/src/features/cards/components/__tests__/CardDetailView.test.tsx
+++ b/src/frontend/src/features/cards/components/__tests__/CardDetailView.test.tsx
@@ -1,0 +1,66 @@
+// src/frontend/src/features/cards/components/__tests__/CardDetailView.test.tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CardDetailView } from '../CardDetailView'
+import type { CardDetail } from '../../types'
+
+vi.mock('../PriceCharts', () => ({
+  PriceCharts: ({ finish }: { finish?: string }) => (
+    <div data-testid="price-charts" data-finish={finish ?? ''} />
+  ),
+}))
+vi.mock('../../../../components/design-system/CardArt', () => ({
+  CardArt: () => <div />,
+}))
+vi.mock('../../../../components/design-system/AreaChart', () => ({
+  AreaChart: () => <div />,
+}))
+vi.mock('../../../../components/design-system/Pip', () => ({
+  Pip: () => <span />,
+}))
+
+const mockCard: CardDetail = {
+  card_version_id: '11111111-1111-1111-1111-111111111111',
+  card_name: 'Sheoldred',
+  set_code: 'mom',
+  set_name: 'March of the Machine',
+  finish: 'non-foil',
+  rarity_name: 'rare',
+  price: 42.5,
+  price_change_1d: 1.2,
+  price_change_7d: -0.5,
+  price_change_30d: 3.1,
+  image_uri: null,
+  spark: [],
+  available_finishes: ['nonfoil', 'foil'],
+}
+
+describe('CardDetailView', () => {
+  it('renders a chip for each available finish', () => {
+    render(<CardDetailView card={mockCard} />)
+    expect(screen.getByText('nonfoil')).toBeTruthy()
+    expect(screen.getByText('foil')).toBeTruthy()
+  })
+
+  it('defaults selected finish to first available finish', () => {
+    render(<CardDetailView card={mockCard} />)
+    expect(screen.getByTestId('price-charts').dataset.finish).toBe('nonfoil')
+  })
+
+  it('updates selected finish and passes it to PriceCharts when chip clicked', () => {
+    render(<CardDetailView card={mockCard} />)
+    fireEvent.click(screen.getByText('foil'))
+    expect(screen.getByTestId('price-charts').dataset.finish).toBe('foil')
+  })
+
+  it('falls back to nonfoil chip when available_finishes is empty', () => {
+    render(<CardDetailView card={{ ...mockCard, available_finishes: [] }} />)
+    expect(screen.getByText('nonfoil')).toBeTruthy()
+  })
+
+  it('falls back to nonfoil chip when available_finishes is undefined', () => {
+    const { available_finishes: _, ...cardWithoutFinishes } = mockCard
+    render(<CardDetailView card={cardWithoutFinishes as CardDetail} />)
+    expect(screen.getByText('nonfoil')).toBeTruthy()
+  })
+})

--- a/src/frontend/src/features/cards/components/__tests__/PriceCharts.test.tsx
+++ b/src/frontend/src/features/cards/components/__tests__/PriceCharts.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
+import { server } from '../../../../mocks/server'
+import { PriceCharts } from '../PriceCharts'
+import type { CardDetail } from '../../types'
+
+const mockCard: CardDetail = {
+  card_version_id: '11111111-1111-1111-1111-111111111111',
+  card_name: 'Sheoldred',
+  set_code: 'mom',
+  set_name: 'March of the Machine',
+  finish: 'non-foil',
+  rarity_name: 'rare',
+  price_change_1d: 0,
+  price_change_7d: 0,
+  price_change_30d: 0,
+  image_uri: null,
+  spark: [],
+  available_finishes: ['nonfoil', 'foil'],
+}
+
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+)
+
+describe('PriceCharts', () => {
+  it('sends finish query param when finish prop is provided', async () => {
+    let capturedFinish: string | null = null
+
+    server.use(
+      http.get('/api/catalog/mtg/card-reference/:id/price-history', ({ request }) => {
+        capturedFinish = new URL(request.url).searchParams.get('finish')
+        return HttpResponse.json({
+          data: { price_history_list_avg: [], price_history_sold_avg: [] },
+        })
+      })
+    )
+
+    render(<PriceCharts card={mockCard} finish="foil" />, { wrapper: Wrapper })
+
+    await waitFor(() => expect(capturedFinish).toBe('foil'))
+  })
+
+  it('omits finish query param when no finish prop is provided', async () => {
+    let capturedFinish: string | null = 'sentinel'
+
+    server.use(
+      http.get('/api/catalog/mtg/card-reference/:id/price-history', ({ request }) => {
+        capturedFinish = new URL(request.url).searchParams.get('finish')
+        return HttpResponse.json({
+          data: { price_history_list_avg: [], price_history_sold_avg: [] },
+        })
+      })
+    )
+
+    render(<PriceCharts card={mockCard} />, { wrapper: Wrapper })
+
+    await waitFor(() => expect(capturedFinish).toBeNull())
+  })
+})

--- a/src/frontend/src/features/cards/types.ts
+++ b/src/frontend/src/features/cards/types.ts
@@ -35,6 +35,7 @@ export interface CardDetail extends CardSummary {
   image_large?: string | null
   price_history_list_avg?: number[]
   price_history_sold_avg?: number[]
+  available_finishes?: string[]
 }
 
 export interface CardSearchParams {

--- a/src/frontend/src/mocks/data.ts
+++ b/src/frontend/src/mocks/data.ts
@@ -23,15 +23,16 @@ export const MOCK_CARDS: CardSummary[] = [
 export const MOCK_CARD_DETAIL: Record<string, CardDetail> = {
   'ragavan-mh2': {
     ...MOCK_CARDS[0],
+    available_finishes: ['nonfoil', 'foil', 'etched'],
     mana_cost: '{R}',
     type_line: 'Legendary Creature — Monkey Pirate',
     oracle_text: "Whenever Ragavan, Nimble Pilferer deals combat damage to a player, create a Treasure token and exile the top card of that player's library. Until end of turn, you may cast that card.\nDash {R}",
     artist: 'Simon Dominic',
     price_history: makeSpark(50, 84.5, 365),
     prints: [
-      { id: 'ragavan-mh2-foil',   set_code: 'MH2', set_name: 'Modern Horizons 2', finish: 'foil',     price: 110.0, image_uri: null },
-      { id: 'ragavan-mh2-etched', set_code: 'MH2', set_name: 'Modern Horizons 2', finish: 'etched',   price: 95.0,  image_uri: null },
-      { id: 'ragavan-mh2-retro',  set_code: 'MH2', set_name: 'Modern Horizons 2', finish: 'non-foil', price: 88.0,  image_uri: null },
+      { id: 'ragavan-mh2-foil',   set: 'MH2', set_name: 'Modern Horizons 2', finish: 'foil',     price: 110.0, image_uri: null },
+      { id: 'ragavan-mh2-etched', set: 'MH2', set_name: 'Modern Horizons 2', finish: 'etched',   price: 95.0,  image_uri: null },
+      { id: 'ragavan-mh2-retro',  set: 'MH2', set_name: 'Modern Horizons 2', finish: 'non-foil', price: 88.0,  image_uri: null },
     ],
   },
 }

--- a/tests/unit/core/models/card_catalog/test_card_detail_model.py
+++ b/tests/unit/core/models/card_catalog/test_card_detail_model.py
@@ -1,0 +1,26 @@
+"""Unit tests for CardDetail.available_finishes field."""
+import pytest
+from automana.core.models.card_catalog.card import CardDetail
+
+pytestmark = pytest.mark.unit
+
+_BASE = {
+    "card_name": "Sheoldred",
+    "set_name": "March of the Machine",
+    "set_code": "mom",
+    "cmc": 4,
+    "rarity_name": "rare",
+    "oracle_text": "",
+    "digital": False,
+    "image_normal": None,
+}
+
+
+def test_card_detail_available_finishes_populated():
+    card = CardDetail.model_validate({**_BASE, "available_finishes": ["nonfoil", "foil"]})
+    assert card.available_finishes == ["nonfoil", "foil"]
+
+
+def test_card_detail_available_finishes_defaults_to_empty_list():
+    card = CardDetail.model_validate(_BASE)
+    assert card.available_finishes == []

--- a/tests/unit/core/repositories/card_catalog/test_card_repository_get.py
+++ b/tests/unit/core/repositories/card_catalog/test_card_repository_get.py
@@ -49,3 +49,13 @@ async def test_get_returns_none_when_card_not_found():
     repo = _make_repo([])
     result = await repo.get(card_id=UUID("00000000-0000-0000-0000-000000000000"))
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_query_lowercases_finish_codes():
+    repo = _make_repo([{**_BASE_ROW, "available_finishes": []}])
+    await repo.get(card_id=_CARD_ID)
+    sql = repo.execute_query.await_args.args[0]
+    assert "LOWER(cf.code)" in sql
+    assert "card_version_finish" in sql
+    assert "card_catalog.card_finished" in sql

--- a/tests/unit/core/repositories/card_catalog/test_card_repository_get.py
+++ b/tests/unit/core/repositories/card_catalog/test_card_repository_get.py
@@ -1,0 +1,51 @@
+"""Unit tests for CardReferenceRepository.get()"""
+import pytest
+from unittest.mock import AsyncMock
+from uuid import UUID
+from automana.core.repositories.card_catalog.card_repository import CardReferenceRepository
+
+pytestmark = pytest.mark.unit
+
+_CARD_ID = UUID("11111111-1111-1111-1111-111111111111")
+
+_BASE_ROW = {
+    "card_version_id": str(_CARD_ID),
+    "card_name": "Sheoldred",
+    "rarity_name": "rare",
+    "set_name": "March of the Machine",
+    "set_code": "mom",
+    "cmc": 4,
+    "oracle_text": "...",
+    "released_at": "2023-04-21",
+    "digital": False,
+    "image_large": None,
+}
+
+
+def _make_repo(rows):
+    repo = CardReferenceRepository.__new__(CardReferenceRepository)
+    repo.execute_query = AsyncMock(return_value=rows)
+    return repo
+
+
+@pytest.mark.asyncio
+async def test_get_returns_available_finishes():
+    row = {**_BASE_ROW, "available_finishes": ["nonfoil", "foil"]}
+    repo = _make_repo([row])
+    result = await repo.get(card_id=_CARD_ID)
+    assert result["available_finishes"] == ["nonfoil", "foil"]
+
+
+@pytest.mark.asyncio
+async def test_get_returns_empty_list_when_no_finish_rows():
+    row = {**_BASE_ROW, "available_finishes": []}
+    repo = _make_repo([row])
+    result = await repo.get(card_id=_CARD_ID)
+    assert result["available_finishes"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_when_card_not_found():
+    repo = _make_repo([])
+    result = await repo.get(card_id=UUID("00000000-0000-0000-0000-000000000000"))
+    assert result is None


### PR DESCRIPTION
## Summary

- **Backend:** `card_repository.get()` now includes a correlated subquery returning `available_finishes` — an array of lowercased finish codes (e.g. `['nonfoil', 'foil', 'etched']`) from `card_catalog.card_version_finish` for the requested card version. `CardDetail` Pydantic model gains a non-optional `available_finishes: List[str]` field (defaults to `[]`).
- **Frontend:** Card detail page renders dynamic finish chips based on `available_finishes` (falls back to `['nonfoil']` when empty). Selecting a chip sets `selectedFinish` state and triggers a price history re-fetch via `PriceCharts`'s new `finish` prop.
- **Cleanup:** Fixed stale `pricing.card_finished` schema reference → `card_catalog.card_finished` in `pricing_integrity_checks.sql` and in `card_repository.get_price_history()`.

## Test Plan

- [ ] Backend unit tests: `tests/unit/core/repositories/card_catalog/test_card_repository_get.py` (SQL assertions, multi-finish return, empty fallback)
- [ ] Backend model tests: `tests/unit/core/models/card_catalog/test_card_detail_model.py`
- [ ] Frontend component tests: `CardDetailView.test.tsx` (renders chips, click selection, fallback for empty/undefined `available_finishes`)
- [ ] Frontend query tests: `PriceCharts.test.tsx` (asserts `finish` query param forwarded to price-history endpoint)
- [ ] Manual smoke test (requires Scryfall pipeline run to populate `card_version_finish`): navigate to a card detail page and verify finish chips match DB data; clicking a chip re-fetches the price chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)