### PR TITLE
fix: make DFC card flip work end-to-end

### DIFF
--- a/deploy/docker-compose.dev.yml
+++ b/deploy/docker-compose.dev.yml
@@ -87,6 +87,7 @@ services:
       - frontend-node-modules:/app/node_modules
     environment:
       VITE_HMR_HOST: automana.duckdns.org
+      VITE_DISABLE_MSW: "true"
     restart: unless-stopped
     networks:
       - backend-network

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -102,16 +102,23 @@ class CardReferenceRepository(AbstractRepository[Any]):
                 ) AS available_finishes,
                 cv.is_multifaced,
                 cv.card_back_id,
-                (
-                    SELECT i.image_uris->>'large'
-                    FROM   card_catalog.card_faces face
-                    JOIN   card_catalog.face_illustration fi
-                               ON fi.face_id = face.card_faces_id
-                    JOIN   card_catalog.illustrations i
-                               ON i.illustration_id = fi.illustration_id
-                    WHERE  face.card_version_id = cv.card_version_id
-                      AND  face.face_index = 1
-                    LIMIT  1
+                COALESCE(
+                    (
+                        SELECT i.image_uris->>'large'
+                        FROM   card_catalog.card_faces face
+                        JOIN   card_catalog.face_illustration fi
+                                   ON fi.face_id = face.card_faces_id
+                        JOIN   card_catalog.illustrations i
+                                   ON i.illustration_id = fi.illustration_id
+                        WHERE  face.card_version_id = cv.card_version_id
+                          AND  face.face_index = 1
+                        LIMIT  1
+                    ),
+                    CASE
+                        WHEN cv.is_multifaced = TRUE
+                         AND cvi.image_uris->>'large' LIKE '%/front/%'
+                        THEN replace(cvi.image_uris->>'large', '/front/', '/back/')
+                    END
                 ) AS back_face_image_uri
             FROM card_catalog.unique_cards_ref uc
             JOIN card_catalog.card_version cv ON uc.unique_card_id = cv.unique_card_id

--- a/src/automana/database/SQL/migrations/migration_29_japanese_card_filter.sql
+++ b/src/automana/database/SQL/migrations/migration_29_japanese_card_filter.sql
@@ -271,3 +271,8 @@ SELECT
     MAX(cmc) AS max_cmc
 FROM card_catalog.v_card_versions_complete
 GROUP BY set_name, set_code;
+
+-- Restore grants wiped by DROP ... CASCADE
+GRANT SELECT ON card_catalog.v_card_versions_complete TO app_admin, app_rw, app_ro, app_readonly, app_agent, app_backend, app_celery;
+GRANT SELECT ON card_catalog.v_cards_by_name         TO app_admin, app_rw, app_ro, app_readonly, app_agent, app_backend, app_celery;
+GRANT SELECT ON card_catalog.v_cards_latest_version  TO app_admin, app_rw, app_ro, app_readonly, app_agent, app_backend, app_celery;

--- a/src/automana/database/SQL/migrations/migration_30_face_illustration_image_uris.sql
+++ b/src/automana/database/SQL/migrations/migration_30_face_illustration_image_uris.sql
@@ -1,0 +1,46 @@
+-- Backfill illustrations.image_uris for face illustrations.
+--
+-- The insert_full_card_version procedure was not storing image_uris when
+-- inserting face illustration rows.  For DFC cards (face_index > 0) the back
+-- face URL follows the same Scryfall CDN pattern as the front face but with
+-- '/back/' instead of '/front/'.  For front faces (face_index = 0) the image
+-- is already stored in card_version_illustration, so we copy it there too.
+
+UPDATE card_catalog.illustrations il
+SET    image_uris  = face_img.image_uris,
+       updated_at  = now()
+FROM (
+    -- face_index 0: copy image_uris directly from card_version_illustration
+    SELECT fi.illustration_id,
+           cvi.image_uris
+    FROM   card_catalog.face_illustration fi
+    JOIN   card_catalog.card_faces        cf  ON cf.card_faces_id  = fi.face_id
+    JOIN   card_catalog.card_version_illustration cvi
+                                              ON cvi.card_version_id = cf.card_version_id
+    WHERE  cf.face_index = 0
+      AND  cvi.image_uris IS NOT NULL
+
+    UNION ALL
+
+    -- face_index > 0 (back/transform faces): derive from front URL by swapping /front/ -> /back/
+    SELECT fi.illustration_id,
+           jsonb_build_object(
+               'small',    replace(cvi.image_uris->>'small',    '/front/', '/back/'),
+               'normal',   replace(cvi.image_uris->>'normal',   '/front/', '/back/'),
+               'large',    replace(cvi.image_uris->>'large',    '/front/', '/back/'),
+               'png',      replace(cvi.image_uris->>'png',      '/front/', '/back/'),
+               'art_crop', replace(cvi.image_uris->>'art_crop', '/front/', '/back/'),
+               'border_crop', replace(cvi.image_uris->>'border_crop', '/front/', '/back/')
+           ) AS image_uris
+    FROM   card_catalog.face_illustration fi
+    JOIN   card_catalog.card_faces        cf  ON cf.card_faces_id  = fi.face_id
+    JOIN   card_catalog.card_version      cv  ON cv.card_version_id = cf.card_version_id
+    JOIN   card_catalog.card_version_illustration cvi
+                                              ON cvi.card_version_id = cf.card_version_id
+    WHERE  cf.face_index > 0
+      AND  cv.is_multifaced = TRUE
+      AND  cvi.image_uris IS NOT NULL
+      AND  cvi.image_uris->>'large' LIKE '%/front/%'
+) face_img
+WHERE il.illustration_id = face_img.illustration_id
+  AND il.image_uris IS DISTINCT FROM face_img.image_uris;

--- a/src/automana/database/SQL/schemas/02_card_schema.sql
+++ b/src/automana/database/SQL/schemas/02_card_schema.sql
@@ -1060,16 +1060,17 @@ BEGIN
                 VALUES (v_artist_uuid, v_artist_name)
                 ON CONFLICT DO NOTHING;
 
-                INSERT INTO card_catalog.illustrations (illustration_id)
-                VALUES (v_illustration_id)
-                ON CONFLICT DO NOTHING;
+                INSERT INTO card_catalog.illustrations (illustration_id, image_uris)
+                VALUES (v_illustration_id, v_face -> 'image_uris')
+                ON CONFLICT (illustration_id) DO UPDATE
+                    SET image_uris = EXCLUDED.image_uris,
+                        updated_at = now()
+                WHERE card_catalog.illustrations.image_uris IS DISTINCT FROM EXCLUDED.image_uris;
 
                 INSERT INTO card_catalog.illustration_artist (illustration_id, artist_id)
                 VALUES (v_illustration_id, v_artist_uuid)
                 ON CONFLICT DO NOTHING;
 
-                --INSERT INTO card_catalog.card_version_illustration (card_version_id, illustration_id)
-                --VALUES (v_card_version_id, v_illustration_id)
                 INSERT INTO card_catalog.face_illustration (face_id, illustration_id)
                 VALUES  (v_card_faces_id , v_illustration_id)
                 ON CONFLICT DO NOTHING;

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -1,7 +1,6 @@
 // src/frontend/src/mocks/handlers.ts
-import { http, HttpResponse } from 'msw'
-import { MOCK_CARDS, MOCK_CARD_DETAIL } from './data'
-import type { CardSearchResponse, CardSuggestResponse } from '../features/cards/types'
+import { http, HttpResponse, passthrough } from 'msw'
+import { MOCK_CARD_DETAIL } from './data'
 import {
   MOCK_AUTHORIZED_USERS,
   MOCK_PENDING_INVITES,
@@ -49,52 +48,13 @@ export const handlers = [
   }),
 
 
-  http.get('/api/catalog/mtg/card-reference/', ({ request }) => {
-    const url = new URL(request.url)
-    const q = (url.searchParams.get('q') ?? '').toLowerCase()
-    const rarity = url.searchParams.get('rarity')
-    const finish = url.searchParams.get('finish')
-
-    let cards = MOCK_CARDS
-    if (q) cards = cards.filter((c) => c.card_name.toLowerCase().includes(q))
-    if (rarity) cards = cards.filter((c) => c.rarity_name === rarity)
-    if (finish) cards = cards.filter((c) => c.finish === finish)
-
-    const response: CardSearchResponse = {
-      cards,
-      total: cards.length,
-      page: 1,
-      per_page: 20,
-    }
-    return HttpResponse.json(response)
-  }),
-
-  http.get('/api/catalog/mtg/card-reference/suggest', ({ request }) => {
-    const url = new URL(request.url)
-    const q = (url.searchParams.get('q') ?? '').toLowerCase()
-    const limit = parseInt(url.searchParams.get('limit') ?? '10', 10)
-
-    let suggestions = MOCK_CARDS
-    if (q) suggestions = suggestions.filter((c) => c.card_name.toLowerCase().includes(q))
-    suggestions = suggestions.slice(0, limit)
-
-    const response: CardSuggestResponse = {
-      suggestions: suggestions.map((c) => ({
-        card_version_id: c.card_version_id,
-        card_name: c.card_name,
-        set_code: c.set_code,
-        collector_number: '1',
-        rarity_name: c.rarity_name,
-        scryfall_id: undefined,
-        score: 1.0,
-      })),
-    }
-    return HttpResponse.json(response)
-  }),
-
+  http.get('/api/catalog/mtg/card-reference/', () => passthrough()),
+  http.get('/api/catalog/mtg/card-reference/suggest', () => passthrough()),
+  http.get('/api/catalog/mtg/card-reference/stats', () => passthrough()),
+  http.get('/api/catalog/mtg/card-reference/:id/price-history', () => passthrough()),
   http.get('/api/catalog/mtg/card-reference/:id', ({ params }) => {
     const card = MOCK_CARD_DETAIL[params.id as string]
-    if (!card) return new HttpResponse(null, { status: 404 })
-    return HttpResponse.json(card)
+    if (card) return HttpResponse.json(card)
+    return passthrough()
   }),
 ]

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -12,6 +12,10 @@ export default defineConfig({
   ],
   server: {
     allowedHosts: ['automana.duckdns.org'],
+    watch: {
+      usePolling: true,
+      interval: 300,
+    },
     proxy: {
       '/api': 'http://backend:8000',
     },


### PR DESCRIPTION
# Summary

Three independent root causes were preventing the flip button from appearing on double-faced cards (DFCs). This PR fixes all three layers: a database permission regression from the previous migration, missing back-face image data in the DB, and a dev-environment issue where MSW was silently intercepting all card API calls with stale mock data.

---

# Changes Introduced

**DB grants (migration_29 regression)**
- `migration_29_japanese_card_filter.sql`: the `DROP MATERIALIZED VIEW ... CASCADE` wiped all existing `SELECT` grants on `v_card_versions_complete`, `v_cards_by_name`, and `v_cards_latest_version`. Added `GRANT SELECT` for all app roles at the end of the migration. Applied live; card search was returning 500 for all users.

**DFC back face image data**
- `02_card_schema.sql`: `insert_full_card_version` inserted face illustration rows with no `image_uris` (treating `illustrations` as a deduplication anchor only). Fixed to store the face's `image_uris` via `ON CONFLICT DO UPDATE`.
- `migration_30_face_illustration_image_uris.sql`: backfills `illustrations.image_uris` for 6,984 existing face illustrations. `face_index=0` copies directly from `card_version_illustration`; `face_index>0` derives the Scryfall back URL via `/front/` → `/back/` substitution.
- `card_repository.py`: adds a `COALESCE` fallback for 1,443 DFC cards whose `face_illustration` row was never created (illustration_id was null at ingest time). Falls back to the URL substitution so these cards also return a usable `back_face_image_uri`.

**Frontend / dev environment**
- `handlers.ts`: replaced the card catalog mock handlers (which returned 8 hardcoded non-DFC cards for search and 404 for any real card UUID) with `passthrough()`.
- `docker-compose.dev.yml`: added `VITE_DISABLE_MSW=true` — MSW service-worker handler changes don't propagate via HMR without a full page reload, making passthrough unreliable without this flag.
- `vite.config.ts`: added `usePolling: true / interval: 300ms` — Vite inside Docker on Linux doesn't receive inotify events from the bind-mounted source tree, so HMR was silently broken.

---

# How to Test

1. Hard-refresh the browser (`Ctrl+Shift+R`) after pulling.
2. Navigate to the search page and search for `"Delver"`.
3. Click **Delver of Secrets // Insectile Aberration**.
4. Confirm the `↻` flip button appears in the bottom-right of the card art.
5. Click it — the card should flip with a CSS 3D animation to show Insectile Aberration.
6. Confirm card search results are now real DB cards (not the 8 hardcoded mock cards).

---

# Acceptance Checklist
- [ ] Code compiles without errors
- [ ] All tests pass (if applicable)
- [ ] Documentation updated
- [ ] No debug logs left behind
- [ ] Follows project coding standards
- [ ] Ready for review

---

# Additional Notes

- The 1,443 DFC cards with missing `face_illustration` entries will continue to use the URL-derivation fallback at query time. They can be fully backfilled on the next Scryfall pipeline run now that the stored procedure is fixed.
- `VITE_DISABLE_MSW=true` disables all MSW mocks including the eBay credential/user stubs. Re-enable by removing the env var if eBay mock flows are needed before the real eBay integration is wired up.