### PR TITLE
feat(search): polish set-browser landing — hero header, bigger filter, mode tabs

### DIFF
--- a/src/frontend/src/features/cards/components/SetBrowser.module.css
+++ b/src/frontend/src/features/cards/components/SetBrowser.module.css
@@ -1,22 +1,69 @@
 /* SetBrowser.module.css */
 .wrap { display: flex; flex-direction: column; padding: 24px 36px; }
 
+/* Hero header */
+.hero { text-align: center; padding: 16px 0 4px; }
+.heroTitle {
+  font-family: var(--font-serif, serif);
+  font-size: 28px;
+  font-weight: 400;
+  color: var(--hd-text);
+  margin: 0 0 6px;
+  letter-spacing: -0.5px;
+}
+.heroAccent {
+  display: inline-block;
+  width: 38px;
+  height: 2px;
+  background: var(--hd-accent);
+  border-radius: 1px;
+  margin: 6px auto 12px;
+}
+.heroSub { font-size: 13px; color: var(--hd-muted); margin: 0; }
+.heroSub strong { color: var(--hd-text); }
+
+/* Bigger filter input */
+.filterWrap { padding: 16px 0 8px; max-width: 640px; margin: 0 auto; width: 100%; }
+.filterField { position: relative; }
 .filterInput {
-  background: var(--hd-surface-alt);
-  border: 1px solid var(--hd-border);
-  border-radius: 8px;
-  padding: 8px 14px;
-  font-size: 13px;
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--hd-surface);
+  border: 1px solid var(--hd-border-hot, rgba(150, 200, 255, 0.28));
+  border-radius: 12px;
+  padding: 16px 18px 16px 48px;
+  font-size: 16px;
   color: var(--hd-text);
   outline: none;
-  margin-bottom: 16px;
-  width: 100%;
-  max-width: 420px;
+  transition: border-color 0.15s, box-shadow 0.15s;
 }
 .filterInput::placeholder { color: var(--hd-muted); }
-.filterInput:focus { border-color: rgba(var(--hd-accent-rgb), 0.5); }
+.filterInput:focus {
+  border-color: rgba(var(--hd-accent-rgb), 0.55);
+  box-shadow: 0 0 0 4px rgba(var(--hd-accent-rgb), 0.08);
+}
+.filterIcon {
+  position: absolute;
+  left: 18px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--hd-muted);
+  pointer-events: none;
+}
+.filterHint {
+  font-size: 11px;
+  color: var(--hd-sub, var(--hd-muted));
+  text-align: center;
+  margin: 8px 0 16px;
+  font-family: var(--font-mono);
+}
+.filterHint code {
+  color: var(--hd-accent);
+  background: transparent;
+  font-family: var(--font-mono);
+}
 
-.list { display: flex; flex-direction: column; gap: 5px; }
+.list { display: flex; flex-direction: column; gap: 5px; max-width: 760px; margin: 0 auto; width: 100%; }
 
 .row {
   background: var(--hd-surface);
@@ -86,4 +133,4 @@
   text-align: right;
 }
 
-.empty { font-size: 13px; color: var(--hd-muted); padding: 16px 0; }
+.empty { font-size: 13px; color: var(--hd-muted); padding: 16px 0; text-align: center; }

--- a/src/frontend/src/features/cards/components/SetBrowser.tsx
+++ b/src/frontend/src/features/cards/components/SetBrowser.tsx
@@ -11,6 +11,13 @@ const FALLBACK_ICON = (
   </svg>
 )
 
+const SEARCH_ICON = (
+  <svg className={styles.filterIcon} width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="11" cy="11" r="7"/>
+    <path d="M21 21l-4.35-4.35"/>
+  </svg>
+)
+
 function SetRow({ set, onSelect }: { set: SetBrowseItem; onSelect: (code: string) => void }) {
   return (
     <button className={styles.row} onClick={() => onSelect(set.set_code)}>
@@ -54,13 +61,30 @@ export function SetBrowser({ onSelect }: SetBrowserProps) {
 
   return (
     <div className={styles.wrap}>
-      <input
-        className={styles.filterInput}
-        placeholder="Filter sets…"
-        value={filter}
-        onChange={e => setFilter(e.target.value)}
-        aria-label="Filter sets by name or code"
-      />
+      <header className={styles.hero}>
+        <h1 className={styles.heroTitle}>Browse Magic Sets</h1>
+        <span className={styles.heroAccent} aria-hidden />
+        <p className={styles.heroSub}>
+          <strong>{sets.length.toLocaleString()} sets</strong> · sorted by release date · newest first
+        </p>
+      </header>
+
+      <div className={styles.filterWrap}>
+        <div className={styles.filterField}>
+          {SEARCH_ICON}
+          <input
+            className={styles.filterInput}
+            placeholder="Filter sets — type a name or code…"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            aria-label="Filter sets by name or code"
+          />
+        </div>
+        <p className={styles.filterHint}>
+          e.g. <code>mkm</code>, <code>Karlov Manor</code>, <code>Eldraine</code>
+        </p>
+      </div>
+
       <div className={styles.list}>
         {filtered.length === 0
           ? <p className={styles.empty}>No sets match "{filter}"</p>

--- a/src/frontend/src/routes/Search.module.css
+++ b/src/frontend/src/routes/Search.module.css
@@ -7,3 +7,54 @@
   margin: 0 -36px;
   border-top: 1px solid var(--hd-border);
 }
+
+/* Mode tabs (entry-point page only) */
+.tabs {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  padding: 12px 36px 0;
+}
+.tab {
+  background: transparent;
+  border: 1px solid var(--hd-border);
+  border-radius: 999px;
+  padding: 7px 18px;
+  font-size: 12px;
+  color: var(--hd-muted);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+.tab:hover {
+  border-color: rgba(var(--hd-accent-rgb), 0.3);
+  color: var(--hd-text);
+}
+.tabActive {
+  background: rgba(var(--hd-accent-rgb), 0.08);
+  border-color: rgba(var(--hd-accent-rgb), 0.4);
+  color: var(--hd-accent);
+  font-weight: 700;
+}
+.tabActive:hover {
+  border-color: rgba(var(--hd-accent-rgb), 0.55);
+  color: var(--hd-accent);
+}
+.tabDot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+/* Card-name mode wrapper */
+.cardMode { padding: 24px 36px; max-width: 760px; margin: 0 auto; }
+.cardModeHint {
+  font-size: 12px;
+  color: var(--hd-muted);
+  text-align: center;
+  padding: 20px 0;
+}

--- a/src/frontend/src/routes/search.tsx
+++ b/src/frontend/src/routes/search.tsx
@@ -1,4 +1,5 @@
 // src/frontend/src/routes/search.tsx
+import { useState } from 'react'
 import { createFileRoute, useNavigate } from '@tanstack/react-router'
 import { z } from 'zod'
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
@@ -6,6 +7,7 @@ import { AppShell } from '../components/layout/AppShell'
 import { TopBar } from '../components/layout/TopBar'
 import { SearchFilters } from '../features/cards/components/SearchFilters'
 import { SearchResults } from '../features/cards/components/SearchResults'
+import { SearchBarWithSuggestions } from '../features/cards/components/SearchBarWithSuggestions'
 import { SetBrowser } from '../features/cards/components/SetBrowser'
 import { SelectedSetBanner } from '../features/cards/components/SelectedSetBanner'
 import { cardInfiniteSearchQueryOptions, setBrowseQueryOptions } from '../features/cards/api'
@@ -27,6 +29,8 @@ export const Route = createFileRoute('/search')({
   component: SearchPage,
 })
 
+type Mode = 'set' | 'card'
+
 function SearchPage() {
   const search = Route.useSearch()
   const navigate = useNavigate({ from: '/search' })
@@ -34,6 +38,10 @@ function SearchPage() {
   // Always pre-fetch browse data so SelectedSetBanner can resolve metadata
   // even when the user lands directly at /search?set=mkm
   useQuery(setBrowseQueryOptions())
+
+  // Entry-point tab mode (only used when no set is selected).
+  // Defaults to 'card' if the URL already has a name query, else 'set'.
+  const [mode, setMode] = useState<Mode>(search.q ? 'card' : 'set')
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
     cardInfiniteSearchQueryOptions(search)
@@ -48,28 +56,71 @@ function SearchPage() {
     ? search.set.toUpperCase()
     : search.q
       ? `results for "${search.q}"`
-      : 'browse by set'
+      : mode === 'card'
+        ? 'search by card name'
+        : 'browse by set'
 
+  // ---- Set selected: banner + filters + results (unchanged) ----
+  if (search.set) {
+    return (
+      <AppShell active="collection">
+        <TopBar title="Search" subtitle={subtitle} />
+        <SelectedSetBanner
+          setCode={search.set}
+          onClear={() => navigate({ search: prev => ({ ...prev, set: undefined }) })}
+        />
+        <div className={styles.layout}>
+          <SearchFilters
+            params={search}
+            promoTypeFacets={promoTypeFacets}
+            rarityFacets={rarityFacets}
+          />
+          <SearchResults
+            cards={cards}
+            total={total}
+            fetchNextPage={fetchNextPage}
+            hasNextPage={hasNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+          />
+        </div>
+      </AppShell>
+    )
+  }
+
+  // ---- Entry-point: mode tabs + chosen mode body ----
   return (
     <AppShell active="collection">
       <TopBar title="Search" subtitle={subtitle} />
 
-      {!search.set ? (
+      <div className={styles.tabs} role="tablist" aria-label="Search mode">
+        <button
+          role="tab"
+          aria-selected={mode === 'set'}
+          className={`${styles.tab} ${mode === 'set' ? styles.tabActive : ''}`}
+          onClick={() => setMode('set')}
+        >
+          {mode === 'set' && <span className={styles.tabDot} aria-hidden />}
+          By Set
+        </button>
+        <button
+          role="tab"
+          aria-selected={mode === 'card'}
+          className={`${styles.tab} ${mode === 'card' ? styles.tabActive : ''}`}
+          onClick={() => setMode('card')}
+        >
+          {mode === 'card' && <span className={styles.tabDot} aria-hidden />}
+          By Card Name
+        </button>
+      </div>
+
+      {mode === 'set' ? (
         <SetBrowser
           onSelect={(code) => navigate({ search: prev => ({ ...prev, set: code }) })}
         />
       ) : (
-        <>
-          <SelectedSetBanner
-            setCode={search.set}
-            onClear={() => navigate({ search: prev => ({ ...prev, set: undefined }) })}
-          />
-          <div className={styles.layout}>
-            <SearchFilters
-              params={search}
-              promoTypeFacets={promoTypeFacets}
-              rarityFacets={rarityFacets}
-            />
+        <div className={styles.cardMode}>
+          <SearchBarWithSuggestions placeholder="Search any card by name…" />
+          {search.q ? (
             <SearchResults
               cards={cards}
               total={total}
@@ -77,8 +128,12 @@ function SearchPage() {
               hasNextPage={hasNextPage}
               isFetchingNextPage={isFetchingNextPage}
             />
-          </div>
-        </>
+          ) : (
+            <p className={styles.cardModeHint}>
+              Type a card name above — suggestions appear after 2 characters.
+            </p>
+          )}
+        </div>
       )}
     </AppShell>
   )


### PR DESCRIPTION
# Summary

Polishes the `/search` landing page so the set browser feels intentional instead of a bare list. Adds a centred hero, a prominent search-style filter input, and **By Set / By Card Name** mode tabs so card-name search is no longer hidden behind a set selection. Follow-up to #212.

---

# Changes Introduced

**`SetBrowser` (`SetBrowser.tsx` + `.module.css`)**
- Hero header with title "Browse Magic Sets", green accent underline, and a dynamic subtitle: \`{N} sets · sorted by release date · newest first\`
- Filter input enlarged to 16px font, full search-style appearance with magnifying-glass icon, focus glow, and a hint line of example queries (\`mkm\`, \`Karlov Manor\`, \`Eldraine\`)
- List width capped (760px) and centred for better readability

**`/search` route (`search.tsx` + `Search.module.css`)**
- Pill-style mode tabs above the entry-point body — "By Set" (default) and "By Card Name"
- Card-name mode renders `SearchBarWithSuggestions` plus results when a query exists; previously this search bar was only reachable after picking a set
- Mode defaults to "card" when the URL already has `?q=…` (deep-linkable)
- Set-selected mode (banner + filters + grid) is unchanged

---

# How to Test

1. Visit `/search` with no query string → hero header + tabs + big filter visible
2. Click **By Card Name** → `SearchBarWithSuggestions` appears with the empty-state hint
3. Type a card name → results render below
4. Click **By Set** → back to the set browser
5. Visit `/search?q=elesh` directly → defaults to card-name tab

---

# Acceptance Checklist

- [x] Code compiles (TypeScript clean)
- [x] No debug logs left behind
- [x] Follows project coding standards
- [ ] Ready for review