### PR TITLE
feat(card-detail, search): card-detail Hero redesign + search-page grouping

### DIFF
--- a/src/automana/core/repositories/card_catalog/set_repository.py
+++ b/src/automana/core/repositories/card_catalog/set_repository.py
@@ -185,13 +185,13 @@ class SetReferenceRepository(AbstractRepository[Any]):
 
     async def get(self, set_id: UUID) -> dict[str, Any]|None:
         query = """ 
-                SELECT * FROM card_catalog.joined_set_materialized WHERE set_id = $1
+                SELECT * FROM card_catalog.v_joined_set_materialized WHERE set_id = $1
         """
         result =  await self.execute_query(query, set_id)
         return result[0] if result else None
     
     async def list(self, limit: int = 100, offset: int = 0, ids: Optional[Sequence[UUID]] = None):
-        query = "SELECT * FROM card_catalog.joined_set_materialized"
+        query = "SELECT * FROM card_catalog.v_joined_set_materialized"
         counter = 1
         values = []
         if ids:
@@ -213,7 +213,7 @@ class SetReferenceRepository(AbstractRepository[Any]):
                 vsm.card_count,
                 vsm.released_at,
                 iqr.icon_query_uri AS icon_svg_uri
-            FROM card_catalog.joined_set_materialized vsm
+            FROM card_catalog.v_joined_set_materialized vsm
             LEFT JOIN card_catalog.icon_set ics ON ics.set_id = vsm.set_id
             LEFT JOIN card_catalog.icon_query_ref iqr
                    ON iqr.icon_query_id = ics.icon_query_id

--- a/src/frontend/src/routes/search.tsx
+++ b/src/frontend/src/routes/search.tsx
@@ -45,9 +45,16 @@ function SearchPage() {
   // Defaults to 'card' if the URL already has a name query, else 'set'.
   const [mode, setMode] = useState<Mode>(search.q ? 'card' : 'set')
 
-  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery(
-    cardInfiniteSearchQueryOptions(search)
-  )
+  // The card-search endpoint should only fire when we actually have something
+  // to query: either a set is selected (regardless of mode) or the user is in
+  // 'card' mode with a name query. In 'set' mode with no set chosen, only the
+  // set-browse endpoint should hit the network.
+  const shouldFetchCards = !!search.set || (mode === 'card' && !!search.q)
+
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
+    ...cardInfiniteSearchQueryOptions(search),
+    enabled: shouldFetchCards,
+  })
 
   const cards = data?.pages?.flatMap(p => p.cards) ?? []
   const total = data?.pages?.[0]?.pagination?.total_count ?? 0


### PR DESCRIPTION
# Summary

Two parallel UI redesigns plus a backend bug fix that surfaced while testing the search page.

**Card-detail page** has been rewritten around a Hero layout: bigger card art, a unified `GameInfoCard` (mana cost via `mana-font`, oracle text, type line, legalities grid, set info with Keyrune icon, promo badges, illustrator click-through), an extracted `MarketCard`, and an `AIAnalyticsCard` placeholder. The breadcrumb shows `SEARCH > SET > NAME`, each segment is a real link, and the card name lives in the breadcrumb rather than the TopBar.

**Search page** gains a "Group by" control (None / Set / Rarity / Finish), a responsive 2→6 column grid, and applies the same filter-sidebar layout to card-name results that it already uses for set-selected views. Artist click-through navigates to `/search?artist=…`, with backend support in `card_repository.search()`.

**Bug fix:** `set_repository` was querying `card_catalog.joined_set_materialized` (no `v_` prefix), causing a 500 on `/api/catalog/mtg/set-reference/browse` and an empty "By Set" tab. Renamed three call sites to `v_joined_set_materialized` to match the schema.

---

# Changes Introduced

### Card detail
- `card_repository.get()` now reads from `v_card_versions_complete` and deserializes the legalities JSONB to a dict
- New `CardDetail` fields: `mana_cost`, `type_line`, `artist`, `collector_number`, `promo_types`, `legalities`
- `CardDetailView` rewritten with Hero layout
- New components: `GameInfoCard`, `MarketCard`, `LegalityGrid`, `AIAnalyticsCard`, `SetInfoBox`, `OracleCard`, `ManaSymbol`
- Action buttons moved under the card art; "Alert" → "Set alert"
- Keyrune font package installed for set icons; mana-font for symbol rendering
- Breadcrumb: clickable segments, card-name segment runs a card-name search, defensive guards for undefined `set_code`/`card_name`

### Search
- Sidebar nav gets a Search item pointing to `/search`
- `searchSchema` accepts `artist` and `group` (`'set' | 'rarity' | 'finish'`); `group` is excluded from the API request
- `card_repository.search()` adds an artist filter via JSONB EXISTS on illustrations
- `SearchFilters` gains a "Group by" segmented control
- `SearchResults` renders grouped sections with header + count when grouping is on; flat grid otherwise. Rarity/finish ordering respected.
- Grid is responsive: 2 / 3 / 4 / 5 / 6 columns at 720 / 960 / 1200 / 1440 px breakpoints
- Card-name results view (`/search?q=…`) now uses the same sidebar-+-grid layout as the set-selected view; the centered narrow wrapper is kept only for the empty hint state
- `GameInfoCard` illustrator name navigates to `/search?artist={name}`

### Backend fix
- `set_repository.py`: renamed three references from `card_catalog.joined_set_materialized` to `card_catalog.v_joined_set_materialized`

---

# How to Test

1. Card detail
   - Visit any `/cards/:id` route and confirm Hero layout renders with mana symbols, oracle text, legalities grid, set icon, and price charts
   - Click the illustrator name in `GameInfoCard` → should navigate to `/search?artist=<name>`
2. Search grouping
   - Open `/search?q=ragavan`
   - In the left sidebar, toggle "Group by" → Set / Rarity / Finish. Results regroup without a network refetch
3. Set browser
   - On any env where the matview was never refreshed, run `REFRESH MATERIALIZED VIEW card_catalog.v_joined_set_materialized;` once
   - Open `/search` → "By Set" tab → should list ~965 non-digital sets
4. Responsive grid
   - Resize the window: card grid should step between 2/3/4/5/6 columns

---

# Acceptance Checklist
- [x] Code compiles without errors (`vite build` clean, `tsc --noEmit` clean)
- [x] All tests pass (frontend `SearchFilters.promo` + new `GameInfoCard`, `LegalityGrid`, `MarketCard`, `AIAnalyticsCard`, `ManaSymbol` suites — pre-existing `SearchBarWithSuggestions` failures unrelated to this work)
- [ ] Documentation updated
- [x] Added/updated unit tests
- [x] No debug logs left behind
- [x] Follows project coding standards
- [x] Ready for review

---

# Additional Notes
- The `v_joined_set_materialized` matview requires a one-time refresh on environments where it was never populated. The data is built from `card_catalog.sets` + `card_version` and is safe to refresh non-concurrently in dev.
- Pre-existing `SearchBarWithSuggestions` test failures on this branch were verified to exist before this work (via `git stash`) and are not addressed here.