### PR TITLE
fix(set-browser): chips/group filters + ETL icon ingestion + parent-icon fallback

### DIFF
--- a/src/automana/core/models/card_catalog/set.py
+++ b/src/automana/core/models/card_catalog/set.py
@@ -40,7 +40,7 @@ class NewSet(BaseModel):
     nonfoil_only : bool=Field(alias='nonfoil_only', default=False)
     foil_only : bool=Field(alias='foil_only', default=False)
     parent_set : Optional[str]=Field(alias='parent_set', default=None)
-    #icon_svg_uri : Optional[str]=Field(alias='icon_svg_uri', default=None)
+    icon_svg_uri : Optional[str]=Field(alias='icon_svg_uri', default=None)
 
     class Config:
         populate_by_name = True  # Important for handling aliases
@@ -66,6 +66,7 @@ class NewSet(BaseModel):
             'nonfoil_only': data['nonfoil_only'],
             'foil_only': data['foil_only'],
             'parent_set_code': data['parent_set'],
+            'icon_svg_uri': data['icon_svg_uri'],
         }
 
 class UpdatedSet(BaseModel):

--- a/src/automana/core/repositories/card_catalog/set_repository.py
+++ b/src/automana/core/repositories/card_catalog/set_repository.py
@@ -204,6 +204,9 @@ class SetReferenceRepository(AbstractRepository[Any]):
         return await self.execute_query(query, tuple(values))
 
     async def browse(self) -> List[Dict]:
+        # Falls back to the parent set's icon when the set has none of its own —
+        # promo/box sub-sets often ship without their own SVG and inherit the
+        # parent's mark visually.
         query = """
             SELECT
                 vsm.set_id,
@@ -212,11 +215,16 @@ class SetReferenceRepository(AbstractRepository[Any]):
                 vsm.set_type,
                 vsm.card_count,
                 vsm.released_at,
-                iqr.icon_query_uri AS icon_svg_uri
+                COALESCE(iqr.icon_query_uri, parent_iqr.icon_query_uri) AS icon_svg_uri
             FROM card_catalog.v_joined_set_materialized vsm
+            JOIN card_catalog.sets s ON s.set_id = vsm.set_id
             LEFT JOIN card_catalog.icon_set ics ON ics.set_id = vsm.set_id
             LEFT JOIN card_catalog.icon_query_ref iqr
                    ON iqr.icon_query_id = ics.icon_query_id
+            LEFT JOIN card_catalog.icon_set parent_ics
+                   ON parent_ics.set_id = s.parent_set
+            LEFT JOIN card_catalog.icon_query_ref parent_iqr
+                   ON parent_iqr.icon_query_id = parent_ics.icon_query_id
             WHERE vsm.digital = FALSE
             ORDER BY vsm.released_at DESC
         """

--- a/src/automana/core/services/card_catalog/set_service.py
+++ b/src/automana/core/services/card_catalog/set_service.py
@@ -226,6 +226,11 @@ class EnhancedSetImportService:
             if not await storage_service.file_exists(filename):
                 raise set_exception.SetInsertError(f"File not found in storage: {filename}")
 
+            # Insert all sets. parent_set links to sets that did not exist yet
+            # at the time of their child's insertion will be NULL on this run,
+            # but the next weekly Scryfall pipeline pass will backfill them
+            # idempotently via the `parent_set = EXCLUDED.parent_set` UPSERT
+            # in card_catalog.insert_batch_sets.
             await self._process_file_stream(storage_service, filename, resume_from_batch)
 
             self.stats.end_time = datetime.utcnow()
@@ -278,7 +283,7 @@ class EnhancedSetImportService:
                             await asyncio.sleep(0)
                         
                     except Exception as e:
-                        self.stats.processing_errors += 1   
+                        self.stats.processing_errors += 1
                         logger.error(f"âŒ Error processing set at position {self.stats.total_sets}: {str(e)}, {set}")
 
                         # Save failed set for analysis

--- a/src/frontend/src/features/cards/components/SetBrowser.module.css
+++ b/src/frontend/src/features/cards/components/SetBrowser.module.css
@@ -22,48 +22,114 @@
 .heroSub { font-size: 13px; color: var(--hd-muted); margin: 0; }
 .heroSub strong { color: var(--hd-text); }
 
-/* Bigger filter input */
-.filterWrap { padding: 16px 0 8px; max-width: 640px; margin: 0 auto; width: 100%; }
-.filterField { position: relative; }
-.filterInput {
+/* Controls block */
+.controls {
+  max-width: 1000px;
+  margin: 16px auto 20px;
   width: 100%;
-  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px 18px;
   background: var(--hd-surface);
-  border: 1px solid var(--hd-border-hot, rgba(150, 200, 255, 0.28));
-  border-radius: 12px;
-  padding: 16px 18px 16px 48px;
-  font-size: 16px;
-  color: var(--hd-text);
-  outline: none;
-  transition: border-color 0.15s, box-shadow 0.15s;
-}
-.filterInput::placeholder { color: var(--hd-muted); }
-.filterInput:focus {
-  border-color: rgba(var(--hd-accent-rgb), 0.55);
-  box-shadow: 0 0 0 4px rgba(var(--hd-accent-rgb), 0.08);
-}
-.filterIcon {
-  position: absolute;
-  left: 18px;
-  top: 50%;
-  transform: translateY(-50%);
-  color: var(--hd-muted);
-  pointer-events: none;
-}
-.filterHint {
-  font-size: 11px;
-  color: var(--hd-sub, var(--hd-muted));
-  text-align: center;
-  margin: 8px 0 16px;
-  font-family: var(--font-mono);
-}
-.filterHint code {
-  color: var(--hd-accent);
-  background: transparent;
-  font-family: var(--font-mono);
+  border: 1px solid var(--hd-border);
+  border-radius: 10px;
 }
 
-.list { display: flex; flex-direction: column; gap: 5px; max-width: 760px; margin: 0 auto; width: 100%; }
+.controlBlock {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.controlLabel {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  min-width: 70px;
+  padding-top: 6px;
+  flex-shrink: 0;
+}
+
+.chipRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  flex: 1;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  border-radius: 20px;
+  border: 1px solid var(--hd-border);
+  background: transparent;
+  color: var(--hd-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+}
+
+.chip:hover {
+  border-color: var(--hd-border-hot);
+  color: var(--hd-text);
+}
+
+.chipActive {
+  background: rgba(var(--hd-accent-rgb), 0.12);
+  border-color: rgba(var(--hd-accent-rgb), 0.4);
+  color: var(--hd-accent);
+}
+
+.chipCount {
+  font-size: 9.5px;
+  color: var(--hd-sub);
+  padding-left: 4px;
+  border-left: 1px solid var(--hd-border);
+}
+
+.chipActive .chipCount {
+  color: rgba(var(--hd-accent-rgb), 0.7);
+  border-color: rgba(var(--hd-accent-rgb), 0.3);
+}
+
+/* Group sections */
+.group {
+  max-width: 1000px;
+  margin: 0 auto 24px;
+  width: 100%;
+}
+
+.groupHeader {
+  display: flex;
+  align-items: baseline;
+  gap: 12px;
+  padding: 8px 0 10px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid var(--hd-border);
+}
+
+.groupTitle {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--hd-text);
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+}
+
+.groupCount {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--hd-sub);
+}
+
+.list { display: flex; flex-direction: column; gap: 5px; max-width: 1000px; margin: 0 auto; width: 100%; }
 
 .row {
   background: var(--hd-surface);

--- a/src/frontend/src/features/cards/components/SetBrowser.module.css
+++ b/src/frontend/src/features/cards/components/SetBrowser.module.css
@@ -36,6 +36,58 @@
   border-radius: 10px;
 }
 
+.searchRow {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--hd-surface-alt);
+  border: 1px solid var(--hd-border);
+  border-radius: 8px;
+  padding: 10px 14px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.searchRow:focus-within {
+  border-color: rgba(var(--hd-accent-rgb), 0.55);
+  box-shadow: 0 0 0 3px rgba(var(--hd-accent-rgb), 0.08);
+}
+
+.searchIcon {
+  flex-shrink: 0;
+  color: var(--hd-muted);
+}
+
+.searchInput {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--hd-text);
+  font-family: var(--font-sans);
+  font-size: 14px;
+}
+
+.searchInput::placeholder {
+  color: var(--hd-muted);
+}
+
+.searchClear {
+  flex-shrink: 0;
+  background: transparent;
+  border: none;
+  color: var(--hd-sub);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0 4px;
+  transition: color 120ms ease;
+}
+
+.searchClear:hover {
+  color: var(--hd-text);
+}
+
 .controlBlock {
   display: flex;
   align-items: flex-start;

--- a/src/frontend/src/features/cards/components/SetBrowser.tsx
+++ b/src/frontend/src/features/cards/components/SetBrowser.tsx
@@ -46,13 +46,24 @@ function yearOf(released?: string | null): string {
   return released ? released.slice(0, 4) : 'Unknown'
 }
 
+/**
+ * Fallback icon URL constructed from set_code when the DB-backed
+ * icon_svg_uri is null (current state: icon_set / icon_query_ref
+ * tables are not populated by the Scryfall ETL).
+ * Scryfall hosts every set symbol at this stable URL pattern.
+ */
+function iconUrl(set: SetBrowseItem): string {
+  return set.icon_svg_uri || `https://svgs.scryfall.io/sets/${set.set_code.toLowerCase()}.svg`
+}
+
 function SetRow({ set, onSelect }: { set: SetBrowseItem; onSelect: (code: string) => void }) {
+  const [iconBroken, setIconBroken] = useState(false)
   return (
     <button className={styles.row} onClick={() => onSelect(set.set_code)}>
       <span className={styles.icon}>
-        {set.icon_svg_uri
-          ? <img src={set.icon_svg_uri} alt="" aria-hidden />
-          : FALLBACK_ICON}
+        {iconBroken
+          ? FALLBACK_ICON
+          : <img src={iconUrl(set)} alt="" aria-hidden onError={() => setIconBroken(true)} />}
       </span>
       <span className={styles.name}>{set.set_name}</span>
       <span className={styles.meta}>
@@ -70,6 +81,7 @@ interface SetBrowserProps {
 
 export function SetBrowser({ onSelect }: SetBrowserProps) {
   const { data: sets = [], isLoading, isError } = useQuery(setBrowseQueryOptions())
+  const [search, setSearch] = useState('')
   const [selectedTypes, setSelectedTypes] = useState<Set<string>>(new Set())
   const [groupBy, setGroupBy] = useState<GroupBy>('none')
 
@@ -82,9 +94,13 @@ export function SetBrowser({ onSelect }: SetBrowserProps) {
   }, [sets])
 
   const visible = useMemo(() => {
-    if (selectedTypes.size === 0) return sets
-    return sets.filter((s) => selectedTypes.has(s.set_type))
-  }, [sets, selectedTypes])
+    const q = search.trim().toLowerCase()
+    return sets.filter((s) => {
+      if (selectedTypes.size > 0 && !selectedTypes.has(s.set_type)) return false
+      if (q && !s.set_name.toLowerCase().includes(q) && !s.set_code.toLowerCase().includes(q)) return false
+      return true
+    })
+  }, [sets, selectedTypes, search])
 
   const groups = useMemo(() => {
     if (groupBy === 'none') return [{ key: '__all__', label: '', sets: visible }]
@@ -141,6 +157,30 @@ export function SetBrowser({ onSelect }: SetBrowserProps) {
       </header>
 
       <div className={styles.controls}>
+        <div className={styles.searchRow}>
+          <svg className={styles.searchIcon} width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+            <circle cx="11" cy="11" r="7"/>
+            <path d="M21 21l-4.35-4.35"/>
+          </svg>
+          <input
+            className={styles.searchInput}
+            placeholder="Search sets by name or code…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            aria-label="Search sets"
+          />
+          {search && (
+            <button
+              type="button"
+              className={styles.searchClear}
+              onClick={() => setSearch('')}
+              aria-label="Clear search"
+            >
+              ×
+            </button>
+          )}
+        </div>
+
         <div className={styles.controlBlock}>
           <span className={styles.controlLabel}>Type</span>
           <div className={styles.chipRow}>

--- a/src/frontend/src/features/cards/components/SetBrowser.tsx
+++ b/src/frontend/src/features/cards/components/SetBrowser.tsx
@@ -1,5 +1,5 @@
 // src/frontend/src/features/cards/components/SetBrowser.tsx
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { setBrowseQueryOptions } from '../api'
 import type { SetBrowseItem } from '../types'
@@ -11,12 +11,40 @@ const FALLBACK_ICON = (
   </svg>
 )
 
-const SEARCH_ICON = (
-  <svg className={styles.filterIcon} width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-    <circle cx="11" cy="11" r="7"/>
-    <path d="M21 21l-4.35-4.35"/>
-  </svg>
-)
+type GroupBy = 'none' | 'type' | 'year'
+
+const SET_TYPE_LABELS: Record<string, string> = {
+  expansion: 'Expansion',
+  core: 'Core',
+  masters: 'Masters',
+  commander: 'Commander',
+  draft_innovation: 'Draft Innovation',
+  alchemy: 'Alchemy',
+  funny: 'Funny',
+  promo: 'Promo',
+  starter: 'Starter',
+  duel_deck: 'Duel Deck',
+  from_the_vault: 'From the Vault',
+  premium_deck: 'Premium Deck',
+  spellbook: 'Spellbook',
+  archenemy: 'Archenemy',
+  planechase: 'Planechase',
+  vanguard: 'Vanguard',
+  treasure_chest: 'Treasure Chest',
+  box: 'Box Set',
+  token: 'Token',
+  memorabilia: 'Memorabilia',
+  jumpstart: 'Jumpstart',
+  minigame: 'Minigame',
+}
+
+function prettyType(t: string): string {
+  return SET_TYPE_LABELS[t] ?? t.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+function yearOf(released?: string | null): string {
+  return released ? released.slice(0, 4) : 'Unknown'
+}
 
 function SetRow({ set, onSelect }: { set: SetBrowseItem; onSelect: (code: string) => void }) {
   return (
@@ -29,7 +57,7 @@ function SetRow({ set, onSelect }: { set: SetBrowseItem; onSelect: (code: string
       <span className={styles.name}>{set.set_name}</span>
       <span className={styles.meta}>
         <span className={styles.code}>{set.set_code}</span>
-        <span className={styles.type}>{set.set_type}</span>
+        <span className={styles.type}>{prettyType(set.set_type)}</span>
       </span>
       <span className={styles.count}>{set.card_count}</span>
     </button>
@@ -41,15 +69,50 @@ interface SetBrowserProps {
 }
 
 export function SetBrowser({ onSelect }: SetBrowserProps) {
-  const [filter, setFilter] = useState('')
-  const { data: sets = [], isError } = useQuery(setBrowseQueryOptions())
+  const { data: sets = [], isLoading, isError } = useQuery(setBrowseQueryOptions())
+  const [selectedTypes, setSelectedTypes] = useState<Set<string>>(new Set())
+  const [groupBy, setGroupBy] = useState<GroupBy>('none')
 
-  const filtered = filter.trim()
-    ? sets.filter(s =>
-        s.set_name.toLowerCase().includes(filter.toLowerCase()) ||
-        s.set_code.toLowerCase().includes(filter.toLowerCase())
-      )
-    : sets
+  const availableTypes = useMemo(() => {
+    const counts = new Map<string, number>()
+    for (const s of sets) counts.set(s.set_type, (counts.get(s.set_type) ?? 0) + 1)
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([type, count]) => ({ type, count }))
+  }, [sets])
+
+  const visible = useMemo(() => {
+    if (selectedTypes.size === 0) return sets
+    return sets.filter((s) => selectedTypes.has(s.set_type))
+  }, [sets, selectedTypes])
+
+  const groups = useMemo(() => {
+    if (groupBy === 'none') return [{ key: '__all__', label: '', sets: visible }]
+    const buckets = new Map<string, SetBrowseItem[]>()
+    for (const s of visible) {
+      const key = groupBy === 'type' ? s.set_type : yearOf(s.released_at)
+      if (!buckets.has(key)) buckets.set(key, [])
+      buckets.get(key)!.push(s)
+    }
+    const sortedKeys = Array.from(buckets.keys()).sort((a, b) => {
+      if (groupBy === 'year') return b.localeCompare(a) // newer years first
+      return a.localeCompare(b)                          // alpha for type
+    })
+    return sortedKeys.map((key) => ({
+      key,
+      label: groupBy === 'type' ? prettyType(key) : key,
+      sets: buckets.get(key)!,
+    }))
+  }, [visible, groupBy])
+
+  function toggleType(t: string) {
+    setSelectedTypes((prev) => {
+      const next = new Set(prev)
+      if (next.has(t)) next.delete(t)
+      else next.add(t)
+      return next
+    })
+  }
 
   if (isError) {
     return (
@@ -65,34 +128,84 @@ export function SetBrowser({ onSelect }: SetBrowserProps) {
         <h1 className={styles.heroTitle}>Browse Magic Sets</h1>
         <span className={styles.heroAccent} aria-hidden />
         <p className={styles.heroSub}>
-          <strong>{sets.length.toLocaleString()} sets</strong> · sorted by release date · newest first
+          {isLoading
+            ? 'Loading…'
+            : (
+              <>
+                <strong>{visible.length.toLocaleString()}</strong>
+                {selectedTypes.size > 0 && ` of ${sets.length.toLocaleString()}`}
+                {' '}sets
+              </>
+            )}
         </p>
       </header>
 
-      <div className={styles.filterWrap}>
-        <div className={styles.filterField}>
-          {SEARCH_ICON}
-          <input
-            className={styles.filterInput}
-            placeholder="Filter sets — type a name or code…"
-            value={filter}
-            onChange={e => setFilter(e.target.value)}
-            aria-label="Filter sets by name or code"
-          />
+      <div className={styles.controls}>
+        <div className={styles.controlBlock}>
+          <span className={styles.controlLabel}>Type</span>
+          <div className={styles.chipRow}>
+            <button
+              className={`${styles.chip} ${selectedTypes.size === 0 ? styles.chipActive : ''}`}
+              onClick={() => setSelectedTypes(new Set())}
+              type="button"
+            >
+              All
+              <span className={styles.chipCount}>{sets.length}</span>
+            </button>
+            {availableTypes.map(({ type, count }) => (
+              <button
+                key={type}
+                className={`${styles.chip} ${selectedTypes.has(type) ? styles.chipActive : ''}`}
+                onClick={() => toggleType(type)}
+                type="button"
+              >
+                {prettyType(type)}
+                <span className={styles.chipCount}>{count}</span>
+              </button>
+            ))}
+          </div>
         </div>
-        <p className={styles.filterHint}>
-          e.g. <code>mkm</code>, <code>Karlov Manor</code>, <code>Eldraine</code>
-        </p>
+
+        <div className={styles.controlBlock}>
+          <span className={styles.controlLabel}>Group by</span>
+          <div className={styles.chipRow}>
+            {(['none', 'type', 'year'] as GroupBy[]).map((g) => (
+              <button
+                key={g}
+                className={`${styles.chip} ${groupBy === g ? styles.chipActive : ''}`}
+                onClick={() => setGroupBy(g)}
+                type="button"
+              >
+                {g === 'none' ? 'None' : g === 'type' ? 'Type' : 'Year'}
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
-      <div className={styles.list}>
-        {filtered.length === 0
-          ? <p className={styles.empty}>No sets match "{filter}"</p>
-          : filtered.map(set => (
-              <SetRow key={set.set_code} set={set} onSelect={onSelect} />
-            ))
-        }
-      </div>
+      {visible.length === 0 ? (
+        <p className={styles.empty}>No sets match the current filters.</p>
+      ) : groupBy === 'none' ? (
+        <div className={styles.list}>
+          {visible.map((set) => (
+            <SetRow key={set.set_code} set={set} onSelect={onSelect} />
+          ))}
+        </div>
+      ) : (
+        groups.map((g) => (
+          <section key={g.key} className={styles.group}>
+            <header className={styles.groupHeader}>
+              <span className={styles.groupTitle}>{g.label}</span>
+              <span className={styles.groupCount}>{g.sets.length}</span>
+            </header>
+            <div className={styles.list}>
+              {g.sets.map((set) => (
+                <SetRow key={set.set_code} set={set} onSelect={onSelect} />
+              ))}
+            </div>
+          </section>
+        ))
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **Set browser UX**: replace the filter input with type chips + group-by (none/type/year) controls, plus restore the live search input for quick lookups
- **Scryfall ETL fix**: uncomment \`icon_svg_uri\` on the \`NewSet\` model and include it in \`model_dump_for_sql()\` so \`card_catalog.insert_batch_sets\` finally populates \`icon_query_ref\` and \`icon_set\` (both were 0 rows across 965 sets)
- **Parent-icon fallback**: \`set_repository.browse()\` COALESCEs the set's own icon URI with its parent's, so promo/box sub-sets without their own SVG inherit the parent's mark
- **Frontend safety net**: \`SetBrowser\` falls back to the Scryfall CDN (\`https://svgs.scryfall.io/sets/{code}.svg\`) when neither child nor parent icon is in the DB, with an inline SVG as the final fallback

## Notes
- No second pass added to the ETL — parent_set links that fail to resolve on first ingestion (child set comes before parent in the JSON) heal naturally on the next weekly Scryfall pipeline pass via the existing \`parent_set = EXCLUDED.parent_set\` UPSERT.

## Test plan
- [ ] Re-run the Scryfall pipeline; verify \`SELECT COUNT(*) FROM card_catalog.icon_query_ref\` and \`card_catalog.icon_set\` go from 0 → ~900+ rows
- [ ] \`/search\` (By Set) renders DB-backed icons (no CDN hit) for sets with their own icon
- [ ] Promo/box sub-sets without an icon render the parent set's icon
- [ ] Type chips filter correctly; group-by toggles produce the expected sections
- [ ] Search input narrows the list by name/code

🤖 Generated with [Claude Code](https://claude.com/claude-code)