### PR TITLE
feat(set-browser): sidebar layout + default sort by release date

### DIFF
--- a/src/automana/api/dependancies/query_deps.py
+++ b/src/automana/api/dependancies/query_deps.py
@@ -33,7 +33,7 @@ async def pagination_params(
     return PaginationParams(limit=limit, offset=offset)
 
 async def sort_params(
-    sort_by: str = Query("created_at", description="Field to sort by"),
+    sort_by: str = Query("released_at", description="Field to sort by"),
     sort_order: str = Query("desc", regex="^(asc|desc)$", description="Sort order")
 ) -> SortParams:
     """Standard sorting parameters"""

--- a/src/automana/core/repositories/card_catalog/card_repository.py
+++ b/src/automana/core/repositories/card_catalog/card_repository.py
@@ -412,11 +412,14 @@ class CardReferenceRepository(AbstractRepository[Any]):
                 f"websearch_to_tsquery('english', ${oracle_param_idx})) DESC"
             )
         else:
-            safe_sort_by = sort_by if sort_by in {
-                "card_name", "cmc", "rarity_name", "set_name", "set_code"
-            } else "card_name"
+            _set_cols = {"released_at"}
+            _view_cols = {"card_name", "cmc", "rarity_name", "set_name", "set_code"}
             safe_sort_order = "DESC" if (sort_order or "").upper() == "DESC" else "ASC"
-            order_clause = f"ORDER BY v.{safe_sort_by} {safe_sort_order}"
+            if sort_by in _set_cols:
+                order_clause = f"ORDER BY s.{sort_by} {safe_sort_order}"
+            else:
+                safe_sort_by = sort_by if sort_by in _view_cols else "card_name"
+                order_clause = f"ORDER BY v.{safe_sort_by} {safe_sort_order}"
 
         # JOIN sets for released_at (not projected by the view) and to filter on date range.
         from_clause = (

--- a/src/frontend/src/features/cards/components/SetBrowser.module.css
+++ b/src/frontend/src/features/cards/components/SetBrowser.module.css
@@ -1,76 +1,53 @@
 /* SetBrowser.module.css */
-.wrap { display: flex; flex-direction: column; padding: 24px 36px; }
 
-/* Hero header */
-.hero { text-align: center; padding: 16px 0 4px; }
-.heroTitle {
-  font-family: var(--font-serif, serif);
-  font-size: 28px;
-  font-weight: 400;
-  color: var(--hd-text);
-  margin: 0 0 6px;
-  letter-spacing: -0.5px;
+/* Outer layout — mirrors .layout in Search.module.css */
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 0;
+  min-height: calc(100vh - 120px);
+  margin: 0 -36px;
+  border-top: 1px solid var(--hd-border);
 }
-.heroAccent {
-  display: inline-block;
-  width: 38px;
-  height: 2px;
-  background: var(--hd-accent);
-  border-radius: 1px;
-  margin: 6px auto 12px;
-}
-.heroSub { font-size: 13px; color: var(--hd-muted); margin: 0; }
-.heroSub strong { color: var(--hd-text); }
 
-/* Controls block */
-.controls {
-  max-width: 1000px;
-  margin: 16px auto 20px;
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  padding: 14px 18px;
-  background: var(--hd-surface);
-  border: 1px solid var(--hd-border);
-  border-radius: 10px;
+/* Sidebar — mirrors SearchFilters.module.css .filters */
+.sidebar {
+  padding: 24px 22px;
+  border-right: 1px solid var(--hd-border);
+  overflow-y: auto;
 }
 
 .searchRow {
-  position: relative;
   display: flex;
   align-items: center;
-  gap: 10px;
-  background: var(--hd-surface-alt);
+  gap: 8px;
+  padding: 0 14px;
+  background: var(--hd-surface);
   border: 1px solid var(--hd-border);
   border-radius: 8px;
-  padding: 10px 14px;
+  height: 44px;
+  margin-bottom: 20px;
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
 .searchRow:focus-within {
-  border-color: rgba(var(--hd-accent-rgb), 0.55);
-  box-shadow: 0 0 0 3px rgba(var(--hd-accent-rgb), 0.08);
+  border-color: var(--hd-accent);
+  box-shadow: 0 0 0 2px rgba(var(--hd-accent-rgb), 0.1);
 }
 
-.searchIcon {
-  flex-shrink: 0;
-  color: var(--hd-muted);
-}
+.searchIcon { flex-shrink: 0; color: var(--hd-muted); }
 
 .searchInput {
   flex: 1;
-  background: transparent;
   border: none;
-  outline: none;
-  color: var(--hd-text);
-  font-family: var(--font-sans);
+  background: none;
   font-size: 14px;
+  color: var(--hd-text);
+  outline: none;
+  font-family: var(--font-sans);
 }
 
-.searchInput::placeholder {
-  color: var(--hd-muted);
-}
+.searchInput::placeholder { color: var(--hd-muted); }
 
 .searchClear {
   flex-shrink: 0;
@@ -84,122 +61,118 @@
   transition: color 120ms ease;
 }
 
-.searchClear:hover {
-  color: var(--hd-text);
-}
+.searchClear:hover { color: var(--hd-text); }
 
-.controlBlock {
+.header {
   display: flex;
-  align-items: flex-start;
-  gap: 14px;
-  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 18px;
 }
 
-.controlLabel {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--hd-sub);
-  letter-spacing: 1.4px;
-  text-transform: uppercase;
-  min-width: 70px;
-  padding-top: 6px;
-  flex-shrink: 0;
-}
+.title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; }
 
-.chipRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  flex: 1;
-}
-
-.chip {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 5px 12px;
-  border-radius: 20px;
-  border: 1px solid var(--hd-border);
-  background: transparent;
-  color: var(--hd-muted);
+.clearBtn {
   font-family: var(--font-mono);
   font-size: 11px;
-  cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
-}
-
-.chip:hover {
-  border-color: var(--hd-border-hot);
-  color: var(--hd-text);
-}
-
-.chipActive {
-  background: rgba(var(--hd-accent-rgb), 0.12);
-  border-color: rgba(var(--hd-accent-rgb), 0.4);
   color: var(--hd-accent);
+  background: none;
+  border: none;
+  cursor: pointer;
 }
 
-.chipCount {
-  font-size: 9.5px;
+.filterGroup {
+  padding-top: 16px;
+  margin-top: 16px;
+  border-top: 1px solid var(--hd-border);
+}
+
+.filterLabel {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--hd-text);
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.btnGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.btn {
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-family: var(--font-mono);
+  border: 1px solid var(--hd-border);
+  color: var(--hd-muted);
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: border-color 120ms, color 120ms, background 120ms;
+}
+
+.btn:hover { border-color: var(--hd-border-hot, var(--hd-accent)); color: var(--hd-text); }
+
+.btnActive {
+  border-color: var(--hd-accent);
+  color: var(--hd-accent);
+  background: rgba(var(--hd-accent-rgb), 0.10);
+}
+
+/* Content area — mirrors SearchResults.module.css .results */
+.content { padding: 24px 36px 36px; overflow: hidden; }
+
+.meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
   color: var(--hd-sub);
-  padding-left: 4px;
-  border-left: 1px solid var(--hd-border);
+  margin-bottom: 16px;
 }
 
-.chipActive .chipCount {
-  color: rgba(var(--hd-accent-rgb), 0.7);
-  border-color: rgba(var(--hd-accent-rgb), 0.3);
+/* Grid — same breakpoints as SearchResults (viewport-relative, sidebar-compensated) */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
 }
+
+@media (min-width: 980px)  { .grid { grid-template-columns: repeat(3, 1fr); } }
+@media (min-width: 1220px) { .grid { grid-template-columns: repeat(4, 1fr); } }
+@media (min-width: 1460px) { .grid { grid-template-columns: repeat(5, 1fr); } }
+@media (min-width: 1700px) { .grid { grid-template-columns: repeat(6, 1fr); } }
 
 /* Group sections */
-.group {
-  max-width: 1000px;
-  margin: 0 auto 24px;
-  width: 100%;
-}
+.group { margin-bottom: 28px; }
+.group:last-child { margin-bottom: 0; }
 
 .groupHeader {
   display: flex;
   align-items: baseline;
-  gap: 12px;
-  padding: 8px 0 10px;
-  margin-bottom: 8px;
+  gap: 10px;
+  padding: 8px 0 12px;
+  margin-bottom: 12px;
   border-bottom: 1px solid var(--hd-border);
 }
 
 .groupTitle {
   font-family: var(--font-mono);
-  font-size: 12px;
+  font-size: 11px;
   color: var(--hd-text);
   letter-spacing: 1.6px;
   text-transform: uppercase;
 }
 
-.groupCount {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  color: var(--hd-sub);
-}
+.groupCount { font-family: var(--font-mono); font-size: 10px; color: var(--hd-sub); }
 
-/* Responsive grid — same breakpoints as SearchResults.module.css */
-.grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 14px;
-  max-width: 1000px;
-  margin: 0 auto;
-  width: 100%;
-}
-
-@media (min-width: 720px)  { .grid { grid-template-columns: repeat(3, 1fr); } }
-@media (min-width: 960px)  { .grid { grid-template-columns: repeat(4, 1fr); } }
-@media (min-width: 1200px) { .grid { grid-template-columns: repeat(5, 1fr); } }
-@media (min-width: 1440px) { .grid { grid-template-columns: repeat(6, 1fr); } }
-
-/* Parent-child grouping — parent + its children as one cell-spanning block */
-.parentGroup {
-  display: contents;
-}
+/* Parent-child grouping */
+.parentGroup { display: contents; }
 
 .childrenRow {
   grid-column: 1 / -1;
@@ -213,9 +186,6 @@
   margin-bottom: 4px;
 }
 
-.childrenRow > * {
-  width: 100px;
-  flex-shrink: 0;
-}
+.childrenRow > * { width: 80px; flex-shrink: 0; }
 
-.empty { font-size: 13px; color: var(--hd-muted); padding: 16px 0; text-align: center; }
+.empty { font-size: 13px; color: var(--hd-muted); padding: 40px; text-align: center; }

--- a/src/frontend/src/features/cards/components/SetBrowser.tsx
+++ b/src/frontend/src/features/cards/components/SetBrowser.tsx
@@ -59,6 +59,12 @@ interface SetBrowserProps {
   onSelect: (setCode: string) => void
 }
 
+const GROUP_BY_OPTIONS: { value: GroupBy; label: string }[] = [
+  { value: 'year', label: 'Year' },
+  { value: 'type', label: 'Type' },
+  { value: 'none', label: 'None' },
+]
+
 export function SetBrowser({ onSelect }: SetBrowserProps) {
   const { data: sets = [], isLoading, isError } = useQuery(setBrowseQueryOptions())
   const [search, setSearch] = useState('')
@@ -109,120 +115,122 @@ export function SetBrowser({ onSelect }: SetBrowserProps) {
     })
   }
 
+  function clearFilters() {
+    setSearch('')
+    setSelectedTypes(new Set())
+  }
+
   if (isError) {
     return (
-      <div className={styles.wrap}>
+      <div className={styles.layout}>
         <p className={styles.empty}>Failed to load sets. Please refresh.</p>
       </div>
     )
   }
 
   return (
-    <div className={styles.wrap}>
-      <header className={styles.hero}>
-        <h1 className={styles.heroTitle}>Browse Magic Sets</h1>
-        <span className={styles.heroAccent} aria-hidden />
-        <p className={styles.heroSub}>
-          {isLoading
-            ? 'Loading…'
-            : (
-              <>
-                <strong>{visible.length.toLocaleString()}</strong>
-                {selectedTypes.size > 0 && ` of ${sets.length.toLocaleString()}`}
-                {' '}sets
-              </>
-            )}
-        </p>
-      </header>
-
-      <div className={styles.controls}>
+    <div className={styles.layout}>
+      {/* Sidebar — same structure as SearchFilters */}
+      <aside className={styles.sidebar}>
         <div className={styles.searchRow}>
-          <svg className={styles.searchIcon} width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
-            <circle cx="11" cy="11" r="7"/>
-            <path d="M21 21l-4.35-4.35"/>
+          <svg className={styles.searchIcon} width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden>
+            <circle cx="11" cy="11" r="7" /><path d="M21 21l-4.35-4.35" />
           </svg>
           <input
             className={styles.searchInput}
-            placeholder="Search sets by name or code…"
+            placeholder="Search sets…"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             aria-label="Search sets"
           />
           {search && (
-            <button type="button" className={styles.searchClear} onClick={() => setSearch('')} aria-label="Clear search">
-              ×
-            </button>
+            <button type="button" className={styles.searchClear} onClick={() => setSearch('')} aria-label="Clear">×</button>
           )}
         </div>
 
-        <div className={styles.controlBlock}>
-          <span className={styles.controlLabel}>Type</span>
-          <div className={styles.chipRow}>
+        <div className={styles.header}>
+          <span className={styles.title}>Filters</span>
+          <button className={styles.clearBtn} onClick={clearFilters}>clear</button>
+        </div>
+
+        <section className={styles.filterGroup}>
+          <div className={styles.filterLabel}>Group by</div>
+          <div className={styles.btnGrid}>
+            {GROUP_BY_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                className={`${styles.btn} ${groupBy === value ? styles.btnActive : ''}`}
+                onClick={() => setGroupBy(value)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className={styles.filterGroup}>
+          <div className={styles.filterLabel}>Type</div>
+          <div className={styles.btnGrid}>
             <button
-              className={`${styles.chip} ${selectedTypes.size === 0 ? styles.chipActive : ''}`}
-              onClick={() => setSelectedTypes(new Set())}
               type="button"
+              className={`${styles.btn} ${selectedTypes.size === 0 ? styles.btnActive : ''}`}
+              onClick={() => setSelectedTypes(new Set())}
             >
-              All<span className={styles.chipCount}>{sets.length}</span>
+              All
             </button>
             {availableTypes.map(({ type, count }) => (
               <button
                 key={type}
-                className={`${styles.chip} ${selectedTypes.has(type) ? styles.chipActive : ''}`}
+                type="button"
+                title={`${prettyType(type)} (${count})`}
+                className={`${styles.btn} ${selectedTypes.has(type) ? styles.btnActive : ''}`}
                 onClick={() => toggleType(type)}
-                type="button"
               >
-                {prettyType(type)}<span className={styles.chipCount}>{count}</span>
+                {prettyType(type)}
               </button>
             ))}
           </div>
+        </section>
+      </aside>
+
+      {/* Content — same structure as SearchResults */}
+      <div className={styles.content}>
+        <div className={styles.meta}>
+          {isLoading
+            ? 'Loading…'
+            : `${visible.length.toLocaleString()}${selectedTypes.size > 0 ? ` of ${sets.length.toLocaleString()}` : ''} sets`}
         </div>
 
-        <div className={styles.controlBlock}>
-          <span className={styles.controlLabel}>Group by</span>
-          <div className={styles.chipRow}>
-            {(['year', 'type', 'none'] as GroupBy[]).map((g) => (
-              <button
-                key={g}
-                className={`${styles.chip} ${groupBy === g ? styles.chipActive : ''}`}
-                onClick={() => setGroupBy(g)}
-                type="button"
-              >
-                {g === 'none' ? 'None' : g === 'type' ? 'Type' : 'Year'}
-              </button>
-            ))}
-          </div>
-        </div>
+        {visible.length === 0 ? (
+          <p className={styles.empty}>No sets match the current filters.</p>
+        ) : (
+          groups.map((g) => (
+            <section key={g.key} className={styles.group}>
+              {g.key !== '__all__' && (
+                <header className={styles.groupHeader}>
+                  <span className={styles.groupTitle}>{g.label}</span>
+                  <span className={styles.groupCount}>{g.sets.length}</span>
+                </header>
+              )}
+              <div className={styles.grid}>
+                {groupByParentChild(g.sets).map((group) => (
+                  <div key={group.parent.set_code} className={styles.parentGroup}>
+                    <SetCard set={group.parent} onSelect={onSelect} />
+                    {group.children.length > 0 && (
+                      <div className={styles.childrenRow}>
+                        {group.children.map((child) => (
+                          <SetCard key={child.set_code} set={child} isChild onSelect={onSelect} />
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </section>
+          ))
+        )}
       </div>
-
-      {visible.length === 0 ? (
-        <p className={styles.empty}>No sets match the current filters.</p>
-      ) : (
-        groups.map((g) => (
-          <section key={g.key} className={styles.group}>
-            {g.key !== '__all__' && (
-              <header className={styles.groupHeader}>
-                <span className={styles.groupTitle}>{g.label}</span>
-                <span className={styles.groupCount}>{g.sets.length}</span>
-              </header>
-            )}
-            <div className={styles.grid}>
-              {groupByParentChild(g.sets).map((group) => (
-                <div key={group.parent.set_code} className={styles.parentGroup}>
-                  <SetCard set={group.parent} onSelect={onSelect} />
-                  {group.children.length > 0 && (
-                    <div className={styles.childrenRow}>
-                      {group.children.map((child) => (
-                        <SetCard key={child.set_code} set={child} isChild onSelect={onSelect} />
-                      ))}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          </section>
-        ))
-      )}
     </div>
   )
 }

--- a/src/frontend/src/features/cards/components/__tests__/SetBrowser.test.tsx
+++ b/src/frontend/src/features/cards/components/__tests__/SetBrowser.test.tsx
@@ -78,7 +78,7 @@ describe('SetBrowser', () => {
     render(<SetBrowser onSelect={vi.fn()} />, { wrapper: Wrapper })
     await waitFor(() => expect(screen.getByText('WOE')).toBeTruthy())
 
-    fireEvent.change(screen.getByPlaceholderText('Search sets by name or code…'), {
+    fireEvent.change(screen.getByPlaceholderText('Search sets…'), {
       target: { value: 'Wilds' },
     })
 


### PR DESCRIPTION
# Summary

Two follow-up improvements after PR #218:

1. **Set browser now matches the card search layout** — the "Browse Magic Sets" hero banner is removed. The set browser uses the same 260 px sidebar + content grid as the card search page. Set type filter, group-by, and name search all live in the sidebar, styled identically to `SearchFilters`.

2. **Card landing sorts by most recently released** — fixed the default `sort_by` from the unrecognised `created_at` to `released_at`, so the no-query landing page shows the newest cards first instead of alphabetical A-to-Z.

---

# Changes Introduced

- `SetBrowser.tsx` — restructured JSX: `aside.sidebar` + `div.content`, removed hero header
- `SetBrowser.module.css` — full rewrite: `.layout`, `.sidebar`, `.content`, `.grid` matching `Search.module.css` / `SearchFilters.module.css` / `SearchResults.module.css`
- `SetBrowser.test.tsx` — updated placeholder text to match new sidebar input
- `card_repository.py` — added `released_at` to allowed sort columns (`s.released_at`)
- `query_deps.py` — changed default `sort_by` from `created_at` → `released_at`

---

# Acceptance Checklist
- [x] All 13 unit tests pass
- [x] UI verified via Playwright screenshots
- [x] No debug logs
- [x] Follows project coding standards