### PR TITLE
fix(set-browser): bigger tiles, taller year headers, hide tokens by default

### DIFF
--- a/src/frontend/src/features/cards/components/SetBrowser.module.css
+++ b/src/frontend/src/features/cards/components/SetBrowser.module.css
@@ -136,7 +136,7 @@
   margin-bottom: 16px;
 }
 
-/* Grid — same breakpoints as SearchResults (viewport-relative, sidebar-compensated) */
+/* Grid — one fewer column than card grid so set tiles are visually larger */
 .grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
@@ -144,32 +144,31 @@
 }
 
 @media (min-width: 980px)  { .grid { grid-template-columns: repeat(3, 1fr); } }
-@media (min-width: 1220px) { .grid { grid-template-columns: repeat(4, 1fr); } }
-@media (min-width: 1460px) { .grid { grid-template-columns: repeat(5, 1fr); } }
-@media (min-width: 1700px) { .grid { grid-template-columns: repeat(6, 1fr); } }
+@media (min-width: 1460px) { .grid { grid-template-columns: repeat(4, 1fr); } }
+@media (min-width: 1700px) { .grid { grid-template-columns: repeat(5, 1fr); } }
 
 /* Group sections */
-.group { margin-bottom: 28px; }
+.group { margin-bottom: 36px; }
 .group:last-child { margin-bottom: 0; }
 
 .groupHeader {
   display: flex;
   align-items: baseline;
   gap: 10px;
-  padding: 8px 0 12px;
-  margin-bottom: 12px;
+  padding: 18px 0 14px;
+  margin-bottom: 14px;
   border-bottom: 1px solid var(--hd-border);
 }
 
 .groupTitle {
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 13px;
   color: var(--hd-text);
-  letter-spacing: 1.6px;
+  letter-spacing: 1.8px;
   text-transform: uppercase;
 }
 
-.groupCount { font-family: var(--font-mono); font-size: 10px; color: var(--hd-sub); }
+.groupCount { font-family: var(--font-mono); font-size: 11px; color: var(--hd-sub); }
 
 /* Parent-child grouping */
 .parentGroup { display: contents; }

--- a/src/frontend/src/features/cards/components/SetBrowser.tsx
+++ b/src/frontend/src/features/cards/components/SetBrowser.tsx
@@ -82,6 +82,8 @@ export function SetBrowser({ onSelect }: SetBrowserProps) {
   const visible = useMemo(() => {
     const q = search.trim().toLowerCase()
     return sets.filter((s) => {
+      // When no explicit type filter, hide token sheets by default
+      if (selectedTypes.size === 0 && s.set_type === 'token') return false
       if (selectedTypes.size > 0 && !selectedTypes.has(s.set_type)) return false
       if (q && !s.set_name.toLowerCase().includes(q) && !s.set_code.toLowerCase().includes(q)) return false
       return true


### PR DESCRIPTION
# Summary

Polish pass on the set browser following the sidebar layout redesign.

- **Bigger tiles** — grid capped at 3 columns on standard viewports (was 4), so each set card is ~30% wider
- **Taller year headers** — group header padding increased, font size bumped from 11 → 13 px with wider letter-spacing; groups spaced 36 px apart
- **Tokens hidden by default** — token sets are excluded from the "All" view; users can explicitly click "Token" in the sidebar to surface them

No new tests needed (pure CSS + one-line filter logic change).