### PR TITLE
fix(search): match card grid breakpoints to set browser tile size

### DIFF
--- a/src/frontend/src/features/cards/components/SearchResults.module.css
+++ b/src/frontend/src/features/cards/components/SearchResults.module.css
@@ -3,16 +3,15 @@
 .meta { font-family: var(--font-mono); font-size: 11px; color: var(--hd-sub); margin-bottom: 16px; }
 .empty { padding: 40px; text-align: center; color: var(--hd-muted); font-size: 14px; }
 
-/* Responsive grid: 2 → 3 → 4 → 5 → 6 columns, capped at 6 on wide screens */
+/* Responsive grid — same breakpoints as SetBrowser so card and set tiles are identical size */
 .grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 14px;
 }
-@media (min-width: 720px)  { .grid { grid-template-columns: repeat(3, 1fr); } }
-@media (min-width: 960px)  { .grid { grid-template-columns: repeat(4, 1fr); } }
-@media (min-width: 1200px) { .grid { grid-template-columns: repeat(5, 1fr); } }
-@media (min-width: 1440px) { .grid { grid-template-columns: repeat(6, 1fr); } }
+@media (min-width: 980px)  { .grid { grid-template-columns: repeat(3, 1fr); } }
+@media (min-width: 1460px) { .grid { grid-template-columns: repeat(4, 1fr); } }
+@media (min-width: 1700px) { .grid { grid-template-columns: repeat(5, 1fr); } }
 
 .card { background: transparent; border: none; cursor: pointer; text-align: left; padding: 0; }
 .card:hover .cardInfo { border-color: var(--hd-accent); }


### PR DESCRIPTION
Card images in SearchResults were smaller than set tiles in SetBrowser because they had more columns. Both grids now use the same breakpoints (3 cols at standard viewport, 4 at 1460px, 5 at 1700px).