### PR TITLE
feat(set-card): display release date alongside set code in info bar

### DIFF
--- a/src/frontend/src/features/cards/components/SetCard.module.css
+++ b/src/frontend/src/features/cards/components/SetCard.module.css
@@ -66,15 +66,30 @@
   transition: border-color 0.15s;
 }
 
+.codeRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 4px;
+  margin-bottom: 3px;
+}
+
 .code {
   font-family: var(--font-mono);
   font-size: 11px;
   font-weight: 700;
   color: var(--hd-text);
-  margin-bottom: 3px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.date {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--hd-sub);
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .meta {

--- a/src/frontend/src/features/cards/components/SetCard.tsx
+++ b/src/frontend/src/features/cards/components/SetCard.tsx
@@ -6,6 +6,10 @@ function iconUrl(set: SetBrowseItem): string {
   return set.icon_svg_uri || `https://svgs.scryfall.io/sets/${set.set_code.toLowerCase()}.svg`
 }
 
+function formatDate(d: string): string {
+  return new Date(d).toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+}
+
 function prettyType(t: string): string {
   const labels: Record<string, string> = {
     expansion: 'Expansion', core: 'Core', masters: 'Masters',
@@ -60,7 +64,10 @@ export function SetCard({ set, isChild = false, onSelect }: SetCardProps) {
 
       {/* Info bar — mirrors .cardInfo in SearchResults */}
       <div className={styles.info}>
-        <div className={styles.code}>{set.set_code.toUpperCase()}</div>
+        <div className={styles.codeRow}>
+          <span className={styles.code}>{set.set_code.toUpperCase()}</span>
+          <span className={styles.date}>{formatDate(set.released_at)}</span>
+        </div>
         <div className={styles.meta}>
           <span className={styles.type}>{prettyType(set.set_type)}</span>
           <span className={styles.count}>{set.card_count}</span>


### PR DESCRIPTION
Adds a formatted release date (e.g. 'Feb 2024') on the right side of the set code row in each set tile's info bar.